### PR TITLE
chore(lint): remove six inert suppressions from .kanon-lint-ignore

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -1,9 +1,9 @@
-# typikon#9: preserve intentional substrate/example prose voice.
-WRITING/em-dash:README.md # typikon#9 preserves public substrate prose voice
-WRITING/em-dash:docs/AGENTIC.md # typikon#9 preserves agent-contract prose voice
-WRITING/em-dash:docs/BOOTSTRAP.md # typikon#9 preserves bootstrap prose voice
-WRITING/em-dash:examples/sample-shop/content/products/gadget.md # typikon#9 preserves rendered example prose voice
-WRITING/em-dash:examples/sample-shop/content/products/widget.md # typikon#9 preserves rendered example prose voice
-
-# typikon#15: keep CSP scan accumulation behavior; set -e would abort on the first grep miss.
-SHELL/strict-mode:ci/csp-enforce.sh # typikon#15 preserves full-report CSP scan behavior
+# Kanon lint suppressions for the typikon repo.
+#
+# Format: RULE/name:path/glob
+#
+# Every entry has a WHY and a tracking issue. No blanket category ignores.
+# Verify before adding: `kanon lint <path> --strict` must show the violation
+# firing without the entry present. A suppression that hides nothing is
+# worse than no suppression at all - it silently re-activates if the file
+# later regresses.


### PR DESCRIPTION
`.kanon-lint-ignore` carried six suppressions. All six were inert — not just the one this started from.

A dead ignore entry is worse than clutter. It silently re-suppresses if the file later regresses, hiding the very defect it was once a stopgap for.

Verified two independent ways before removing anything: `kanon lint <path> --strict` (which bypasses all suppression) returned zero findings for every listed path, and `kanon lint . --show-suppressions-only` over the full tree reported none active.

- `SHELL/strict-mode:ci/csp-enforce.sh` — the file has had `set -euo pipefail` on line 2 since #40; the rule only inspects the first five lines.
- `WRITING/em-dash:README.md` — its em-dashes were removed by that same pass.
- `WRITING/em-dash:docs/AGENTIC.md`, `docs/BOOTSTRAP.md` — these resolve to the `OutwardEssay` writing surface, and `WRITING/em-dash` only fires on `OutwardCode`. Never reachable.
- `WRITING/em-dash:examples/sample-shop/content/products/{gadget,widget}.md` — match no surface pattern at all, defaulting to `InternalUtility`. Also never reachable.

The last four are the interesting ones: they could never have fired regardless of content, so they were never suppressing anything even when written.

The file now carries a format and verification convention header, matching the fleet norm in harmonia, thumos and hamma, rather than orphaned per-entry comments.

## Related, filed rather than worked around

`PYTHON/print-in-lib` fires on `ci/` scripts because kanon's script-directory exemption covers `bin/`, `scripts/` and `experiments/` but not `ci/` — this repo's own convention for CLI entrypoints. Filed as forkwright/kanon#2651 and fixed there, rather than adding a preemptive ignore entry here or renaming a file to dodge the linter.

Separately, reproducing this with `--detect-stale-suppressions` crashed kanon on this repo's tracked JPEGs — an unconditional `read_to_string` with no binary tolerance. Filed as forkwright/kanon#2653.

Refs #27
