### PR TITLE
docs(README): add typikon-migrate-template to binary inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Optimized for agentic operation. Humans should not need to develop here. The sub
 - **Templates** (`templates/`) — Tera templates for base, page, section, journal.
 - **Schemas** (`schemas/`) — JSON Schema for every content type. Frontmatter must validate before commit.
 - **Scaffolds** (`scaffolds/`) — content templates copied by `bin/typikon-init`.
-- **Binaries** (`bin/`) — `typikon-init`, `typikon-validate`, `typikon-check`, `typikon-refresh`. Idempotent CLIs with JSONL output where applicable.
+- **Binaries** (`bin/`) — `typikon-init`, `typikon-validate`, `typikon-check`, `typikon-refresh`, `typikon-migrate-template` (skeleton for schema-migration scripts). Idempotent CLIs with JSONL output where applicable.
 - **CI** (`ci/`) — strict gate: build, CSP enforcement, internal + external link integrity, a11y, smoke. No pass = no deploy.
 - **Headers** (`_headers.tmpl`, `_redirects.tmpl`) — Cloudflare Pages strict-CSP + redirect templates.
 


### PR DESCRIPTION
## Summary

`bin/typikon-migrate-template` is present and executable but was missing from the README's binary inventory. Surfaced by the 2026-05-24 milestone audit.

## Changes

- `README.md` line 16: add `typikon-migrate-template` to the bin list with a one-line purpose blurb.

Closes #10