### PR TITLE
chore(hygiene): kanon lint safe-class fixes

### DIFF
--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -3,7 +3,11 @@
 # spdx: AGPL-3.0-or-later
 
 [pipeline]
-stages = ["fixtures-gate"]
+stages = ["lint", "fixtures-gate"]
+
+[stages.lint]
+cmd = "kanon lint . --summary"
+timeout_secs = 60
 
 [stages.fixtures-gate]
 cmd = "ci/run-fixtures.sh"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,9 @@
+<!--
+scope: Fleet Zola theme, frontmatter schemas, scaffolds, and CI gates for agentic web-property substrate
+defers_to: docs/AGENTIC.md for the agent contract; docs/SCHEMAS.md for frontmatter rules; docs/BOOTSTRAP.md for scaffolder behaviour
+tightens: forge-primary push policy and strict CSP with no unsafe-inline narrow the kanon defaults for fleet web properties
+-->
+
 # CLAUDE.md: Typikon
 
 ## Repository

--- a/_llm/apis.toml
+++ b/_llm/apis.toml
@@ -1,3 +1,9 @@
+# Typikon ships no MCP server and no HTTP routes; these arrays are intentionally empty
+# but declared so the LLM-schema validator passes. Top-level keys must precede any
+# table declarations under TOML semantics.
+mcp_tools = []
+http_routes = []
+
 [meta]
 name = "typikon"
 repo = "forkwright/typikon"
@@ -9,7 +15,7 @@ source_docs = [
 ]
 
 [apis]
-summary = "Typikon exposes local CLI scripts for scaffolding, validation, migration, and CI checks."
+summary = "Typikon exposes local CLI scripts for scaffolding, validation, migration, and CI checks. No MCP server surface and no HTTP routes; all interaction is via the local CLIs enumerated below."
 
 [[cli_commands]]
 name = "bin/typikon-init"

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -1,6 +1,6 @@
 # Agentic operation
 
-Typikon is operated by AI agents. This document is the contract every agent follows when working on typikon itself or on any consumer site.
+Every agent working on typikon itself or on any consumer site follows the contract below. Typikon is operated by AI agents; human edits are exceptions.
 
 If you are a human reading this: every constraint here is also good for humans, but the bias is toward machine ergonomics. When in doubt, optimize for the agent.
 


### PR DESCRIPTION
## Summary

Milestone-level QA sweep, safe-class hygiene only. Reduces kanon lint findings from 24 to 19; remaining 19 are out of safe-class scope (18 prose em-dashes in user-facing docs/examples; 1 csp-enforce.sh strict-mode where adding -e would break violation counting).

- CLAUDE.md: add preamble block (scope / defers_to / tightens) — fixes CONTEXT/preamble-required + WORKFLOW/defers-to
- _llm/apis.toml: declare top-level mcp_tools / http_routes empty arrays (typikon has no MCP surface or HTTP routes) — fixes WORKFLOW/llm-schema-valid x2
- .kanon-ci.toml: register lint stage so pipeline runs kanon lint as a gate — fixes CI/kanon-ci-lint-stage-required
- docs/AGENTIC.md: rewrite "This document is the contract..." opener — fixes WRITING/greeting-conclusion-framing

## Test plan

- [x] kanon lint . --summary (24 -> 19 violations; remaining are out of safe-class scope)
- [x] TOML parses (top-level keys precede tables)
- [x] No secrets/path leakage introduced
- [x] No CI workflows touched (forge-only CI by design; no GitHub Actions surface)