### PR TITLE
docs(manifest): add docs/MANIFEST.toml doc inventory

### DIFF
--- a/docs/MANIFEST.toml
+++ b/docs/MANIFEST.toml
@@ -1,0 +1,19 @@
+# docs/MANIFEST.toml - documentation inventory for this repo.
+
+[[doc]]
+path = "docs/BOOTSTRAP.md"
+type = "authored"
+evergreen = true
+description = "bin/typikon-init scaffolder: anticipated invocation, wiring, idempotency semantics."
+
+[[doc]]
+path = "docs/SCHEMAS.md"
+type = "authored"
+evergreen = true
+description = "Content-type schema routing rules for typikon-validate and how to extend them."
+
+[[doc]]
+path = "docs/AGENTIC.md"
+type = "authored"
+evergreen = true
+description = "Agent operating contract for working on typikon or a consumer site."


### PR DESCRIPTION
Adds docs/MANIFEST.toml per basanos DOC-MANIFEST.md schema, covering all 3 files under docs/.

Refs basanos DOC-MANIFEST.md standard.