### PR TITLE
chore(ci): add gate-attestation trusted-actor waiver

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -1,0 +1,53 @@
+name: Gate Attestation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate-attestation:
+    name: gate-attestation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pass trusted automation PRs
+        if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'release-please[bot]' || github.actor == 'github-actions[bot]' }}
+        run: echo "Gate attestation waived for trusted automation actor."
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'release-please[bot]' && github.actor != 'github-actions[bot]' }}
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify Gate-Passed trailer
+        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'release-please[bot]' && github.actor != 'github-actions[bot]' }}
+        run: |
+          commits=$(git log --format="%H" "origin/${{ github.base_ref }}..HEAD")
+          if [ -z "$commits" ]; then
+            echo "ERROR: No commits found in PR"
+            exit 1
+          fi
+
+          found=false
+          for sha in $commits; do
+            body=$(git log -1 --format="%b" "$sha")
+            if echo "$body" | grep -q "^Gate-Passed:"; then
+              version=$(echo "$body" | grep "^Gate-Passed:" | head -1)
+              echo "Found gate attestation: $version"
+              found=true
+              break
+            fi
+          done
+
+          if [ "$found" = false ]; then
+            echo "ERROR: No Gate-Passed trailer found in any PR commit."
+            echo "Run the local gate and commit with the trailer."
+            exit 1
+          fi


### PR DESCRIPTION
Add gate-attestation workflow with trusted-actor waiver (dependabot, release-please, github-actions bots auto-pass; human PRs still require Gate-Passed trailer). Mirrors fleet-canonical pattern from akroasis#164 / kanon#877.