### PR TITLE
chore(lint): drop stale csp inline ignore

### DIFF
--- a/ci/csp-enforce.sh
+++ b/ci/csp-enforce.sh
@@ -26,7 +26,7 @@
 #   1  violations found (printed with file path + matched line)
 #   2  invocation error
 
-# kanon:ignore SHELL/strict-mode -- counts violations across all files + continues; set -e would abort on first
+# Counts violations across all files and continues; set -e would abort on first miss.
 set -uo pipefail
 
 usage() {


### PR DESCRIPTION
## Summary
- Convert the old inline SHELL/strict-mode kanon suppression in ci/csp-enforce.sh into a plain rationale comment.
- Keep the runtime behavior unchanged; .kanon-lint-ignore from #18 now owns the scoped suppression.

## QA
- Kimi QA: No findings.
- DIFF-VERIFY: one-line comment-only change in ci/csp-enforce.sh.

## Verification
- kanon lint . --summary
- kanon lint . --detect-stale-suppressions --summary
- ci/run-fixtures.sh (typikon-validate passed for both fixtures; zola, lychee, pa11y-ci, and Playwright smoke stages skipped because optional tools/tests are unavailable locally)