### PR TITLE
chore(lint): preserve typikon prose voice

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -1,0 +1,9 @@
+# typikon#9: preserve intentional substrate/example prose voice.
+WRITING/em-dash:README.md # typikon#9 preserves public substrate prose voice
+WRITING/em-dash:docs/AGENTIC.md # typikon#9 preserves agent-contract prose voice
+WRITING/em-dash:docs/BOOTSTRAP.md # typikon#9 preserves bootstrap prose voice
+WRITING/em-dash:examples/sample-shop/content/products/gadget.md # typikon#9 preserves rendered example prose voice
+WRITING/em-dash:examples/sample-shop/content/products/widget.md # typikon#9 preserves rendered example prose voice
+
+# typikon#15: keep CSP scan accumulation behavior; set -e would abort on the first grep miss.
+SHELL/strict-mode:ci/csp-enforce.sh # typikon#15 preserves full-report CSP scan behavior


### PR DESCRIPTION
## Summary
- Add scoped .kanon-lint-ignore entries preserving typikon#9 em-dash prose in public docs and rendered examples.
- Carry the existing typikon#15 CSP strict-mode exception into the root ignore file so kanon lint is green without changing script behavior.

## QA
- Kimi QA: No findings.
- DIFF-VERIFY: single new .kanon-lint-ignore file; no prose sweep.

## Verification
- kanon lint . --summary
- ci/run-fixtures.sh (typikon-validate passed for both fixtures; zola, lychee, pa11y-ci, and Playwright smoke stages skipped because the optional tools/tests are unavailable locally)

Closes #9