### PR TITLE
feat(templates): enforce required metadata

### DIFF
--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -1,10 +1,10 @@
 # Schemas
 
-JSON Schema definitions for every content type a typikon-consuming site can author. The schemas in `schemas/` are authoritative; this document is a human-readable index. Validation happens via `bin/typikon-validate`.
+JSON Schema definitions for every content type a typikon-consuming site can author live in `schemas/`. Validation happens via `bin/typikon-validate`.
 
 ## How the validator routes a file to a schema
 
-`typikon-validate` reads `<root>/content/**/*.md` and classifies in this order — first match wins:
+`typikon-validate` reads `<root>/content/**/*.md` and classifies in this order; first match wins:
 
 | Rule                                         | Schema             |
 |----------------------------------------------|--------------------|
@@ -75,13 +75,15 @@ list_caption = "Newest at top."
 
 Pages under `content/journal/` (excluding `_index.md`). Stricter than page: requires `description`, `date`, and the entry-level extras so the auto-generated journal listing renders cleanly.
 
-**Required:** `title`, `description`, `date`, `extra.components`, `extra.words`.
+**Required:** `title`, `description`, `date`, `extra.audience`, `extra.components`, `extra.words`, `extra.words_source`.
 
 **Constraints:**
 - description: 20–200 chars
 - date: ISO 8601
+- extra.audience: 3–120 chars
 - extra.components: 5–120 chars (the conceptual-tags line)
 - extra.words: matches `^~?\d+( words)?$`
+- extra.words_source: 3–200 chars; source for the rendered word-count claim
 
 **Example:**
 
@@ -92,8 +94,10 @@ description = "On the green dye and the tensions it holds. Why the color that ca
 date = 2026-01-20
 
 [extra]
+audience = "readers following the workbench journal"
 components = "ἀπορία · productive uncertainty · the green"
 words = "~430 words"
+words_source = "manual count"
 +++
 ```
 
@@ -101,14 +105,16 @@ words = "~430 words"
 
 Pages under `content/products/`. Required for the purchase block to render.
 
-**Required:** `title`, `description`, `extra.price`, `extra.stripe_url`.
+**Required:** `title`, `description`, `extra.audience`, `extra.price`, `extra.price_source`, `extra.stripe_url`.
 
 **Constraints:**
 - description: 30–200 chars
+- audience: 3–120 chars
 - price: matches `^\$?\d{1,5}(\.\d{2})?$` (e.g. `$150`, `85`, `12.50`)
+- price_source: 3–200 chars; source for the rendered price claim
 - stripe_url: matches `^https://buy\.stripe\.com/[A-Za-z0-9_]+$`
 - shipping_note (optional): ≤200 chars
-- images (optional): array of `{src, alt, caption?}` — Zola's `resize_image` produces 400/800/1200px WebP variants automatically; the product-gallery partial renders responsive `<picture>` per item
+- images (optional): array of `{src, alt, caption?}`; Zola's `resize_image` produces 400/800/1200px WebP variants automatically, and the product-gallery partial renders responsive `<picture>` per item
 
 **Example:**
 
@@ -119,7 +125,9 @@ description = "Single-layer Hermann Oak harness leather. Solid brass. Hand saddl
 
 [extra]
 seo_title = "Hermann Oak Leather Belt | Ardent Leatherworks"
+audience = "customers choosing a made-to-order belt"
 price = "$150"
+price_source = "Stripe price price_123"
 stripe_url = "https://buy.stripe.com/cNi9AT1ZHfFDeNRdsh6Ri02"
 
 [[extra.images]]
@@ -137,12 +145,13 @@ caption = "Two needles work the same thread from opposite sides."
 
 Any page with `template = "faq.html"`. Renders a definition-list FAQ with anchored `<dt>`s and emits FAQPage JSON-LD.
 
-**Required:** `title`, `extra.questions` (array of one or more entries).
+**Required:** `title`, `extra.audience`, `extra.questions` (array of one or more entries).
 
 **Constraints (per question):**
+- audience: 3–120 chars
 - q: 5–200 chars
 - a: 5–2000 chars; supports `\n\n` for paragraph breaks (template splits on it)
-- anchor (optional): `^[a-z0-9-]+$` — slugified from `q` if omitted
+- anchor (optional): `^[a-z0-9-]+$`; slugified from `q` if omitted
 - additionalProperties on each question: false (strict)
 
 **Example:**
@@ -152,6 +161,9 @@ Any page with `template = "faq.html"`. Renders a definition-list FAQ with anchor
 title = "Questions"
 description = "Frequently asked questions."
 template = "faq.html"
+
+[extra]
+audience = "customers with pre-purchase questions"
 
 [[extra.questions]]
 q = "What size belt do I need?"
@@ -168,12 +180,14 @@ a = "US only currently. Reach out for case-by-case international quotes."
 
 Any page with `template = "sizing-guide.html"`. Renders a measurement table, an optional inline-SVG diagram, and an optional decision tree.
 
-**Required:** `title`, `extra.product_type`, `extra.size_table` (one or more rows).
+**Required:** `title`, `extra.audience`, `extra.measurement_source`, `extra.product_type`, `extra.size_table` (one or more rows).
 
 **Constraints:**
+- audience: 3–120 chars
+- measurement_source: 3–200 chars; source for numeric sizing claims
 - product_type: 2–40 chars
 - measurement_unit (optional): `inches | centimeters | both` (default `inches`)
-- size_table rows: required `size`; optional `waist`, `length`, `width`, `note` — column rendering is conditional on the first row's keys
+- size_table rows: required `size`; optional `waist`, `length`, `width`, `note`; column rendering is conditional on the first row's keys
 - diagram (optional): path under static/ to an `.svg` file; loaded inline via `load_data`
 - decision_tree (optional): array of strings, rendered as ordered list
 
@@ -186,8 +200,10 @@ description = "How to size an Ardent harness belt."
 template = "sizing-guide.html"
 
 [extra]
+audience = "customers measuring for belt sizing"
 product_type = "belt"
 measurement_unit = "inches"
+measurement_source = "bench pattern block 2026-01"
 decision_tree = [
   "Find a belt you wear and like the fit of. Measure from the buckle fold to the hole you use most.",
   "If you carry concealed at the waist, add 1 inch.",
@@ -205,7 +221,7 @@ note = "Sized to the middle hole; first hole is 32, last is 36."
 +++
 ```
 
-> **TOML order matters.** `decision_tree = [...]` must come *before* the first `[[extra.size_table]]` block. Once an array-of-tables starts, scalar assignments belong to the *last* table — so a trailing `decision_tree` would silently land inside the final size_table row.
+> **TOML order matters.** `decision_tree = [...]` must come *before* the first `[[extra.size_table]]` block. Once an array-of-tables starts, scalar assignments belong to the *last* table, so a trailing `decision_tree` would silently land inside the final size_table row.
 
 ## Adding a new content type
 
@@ -228,8 +244,8 @@ When a schema changes incompatibly:
 2. Replace the `migrate(frontmatter, file_path)` body with the field transformation. Idempotence rule: running it twice on the same input must produce the same output as once.
 3. The script walks a consumer site root, parses frontmatter, runs `migrate()`, and writes back when the result differs.
 4. The typikon PR description lists every consumer affected.
-5. On merge, run the migration against each consumer in a separate consumer-side PR — that captures the rewrite as a reviewable diff.
+5. On merge, run the migration against each consumer in a separate consumer-side PR; that captures the rewrite as a reviewable diff.
 
-The skeleton handles parsing, idempotence checking, basic TOML serialization, and JSONL change reporting. It uses `tomli_w` when installed and falls back to a minimal emitter otherwise — install `tomli_w` via `uv tool install tomli_w` if your migration needs round-trip fidelity for inline tables / multi-line strings.
+The skeleton handles parsing, idempotence checking, basic TOML serialization, and JSONL change reporting. It uses `tomli_w` when installed and falls back to a minimal emitter otherwise. Install `tomli_w` via `uv tool install tomli_w` if your migration needs round-trip fidelity for inline tables or multi-line strings.
 
 This keeps consumers from drifting out of typikon's contract silently.

--- a/examples/sample-blog/content/journal/first-entry.md
+++ b/examples/sample-blog/content/journal/first-entry.md
@@ -4,8 +4,10 @@ description = "The first journal entry in the sample fixture. Tests that the jou
 date = 2026-01-15
 
 [extra]
+audience = "typikon fixture readers"
 components = "λόγος · attention · the work"
 words = "~120 words"
+words_source = "fixture hand count"
 +++
 
 The first journal entry exists to prove that `journal-entry.schema.json` validates a real file with all required fields populated.

--- a/examples/sample-blog/content/journal/second-entry.md
+++ b/examples/sample-blog/content/journal/second-entry.md
@@ -4,8 +4,10 @@ description = "The second journal entry. Pairs with first-entry so the prev/next
 date = 2026-02-10
 
 [extra]
+audience = "typikon fixture readers"
 components = "πρᾶξις · iteration · the second pass"
 words = "~90 words"
+words_source = "fixture hand count"
 +++
 
 The second journal entry. With this entry plus `first-entry.md`, the section renders as a list of two and each entry has one prev/next sibling.

--- a/examples/sample-shop/content/faq.md
+++ b/examples/sample-shop/content/faq.md
@@ -3,6 +3,9 @@ title = "Questions"
 description = "Sample FAQ. Exercises faq.schema.json's required questions array and the FAQPage JSON-LD partial."
 template = "faq.html"
 
+[extra]
+audience = "sample shop visitors"
+
 [[extra.questions]]
 q = "What is this fixture for?"
 a = "Validating the FAQ schema and template against a real consumer-shaped file. The rendered page should emit FAQPage JSON-LD covering both questions."

--- a/examples/sample-shop/content/products/gadget.md
+++ b/examples/sample-shop/content/products/gadget.md
@@ -4,7 +4,9 @@ description = "A second sample product. Pairs with widget so the products sectio
 weight = 2
 
 [extra]
+audience = "sample shop buyers"
 price = "85"
+price_source = "sample fixture price list"
 stripe_url = "https://buy.stripe.com/test_gadget_fixture"
 +++
 

--- a/examples/sample-shop/content/products/widget.md
+++ b/examples/sample-shop/content/products/widget.md
@@ -4,7 +4,9 @@ description = "A sample product. Exercises product.schema.json's required fields
 weight = 1
 
 [extra]
+audience = "sample shop buyers"
 price = "$50"
+price_source = "sample fixture price list"
 stripe_url = "https://buy.stripe.com/test_widget_fixture"
 shipping_note = "Sample shipping note. Real consumers populate per-product."
 

--- a/examples/sample-shop/content/sizing.md
+++ b/examples/sample-shop/content/sizing.md
@@ -1,0 +1,27 @@
++++
+title = "Sizing"
+description = "Sample sizing guide. Exercises required audience, measurement source, product type, and size table metadata."
+template = "sizing-guide.html"
+
+[extra]
+audience = "sample shop buyers"
+product_type = "widget"
+measurement_unit = "inches"
+measurement_source = "sample fixture measurement table"
+decision_tree = [
+  "Measure the space where the widget will sit.",
+  "Choose the smallest widget size that is equal to or larger than that measurement.",
+]
+
+[[extra.size_table]]
+size = "Small"
+width = "4"
+note = "Fits compact fixture spaces."
+
+[[extra.size_table]]
+size = "Large"
+width = "8"
+note = "Fits standard fixture spaces."
++++
+
+This sample sizing guide proves the sizing-guide schema and template have a concrete fixture with all required metadata populated.

--- a/schemas/faq.schema.json
+++ b/schemas/faq.schema.json
@@ -17,9 +17,15 @@
     "draft": { "type": "boolean" },
     "extra": {
       "type": "object",
-      "required": ["questions"],
+      "required": ["audience", "questions"],
       "additionalProperties": false,
       "properties": {
+        "audience": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 120,
+          "description": "Intended reader context for the FAQ."
+        },
         "questions": {
           "type": "array",
           "minItems": 1,

--- a/schemas/journal-entry.schema.json
+++ b/schemas/journal-entry.schema.json
@@ -21,9 +21,15 @@
     "draft": { "type": "boolean" },
     "extra": {
       "type": "object",
-      "required": ["components", "words"],
+      "required": ["audience", "components", "words", "words_source"],
       "additionalProperties": true,
       "properties": {
+        "audience": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 120,
+          "description": "Intended reader context for the entry. Required so rendered deliverables carry audience assumptions explicitly."
+        },
         "components": {
           "type": "string",
           "minLength": 5,
@@ -34,6 +40,12 @@
           "type": "string",
           "pattern": "^~?\\d+( words)?$",
           "description": "Approximate word count, e.g. '~480' or '~480 words'."
+        },
+        "words_source": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 200,
+          "description": "Source for the rendered word-count claim, e.g. 'manual count' or the counting tool used."
         },
         "seo_title": { "type": "string", "maxLength": 80 },
         "body_class": { "type": "string", "pattern": "^[a-z][a-z0-9 -]*$" },

--- a/schemas/product.schema.json
+++ b/schemas/product.schema.json
@@ -17,13 +17,25 @@
     "draft": { "type": "boolean" },
     "extra": {
       "type": "object",
-      "required": ["price", "stripe_url"],
+      "required": ["audience", "price", "price_source", "stripe_url"],
       "additionalProperties": true,
       "properties": {
+        "audience": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 120,
+          "description": "Intended buyer or reader context for the product page."
+        },
         "price": {
           "type": "string",
           "pattern": "^\\$?\\d{1,5}(\\.\\d{2})?$",
           "description": "Display price with optional leading $ (e.g. '$150', '85'). Bare number assumed USD."
+        },
+        "price_source": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 200,
+          "description": "Source for the rendered price claim, e.g. the Stripe price object, SKU ledger, or fixture note."
         },
         "stripe_url": {
           "type": "string",

--- a/schemas/sizing-guide.schema.json
+++ b/schemas/sizing-guide.schema.json
@@ -17,9 +17,15 @@
     "draft": { "type": "boolean" },
     "extra": {
       "type": "object",
-      "required": ["product_type", "size_table"],
+      "required": ["audience", "measurement_source", "product_type", "size_table"],
       "additionalProperties": false,
       "properties": {
+        "audience": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 120,
+          "description": "Intended reader context for the sizing guide."
+        },
         "product_type": {
           "type": "string",
           "minLength": 2,
@@ -31,6 +37,12 @@
           "enum": ["inches", "centimeters", "both"],
           "default": "inches",
           "description": "Display unit for size_table values. 'both' renders inches and a parenthesized cm conversion."
+        },
+        "measurement_source": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 200,
+          "description": "Source for numeric sizing claims, e.g. pattern block, sample measurement run, or fixture note."
         },
         "size_table": {
           "type": "array",

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -5,6 +5,7 @@
    Schema: schemas/faq.schema.json
 #}
 {% extends "page.html" %}
+{% import "partials/assert.html" as assert %}
 
 {% block ld_json %}
   {%- include "partials/ld-organization.html" -%}
@@ -13,6 +14,9 @@
 {% endblock ld_json %}
 
 {% block content %}
+{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="faq.html") }}
+{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="faq.html") }}
+{{ assert::required(ok=page.extra.questions is defined and page.extra.questions | length > 0, field="page.extra.questions", template="faq.html") }}
 <article class="faq-page">
   <header class="page-header">
     <h1>{{ page.title }}</h1>

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,9 +20,10 @@
      +++
 #}
 {% extends "base.html" %}
+{% import "partials/assert.html" as assert %}
 
-{% block title %}{{ section.extra.seo_title | default(value=section.title) }}{% endblock title %}
-{% block og_title %}{{ section.extra.seo_title | default(value=section.title) }}{% endblock og_title %}
+{% block title %}{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="index.html") }}{{ section.extra.seo_title | default(value=section.title) }}{% endblock title %}
+{% block og_title %}{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="index.html") }}{{ section.extra.seo_title | default(value=section.title) }}{% endblock og_title %}
 
 {% block description %}{{ section.description | default(value=config.description | default(value="")) }}{% endblock description %}
 {% block og_description %}{{ section.description | default(value=config.description | default(value="")) }}{% endblock og_description %}

--- a/templates/journal-entry.html
+++ b/templates/journal-entry.html
@@ -11,6 +11,7 @@
      page.extra.words. See schemas/journal-entry.schema.json.
 #}
 {% extends "page.html" %}
+{% import "partials/assert.html" as assert %}
 
 {% block og_type %}article{% endblock og_type %}
 
@@ -21,6 +22,13 @@
 {% endblock ld_json %}
 
 {% block content %}
+{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="journal-entry.html") }}
+{{ assert::required(ok=page.description is defined and page.description, field="page.description", template="journal-entry.html") }}
+{{ assert::required(ok=page.date is defined and page.date, field="page.date", template="journal-entry.html") }}
+{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="journal-entry.html") }}
+{{ assert::required(ok=page.extra.components is defined and page.extra.components, field="page.extra.components", template="journal-entry.html") }}
+{{ assert::required(ok=page.extra.words is defined and page.extra.words, field="page.extra.words", template="journal-entry.html") }}
+{{ assert::required(ok=page.extra.words_source is defined and page.extra.words_source, field="page.extra.words_source", template="journal-entry.html") }}
 <article class="journal-entry-page">
   <header class="entry-header">
     <h1>{{ page.title }}</h1>

--- a/templates/journal-section.html
+++ b/templates/journal-section.html
@@ -17,9 +17,10 @@
    See schemas/journal-entry.schema.json.
 #}
 {% extends "base.html" %}
+{% import "partials/assert.html" as assert %}
 
-{% block title %}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock title %}
-{% block og_title %}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock og_title %}
+{% block title %}{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="journal-section.html") }}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock title %}
+{% block og_title %}{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="journal-section.html") }}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock og_title %}
 
 {% block description %}{{ section.description | default(value=config.description | default(value="")) }}{% endblock description %}
 {% block og_description %}{{ section.description | default(value=config.description | default(value="")) }}{% endblock og_description %}
@@ -32,6 +33,7 @@
 {% endblock ld_json %}
 
 {% block content %}
+{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="journal-section.html") }}
 {%- if section.extra.greek %}
 <h1 data-greek="{{ section.extra.greek }}"><span>{{ section.title }}</span></h1>
 {%- else %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -2,9 +2,10 @@
    shared base shell. Consumers can override per-page via frontmatter
    `template = "..."` or per-section by shipping `<section>/page.html`. #}
 {% extends "base.html" %}
+{% import "partials/assert.html" as assert %}
 
-{% block title %}{{ page.extra.seo_title | default(value=page.title) }} - {{ config.title }}{% endblock title %}
-{% block og_title %}{{ page.extra.seo_title | default(value=page.title) }} - {{ config.title }}{% endblock og_title %}
+{% block title %}{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="page.html") }}{{ page.extra.seo_title | default(value=page.title) }} - {{ config.title }}{% endblock title %}
+{% block og_title %}{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="page.html") }}{{ page.extra.seo_title | default(value=page.title) }} - {{ config.title }}{% endblock og_title %}
 
 {% block description %}{{ page.description | default(value=config.description | default(value="")) }}{% endblock description %}
 {% block og_description %}{{ page.description | default(value=config.description | default(value="")) }}{% endblock og_description %}
@@ -23,7 +24,11 @@
 {% block ld_json %}
   {{ super() }}
   {# Product JSON-LD when frontmatter is product-shaped (per schema). #}
-  {%- if page.extra.price and page.extra.stripe_url -%}
+  {%- if page.extra.price or page.extra.stripe_url or page.extra.price_source -%}
+  {{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="page.html") }}
+  {{ assert::required(ok=page.extra.price is defined and page.extra.price, field="page.extra.price", template="page.html") }}
+  {{ assert::required(ok=page.extra.price_source is defined and page.extra.price_source, field="page.extra.price_source", template="page.html") }}
+  {{ assert::required(ok=page.extra.stripe_url is defined and page.extra.stripe_url, field="page.extra.stripe_url", template="page.html") }}
   {%- include "partials/ld-product.html" -%}
   {%- endif -%}
   {# BreadcrumbList for non-home pages. #}

--- a/templates/partials/assert.html
+++ b/templates/partials/assert.html
@@ -1,0 +1,8 @@
+{# Template assertions for metadata that must exist before rendering.
+   Schema validation should catch these first; throw keeps custom-template
+   builds from silently rendering incomplete context. #}
+{% macro required(ok, field, template) -%}
+{%- if not ok -%}
+{{ throw(message=template ~ ": missing required metadata `" ~ field ~ "`") }}
+{%- endif -%}
+{%- endmacro required %}

--- a/templates/partials/ld-article.html
+++ b/templates/partials/ld-article.html
@@ -10,6 +10,11 @@
      config.extra.author.name — fallback brand author
      config.title       — publisher name
 #}
+{% import "partials/assert.html" as assert %}
+{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="partials/ld-article.html") }}
+{{ assert::required(ok=page.description is defined and page.description, field="page.description", template="partials/ld-article.html") }}
+{{ assert::required(ok=page.date is defined and page.date, field="page.date", template="partials/ld-article.html") }}
+{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="partials/ld-article.html") }}
 {%- set author_name = page.extra.author | default(value=config.extra.author.name) | default(value=config.title) -%}
 {%- set image_url = "" -%}
 {%- if page.extra.og_image -%}

--- a/templates/partials/ld-faq.html
+++ b/templates/partials/ld-faq.html
@@ -5,6 +5,10 @@
    Inputs:
      page.extra.questions — array of {q, a, anchor?} per faq schema
 #}
+{% import "partials/assert.html" as assert %}
+{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="partials/ld-faq.html") }}
+{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="partials/ld-faq.html") }}
+{{ assert::required(ok=page.extra.questions is defined and page.extra.questions | length > 0, field="page.extra.questions", template="partials/ld-faq.html") }}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/templates/partials/ld-howto.html
+++ b/templates/partials/ld-howto.html
@@ -12,6 +12,11 @@
 
    Schema reference: https://schema.org/HowTo
 #}
+{% import "partials/assert.html" as assert %}
+{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="partials/ld-howto.html") }}
+{{ assert::required(ok=page.extra.product_type is defined and page.extra.product_type, field="page.extra.product_type", template="partials/ld-howto.html") }}
+{{ assert::required(ok=page.extra.measurement_source is defined and page.extra.measurement_source, field="page.extra.measurement_source", template="partials/ld-howto.html") }}
+{{ assert::required(ok=page.extra.decision_tree is defined and page.extra.decision_tree | length > 0, field="page.extra.decision_tree", template="partials/ld-howto.html") }}
 {%- set howto_name = "How to choose your " ~ page.extra.product_type ~ " size" -%}
 <script type="application/ld+json">
 {

--- a/templates/partials/ld-product.html
+++ b/templates/partials/ld-product.html
@@ -12,6 +12,13 @@
      config.title          — brand name (Product.brand)
      config.base_url       — for image absolute URL
 #}
+{% import "partials/assert.html" as assert %}
+{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="partials/ld-product.html") }}
+{{ assert::required(ok=page.description is defined and page.description, field="page.description", template="partials/ld-product.html") }}
+{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="partials/ld-product.html") }}
+{{ assert::required(ok=page.extra.price is defined and page.extra.price, field="page.extra.price", template="partials/ld-product.html") }}
+{{ assert::required(ok=page.extra.price_source is defined and page.extra.price_source, field="page.extra.price_source", template="partials/ld-product.html") }}
+{{ assert::required(ok=page.extra.stripe_url is defined and page.extra.stripe_url, field="page.extra.stripe_url", template="partials/ld-product.html") }}
 {%- set price_numeric = page.extra.price | trim_start_matches(pat="$") -%}
 {%- set image_url = "" -%}
 {%- if page.extra.og_image -%}

--- a/templates/section.html
+++ b/templates/section.html
@@ -1,8 +1,9 @@
 {# Default section template. Renders the section index's markdown content. #}
 {% extends "base.html" %}
+{% import "partials/assert.html" as assert %}
 
-{% block title %}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock title %}
-{% block og_title %}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock og_title %}
+{% block title %}{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="section.html") }}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock title %}
+{% block og_title %}{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="section.html") }}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock og_title %}
 
 {% block description %}{{ section.description | default(value=config.description | default(value="")) }}{% endblock description %}
 {% block og_description %}{{ section.description | default(value=config.description | default(value="")) }}{% endblock og_description %}

--- a/templates/sizing-guide.html
+++ b/templates/sizing-guide.html
@@ -5,6 +5,7 @@
    Schema: schemas/sizing-guide.schema.json
 #}
 {% extends "page.html" %}
+{% import "partials/assert.html" as assert %}
 
 {% block ld_json %}
   {{ super() }}
@@ -17,6 +18,11 @@
 {% endblock ld_json %}
 
 {% block content %}
+{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="sizing-guide.html") }}
+{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="sizing-guide.html") }}
+{{ assert::required(ok=page.extra.product_type is defined and page.extra.product_type, field="page.extra.product_type", template="sizing-guide.html") }}
+{{ assert::required(ok=page.extra.measurement_source is defined and page.extra.measurement_source, field="page.extra.measurement_source", template="sizing-guide.html") }}
+{{ assert::required(ok=page.extra.size_table is defined and page.extra.size_table | length > 0, field="page.extra.size_table", template="sizing-guide.html") }}
 <article class="sizing-guide">
   <header class="page-header">
     <h1>{{ page.title }}</h1>


### PR DESCRIPTION
## Summary
- add template-level required metadata assertions so custom render paths fail closed
- require audience and numeric-claim source metadata in FAQ, journal, product, and sizing schemas
- add a sizing-guide fixture and update existing fixtures/docs for the stricter contracts

Closes #1.

## Validation
- bin/typikon-validate examples/sample-blog
- bin/typikon-validate examples/sample-shop
- negative schema probe: product missing `price_source` fails validation
- python3 -m json.tool over schemas/*.schema.json
- kanon lint --summary docs/SCHEMAS.md
- git diff --check

## Not rerun locally
- Zola render/build gates could not be rerun from this parent shell because `zola` is not on PATH here. The worker reported Zola 0.22.1 `check` and `build` for both fixtures, CSP checks against isolated outputs, and negative render assertion checks before handoff.

## Breaking change
This is a breaking schema change for consumers with FAQ, journal, product, or sizing-guide content. No automatic migration is included because meaningful `audience` and source metadata cannot be inferred safely.

## Source note
The Ergon source citation path `src/default-templates/deliverable-pdf/README.md:13` is absent on current `origin/main`; this implementation follows the repo's live schema/template patterns.