### PR TITLE
docs(AGENTS): add agent operating manual

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md
+
+Agent operating manual for forkwright/typikon. Read this before contributing to the theme substrate.
+
+## Quick start
+
+Typikon is a Zola theme + frontmatter schemas + CI gates for agentic fleet web properties. Read the entry points in order:
+
+1. [README.md](README.md) — overview, design, usage
+2. [CLAUDE.md](CLAUDE.md) — locked decisions, boundaries
+3. [docs/AGENTIC.md](docs/AGENTIC.md) — agent contract (5 rules)
+4. [docs/SCHEMAS.md](docs/SCHEMAS.md) — frontmatter field reference
+5. [docs/BOOTSTRAP.md](docs/BOOTSTRAP.md) — scaffolder behavior
+
+## Key binaries
+
+| Binary | Purpose |
+|--------|---------|
+| `bin/typikon-init` | Scaffold a new consumer site or content primitive. Usage: `bin/typikon-init <site-name> <dest>`. |
+| `bin/typikon-validate` | Validate frontmatter against schemas. Usage: `bin/typikon-validate <consumer-site-root>`. JSONL output on stderr. |
+| `bin/typikon-check` | Run the full local pre-push gate (7 stages). Usage: `bin/typikon-check <consumer-site-root>`. |
+| `bin/typikon-refresh` | Bump consumer site submodule + re-render templates. Run from consumer site root. |
+| `bin/typikon-migrate-template` | Skeleton for schema-migration scripts. Copy and adapt when frontmatter changes incompatibly. |
+
+All CLIs are idempotent; JSONL output for parsing.
+
+## Development loop
+
+### Theme changes
+
+1. Edit template, schema, scaffold, or CI gate in typikon.
+2. Validate: `cd <consumer-site> && themes/typikon/bin/typikon-check .` (all 7 stages pass).
+3. Run the theme gate locally: `cd <typikon> && ci/run-fixtures.sh` (validates typikon's own fixtures).
+4. Commit with conventional commit (type: feat/fix/chore/docs). No inline scripts/styles. No unsafe-inline CSP.
+5. Push to origin (forge is primary). CI gate on forge runs kanon lint + fixtures.
+
+### Consumer site updates
+
+Consumer sites use typikon as a git submodule under `themes/typikon/` and scaffold content via the binaries above. When typikon changes:
+
+1. Consumer runs `themes/typikon/bin/typikon-refresh` (bumps submodule, re-renders templates).
+2. Consumer validates: `bin/typikon-check .` (all 7 stages).
+3. Consumer commits the diff.
+
+## Locked decisions
+
+All decisions are in [CLAUDE.md](CLAUDE.md) under "Locked decisions". Key ones:
+
+- **Static SSG**: Zola 0.22.x. No JavaScript build step in site build path.
+- **Strict CSP**: no `unsafe-inline` anywhere. CSP-enforce CI gate fails the build on inline script/style/handler.
+- **Self-hosted fonts**: WOFF2 under `static/fonts/`. Zero external CDN at visitor runtime.
+- **Forge-primary**: origin points at forkwright forge; GitHub is push-mirror only.
+- **License**: AGPL-3.0-or-later. AI-training prohibited (NOTICE).
+
+## Boundaries
+
+- **Push to origin (forge), not github.** Git remote verify: `git remote -v`.
+- **Never bypass the CI gate.** No `--no-verify`, no `[skip ci]`, no commit on green failure.
+- **Schema changes are migrations.** When a schema changes incompatibly, ship a migration script in `bin/`.
+- **Schemas and primitives change in typikon, not in consumers.** When two consumer sites disagree on a primitive, parameterize the schema here; do not fork the theme.
+
+## Dispatch entry points
+
+When a kimi (T3) worker lands changes to typikon:
+
+- All changes go through `bin/typikon-check` (or CI runs it). Gate must pass.
+- Recent-work review (5 days): commits must be sound (complete, no stubs/TODO-left), no AI indicators.
+- Docs (README/CLAUDE/AGENTS/llms.txt/_llm/) must be kept current — do not defer doc updates to a follow-up PR.
+
+When typikon changes, all consumer sites that use it as a submodule must refresh:
+
+- A parent orchestrator (T2) coordinates typikon bumps across the fleet once per release.
+- Consumers validate and commit the bump.
+
+## Glossary
+
+See [_llm/glossary.toml](_llm/glossary.toml) for typikon vocabulary (scaffold, schema, primitive, substrate, gate, CSP).
+
+## Architecture
+
+See [_llm/architecture.toml](_llm/architecture.toml) for theme layers and tool surfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,35 @@
 # Changelog
+
+All notable changes to this project are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project follows semantic versioning.
+
+This file is maintained by [release-please](https://github.com/googleapis/release-please). Do not edit by hand; use `git commit` with conventional commits, and release-please will populate this file during version cuts.
+
+## Unreleased
+
+### Features
+
+- **ci**: Scaffold kanon deploy template (#17) — consumer sites now scaffold `.kanon-ci.toml` from `ci/kanon-ci.toml.tmpl` with full 14-stage pipeline (zola, CSP, links, a11y, playwright smoke). Dual-CI migration window: forge is primary, GitHub is fallback until forge deploy path validates end-to-end.
+- **bin**: Add `typikon-migrate-template` binary — skeleton for schema-migration scripts when frontmatter evolves incompatibly. Consumer sites run this once per major typikon bump.
+- **templates**: Enforce required metadata (#2) — frontmatter validation now runs pre-commit.
+
+### Fixes
+
+- **ci**: Drive typikon CI to green (#27) — lychee excludes self-host URLs to break the deploy chicken-and-egg.
+- **ci**: Suppress SHELL/strict-mode with intent directive (#15) — `ci/csp-enforce.sh` preserves full-report CSP scan behavior (accumulate violations, do not abort on first miss).
+- **lint**: Drop stale CSP inline ignore — follow-up to #18.
+
+### Documentation
+
+- **README**: Add `typikon-migrate-template` to binary inventory (#14).
+- **CLAUDE.md**: Add preamble with scope/defers_to/tightens per kanon CONTEXT/preamble-required.
+
+### Changed
+
+- **repo**: Align with FLEET-REPO-SETUP standard (forge-primary) (#13) — add .gitattributes with markdown trailing-whitespace carve-out (D-055), bootstrap empty CHANGELOG.md.
+- **lint**: Preserve typikon prose voice — scoped `.kanon-lint-ignore` for typikon#9 (substrate/example prose) and typikon#15 (CSP scan full-report behavior). Per operator decision, em-dash policy is intentional and preserved.
+
+---
+
+## Previous releases
+
+Full release history is available in the [Git log](https://github.com/forkwright/typikon/commits/main).


### PR DESCRIPTION
Add AGENTS.md with agent operating manual for typikon.

## Summary
- Quick-start entry-point nav to README, CLAUDE, AGENTIC, SCHEMAS, BOOTSTRAP docs
- Key binaries table + usage examples (typikon-init, typikon-validate, typikon-check, typikon-refresh, typikon-migrate-template)
- Development loop (theme changes, consumer site updates)
- Locked decisions callout (Zola 0.22.x, strict CSP, self-hosted fonts, forge-primary, AGPL-3.0)
- Boundaries + dispatch entry points
- Glossary/architecture cross-refs to _llm/ corpus

## Required by structure standard
AGENTS.md is required for all dispatched repos per FLEET-REPO-SETUP. Typikon is optimized for agentic operation.
