### PR TITLE
feat(ci): scaffold kanon deploy template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,9 @@ Web-property-specific standards live alongside as kanon STANDARDS/WEB.md (filed 
 
 ## Locked decisions
 
-- **Static SSG**: Zola 0.22.x. No JavaScript build step, no Node toolchain, no npm in the deploy path.
+- **Static SSG**: Zola 0.22.x. No JavaScript build step, no Node toolchain, no npm in the site build path.
+- **Dual-CI migration window**: consumer sites scaffold both `.kanon-ci.toml` and `.github/workflows/deploy.yml`. Forge is primary; GitHub is the executable fallback until menos validates the forge deploy path end-to-end. Both templates target the same Cloudflare Pages project and main/master branch semantics.
+- **Temporary Node deploy-tool exception**: the consumer deploy gates install npm-based `pa11y`, Playwright, and Wrangler so forge and GitHub stay stage-for-stage equivalent during migration. Revisit when forge has native replacements.
 - **Theme distribution**: git submodule under consumer's `themes/typikon/`. (Zola has no theme registry; submodule is current best practice.)
 - **Strict CSP**: no `unsafe-inline` anywhere. CSP-enforce CI gate fails the build on any inline script, style, or `on*=` handler.
 - **Self-hosted fonts**: WOFF2 under `static/fonts/`. Zero external CDN at visitor runtime. OFL families only.

--- a/bin/typikon-init
+++ b/bin/typikon-init
@@ -12,7 +12,7 @@
 #     <dest>/
 #     ├── .git/                     (git init, remotes set: origin=forge, github=mirror)
 #     ├── .gitignore                (zola public/, editor crud)
-#     ├── .kanon-ci.toml            (sentinel pipeline; consumers replace with real gate)
+#     ├── .kanon-ci.toml            (strict forge-primary deploy gate)
 #     ├── themes/typikon/           (git submodule -> forkwright/typikon)
 #     ├── config.toml               (Zola config with placeholder [extra])
 #     ├── content/_index.md         (homepage stub)
@@ -114,7 +114,7 @@ copy_template() {
 copy_template "$TYPIKON_ROOT/_headers.tmpl" "_headers"
 copy_template "$TYPIKON_ROOT/_redirects.tmpl" "_redirects"
 
-# GitHub Actions workflow — substitute placeholders during copy.
+# CI workflow templates - substitute placeholders during copy.
 # ZOLA_VERSION default lives in bin/typikon-defaults.sh (single source
 # of truth shared with typikon-refresh); env-var override stays the
 # same shape (`TYPIKON_ZOLA_VERSION=... typikon-init ...`).
@@ -132,6 +132,16 @@ else
     echo "skip   .github/workflows/deploy.yml (exists)" >&2
 fi
 
+if [[ ! -e .kanon-ci.toml ]]; then
+    sed -e "s|{{ PROJECT_NAME }}|${SITE_NAME}|g" \
+        -e "s|{{ ZOLA_VERSION }}|${ZOLA_VERSION}|g" \
+        "$TYPIKON_ROOT/ci/kanon-ci.toml.tmpl" \
+        > .kanon-ci.toml
+    echo "create .kanon-ci.toml (from ci/kanon-ci.toml.tmpl)" >&2
+else
+    echo "skip   .kanon-ci.toml (exists)" >&2
+fi
+
 write_if_absent ".gitignore" "$(cat <<'GITIGNORE'
 public/
 .zola-cache/
@@ -146,26 +156,6 @@ playwright-report/
 .env
 .env.local
 GITIGNORE
-)
-"
-
-write_if_absent ".kanon-ci.toml" "$(cat <<'CI'
-# Site CI pipeline — sentinel until typikon's full gate ships.
-#
-# Phase 5 of typikon's v1 plan replaces these stages with the strict
-# gate (zola check, zola build, csp-enforce, lychee, pa11y,
-# playwright-smoke). Until then, this sentinel keeps the forge
-# post-receive hook honest.
-[pipeline]
-stages = ["checkout-ok"]
-
-[stages.checkout-ok]
-cmd = "true"
-timeout_secs = 10
-
-[verifier]
-enabled = false
-CI
 )
 "
 
@@ -280,7 +270,8 @@ git commit -m "chore(theme): bump typikon to <sha> + regen templates"
 \`\`\`
 
 \`typikon-refresh\` bumps the submodule to the latest \`origin/main\`,
-re-renders every substituted template (e.g. \`.github/workflows/deploy.yml\`
+re-renders every substituted template (including \`.kanon-ci.toml\`
+from \`ci/kanon-ci.toml.tmpl\` and \`.github/workflows/deploy.yml\`
 from \`ci/github-workflow.yml.tmpl\`), and leaves the diff staged for
 review. Idempotent: re-running with no upstream changes is a no-op.
 See \`themes/typikon/bin/typikon-refresh --help\` for env knobs.

--- a/bin/typikon-refresh
+++ b/bin/typikon-refresh
@@ -20,10 +20,11 @@
 # in `_headers.tmpl` / `_redirects.tmpl` notes that those instances are
 # operator-edited (they're NOT re-rendered here for that reason — only
 # the genuine `{{ PLACEHOLDER }}`-substituted templates pass through).
-# For `ci/github-workflow.yml.tmpl` the rendered instance lives at
-# `.github/workflows/deploy.yml` and is treated as derived: hand-edits
-# there are lost on refresh, by design. Per-site GH Actions deltas
-# belong in a sibling workflow file the consumer authors directly.
+# For `ci/kanon-ci.toml.tmpl` and `ci/github-workflow.yml.tmpl`, the
+# rendered instances live at `.kanon-ci.toml` and
+# `.github/workflows/deploy.yml` and are treated as derived: hand-edits
+# there are lost on refresh, by design. Per-site CI deltas belong in
+# sibling files or operator-authored follow-up commits.
 #
 # Environment:
 #     TYPIKON_ZOLA_VERSION   pinned Zola version (default: 0.22.1, mirroring
@@ -133,6 +134,7 @@ ZOLA_VERSION="${TYPIKON_ZOLA_VERSION:-}"
 # verbatim copies that consumers edit) intentionally do not appear
 # here; they are scaffolded once by typikon-init and not re-rendered.
 declare -a TMPL_TARGETS=(
+    "ci/kanon-ci.toml.tmpl|.kanon-ci.toml"
     "ci/github-workflow.yml.tmpl|.github/workflows/deploy.yml"
 )
 

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -1,0 +1,187 @@
+# kanon-CI pipeline for typikon-consuming sites.
+#
+# This file is a TEMPLATE. typikon-init copies it to a consumer site as
+# .kanon-ci.toml during scaffolding, substituting the two placeholders below.
+#
+# Placeholders:
+#   {{ PROJECT_NAME }}   - Cloudflare Pages project slug (e.g. ardent-site)
+#   {{ ZOLA_VERSION }}   - pinned Zola version (current: 0.22.1)
+#
+# Forge runners must provide:
+#   - CLOUDFLARE_API_TOKEN
+#   - CF_ACCOUNT_ID (or CLOUDFLARE_ACCOUNT_ID for GitHub-env parity)
+#
+# This mirrors ci/github-workflow.yml.tmpl stage-for-stage. GitHub remains
+# the executable fallback until forge runners validate the same deploy path.
+
+[pipeline]
+stages = [
+  "install-zola",
+  "install-python-deps",
+  "setup-node-tooling",
+  "typikon-validate",
+  "zola-check",
+  "zola-build",
+  "copy-cloudflare-files",
+  "csp-enforce",
+  "lychee",
+  "serve-public",
+  "pa11y",
+  "playwright",
+  "teardown-static-server",
+  "deploy-cloudflare-pages",
+]
+
+[stages.install-zola]
+cmd = """
+set -euo pipefail
+ZOLA_SHA256=0ca09aa40376aaa9ddfb512ff9ad963262ef95edb0d0f2d5ec6961b6f5cf22ef
+curl -L "https://github.com/getzola/zola/releases/download/v{{ ZOLA_VERSION }}/zola-v{{ ZOLA_VERSION }}-x86_64-unknown-linux-gnu.tar.gz" -o zola.tar.gz
+echo "${ZOLA_SHA256}  zola.tar.gz" | sha256sum -c
+tar -xzf zola.tar.gz
+mkdir -p .kanon-ci/bin
+mv zola .kanon-ci/bin/
+rm -f zola.tar.gz
+.kanon-ci/bin/zola --version
+"""
+timeout_secs = 120
+
+[stages.install-python-deps]
+cmd = """
+set -euo pipefail
+python3 -m pip install --user jsonschema
+"""
+timeout_secs = 120
+
+[stages.setup-node-tooling]
+cmd = """
+set -euo pipefail
+LYCHEE_VERSION=0.24.2
+LYCHEE_SHA256=1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
+npm install -g pa11y-ci@latest @playwright/test@latest
+npx playwright install --with-deps chromium
+curl -L "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" -o lychee.tar.gz
+echo "${LYCHEE_SHA256}  lychee.tar.gz" | sha256sum -c
+mkdir -p lychee-extract .kanon-ci/bin
+tar -xzf lychee.tar.gz -C lychee-extract --strip-components=1
+mv lychee-extract/lychee .kanon-ci/bin/
+rm -rf lychee.tar.gz lychee-extract
+"""
+timeout_secs = 900
+
+[stages.typikon-validate]
+cmd = """
+set -euo pipefail
+themes/typikon/bin/typikon-validate .
+"""
+timeout_secs = 120
+
+[stages.zola-check]
+cmd = """
+set -euo pipefail
+PATH="$PWD/.kanon-ci/bin:$PATH" zola check
+"""
+timeout_secs = 120
+
+[stages.zola-build]
+cmd = """
+set -euo pipefail
+PATH="$PWD/.kanon-ci/bin:$PATH" zola build
+"""
+timeout_secs = 120
+
+[stages.copy-cloudflare-files]
+cmd = """
+set -euo pipefail
+[ -f _headers ] && cp _headers public/_headers
+[ -f _redirects ] && cp _redirects public/_redirects
+[ -f public/404/index.html ] && cp public/404/index.html public/404.html
+true
+"""
+timeout_secs = 30
+
+[stages.csp-enforce]
+cmd = """
+set -euo pipefail
+themes/typikon/ci/csp-enforce.sh public/
+"""
+timeout_secs = 120
+
+[stages.lychee]
+cmd = """
+set -euo pipefail
+BASE_URL=$(grep -E '^base_url\\s*=' config.toml | head -1 | sed -E 's/^base_url\\s*=\\s*"([^"]+)".*/\\1/' | sed 's:/$::')
+BASE_HOST=$(printf '%s' "$BASE_URL" | sed -E 's|^https?://||' | sed -E 's|/.*$||')
+ESCAPED_HOST=$(printf '%s' "$BASE_HOST" | sed 's/\\./\\\\./g')
+echo "Excluding self-host links: ^https?://${ESCAPED_HOST}/"
+PATH="$PWD/.kanon-ci/bin:$PATH" lychee --config themes/typikon/ci/lychee.toml --root-dir "$PWD/public" --exclude "^https?://${ESCAPED_HOST}/" public/
+"""
+timeout_secs = 300
+
+[stages.serve-public]
+cmd = """
+set -euo pipefail
+cd public
+python3 -m http.server 8080 > ../.kanon-ci/http-server.log 2>&1 &
+echo $! > ../.kanon-ci/server.pid
+sleep 2
+"""
+timeout_secs = 30
+
+[stages.pa11y]
+cmd = """
+set -euo pipefail
+pa11y-ci --config themes/typikon/ci/pa11y.config.js
+"""
+timeout_secs = 300
+
+[stages.playwright]
+cmd = """
+set -euo pipefail
+if find tests/smoke -type f -name '*.spec.ts' | grep -q .; then
+  cp themes/typikon/ci/playwright.config.ts ./playwright.config.ts
+  npx playwright test
+else
+  echo "skip playwright: no tests/smoke/**/*.spec.ts files"
+fi
+"""
+timeout_secs = 300
+
+[stages.teardown-static-server]
+cmd = """
+set -euo pipefail
+kill "$(cat .kanon-ci/server.pid 2>/dev/null)" 2>/dev/null || true
+"""
+timeout_secs = 30
+
+[stages.deploy-cloudflare-pages]
+cmd = """
+set -euo pipefail
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+case "$BRANCH" in
+  main|master) ;;
+  *)
+    echo "skip deploy: branch ${BRANCH} is not main/master"
+    exit 0
+    ;;
+esac
+
+ACCOUNT_ID="${CF_ACCOUNT_ID:-${CLOUDFLARE_ACCOUNT_ID:-}}"
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
+: "${ACCOUNT_ID:?CF_ACCOUNT_ID or CLOUDFLARE_ACCOUNT_ID is required}"
+
+curl -fsS -X PATCH \
+  "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/pages/projects/{{ PROJECT_NAME }}" \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data "{\\\"production_branch\\\": \\\"${BRANCH}\\\"}" \
+  > /tmp/cf-edit.json
+echo "production_branch set to: $(jq -r '.result.production_branch // .errors' /tmp/cf-edit.json)"
+
+npm install -g wrangler
+wrangler pages deploy public --project-name={{ PROJECT_NAME }} --branch="${BRANCH}"
+"""
+timeout_secs = 600
+
+[verifier]
+enabled = false


### PR DESCRIPTION
## Summary

- add `ci/kanon-ci.toml.tmpl` mirroring the consumer GitHub deploy workflow stages
- render `.kanon-ci.toml` from `typikon-init` and `typikon-refresh`
- document the dual-CI migration window and temporary npm deploy-tool exception in `CLAUDE.md`

Closes #12.

## Verification

- `bash -n bin/typikon-init bin/typikon-refresh`
- `shellcheck -x bin/typikon-init bin/typikon-refresh`
- `python3` TOML parse + per-stage `bash -n` validation for `ci/kanon-ci.toml.tmpl`
- `typikon-init test-site /tmp/typikon-scaffold-test` generated `.kanon-ci.toml` and `.github/workflows/deploy.yml` with matching project slug/Zola version
- `typikon-refresh` re-rendered both CI templates from a temporary bare origin
- `./ci/run-fixtures.sh` passed the local validation stage; local Zola/lychee/pa11y/browser stages skipped because those tools are not installed here

## Notes

`kanon lint . --summary` still reports the existing typikon baseline: 18 `WRITING/em-dash` findings plus the pre-existing `ci/csp-enforce.sh` strict-mode finding. This PR does not add new kanon-lint findings.
