### PR TITLE
ci(csp-enforce.sh): suppress SHELL/strict-mode with intent directive

### DIFF
--- a/ci/csp-enforce.sh
+++ b/ci/csp-enforce.sh
@@ -26,6 +26,7 @@
 #   1  violations found (printed with file path + matched line)
 #   2  invocation error
 
+# kanon:ignore SHELL/strict-mode -- counts violations across all files + continues; set -e would abort on first
 set -uo pipefail
 
 usage() {


### PR DESCRIPTION
## Summary

`ci/csp-enforce.sh` intentionally uses `set -uo pipefail` (no `-e`) so the violation-counter walks every HTML file instead of aborting on the first hit. Adds an inline `# kanon:ignore SHELL/strict-mode` directive with rationale.

## Changes

- `ci/csp-enforce.sh`: add ignore directive immediately above the `set` line.

Closes #8