### PR TITLE
fix(ci,schemas): harden the consumer workflow template and pin triad cardinality

### DIFF
--- a/ci/check-triad-schema.py
+++ b/ci/check-triad-schema.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""check-triad-schema — regression test for extra.triad cardinality."""
+
+# WHY: schemas/section.schema.json used to validate `greek` and `english`
+# independently at 2-4 items with no equal-cardinality constraint.
+# templates/index.html indexes english[loop.index0] for every greek entry,
+# and static/js/triad.js + the .triad-1/.triad-2/.triad-3 CSS rules are
+# hard-coded for exactly three terms. A schema-valid mismatched-cardinality
+# fixture (e.g. 4 greek / 2 english) passed bin/typikon-validate and then
+# failed Zola's render with an out-of-bounds index. Fixed by pinning both
+# arrays to minItems=maxItems=3. This script proves the fixture that used
+# to slip through validation is now rejected at the schema boundary, and
+# that a valid three-term triad still passes.
+#
+# NOTE: runs standalone (no consumer site needed) as part of ci/run-fixtures.sh.
+
+import json
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+THEME_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = json.loads((THEME_ROOT / "schemas" / "section.schema.json").read_text(encoding="utf-8"))
+
+
+def section_with_triad(triad: dict) -> dict:
+    return {"title": "Home", "extra": {"triad": triad}}
+
+
+CASES = [
+    (
+        "valid three-term triad",
+        section_with_triad({"greek": ["χείρ", "μνήμη", "προσοχή"], "english": ["hand", "memory", "attention"]}),
+        True,
+    ),
+    (
+        "mismatched cardinality (4 greek / 2 english) — the exact reported regression",
+        section_with_triad({"greek": ["a", "b", "c", "d"], "english": ["x", "y"]}),
+        False,
+    ),
+    (
+        "uniform two-term triad — schema-valid before this fix, contradicts triad.js/CSS three-term lifecycle",
+        section_with_triad({"greek": ["a", "b"], "english": ["x", "y"]}),
+        False,
+    ),
+    (
+        "uniform four-term triad — schema-valid before this fix, contradicts triad.js/CSS three-term lifecycle",
+        section_with_triad({"greek": ["a", "b", "c", "d"], "english": ["w", "x", "y", "z"]}),
+        False,
+    ),
+]
+
+
+def main() -> int:
+    validator = Draft202012Validator(SCHEMA)
+    failed = []
+    for label, doc, should_be_valid in CASES:
+        errors = list(validator.iter_errors(doc))
+        is_valid = not errors
+        if is_valid != should_be_valid:
+            want = "valid" if should_be_valid else "invalid"
+            got = "valid" if is_valid else "invalid"
+            failed.append(f"{label}: expected {want}, got {got}")
+
+    if failed:
+        for line in failed:
+            print(f"FAIL: {line}", file=sys.stderr)
+        return 1
+
+    print(json.dumps({"checked": len(CASES), "passed": len(CASES), "failed": 0}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/check-workflow-template.sh
+++ b/ci/check-workflow-template.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# check-workflow-template — regression test for consumer-facing GH Actions
+# hardening in ci/github-workflow.yml.tmpl.
+#
+# WHY: this template is copied verbatim into every typikon-consuming site's
+# .github/workflows/deploy.yml. A prior version shipped without a
+# concurrency group, without a least-privilege permissions block, with
+# actions/checkout and actions/setup-node pinned to a mutable major-version
+# tag instead of a commit SHA, and without persist-credentials: false on
+# checkout — every consumer inherited the gap. typikon's own
+# .github/workflows/gate-attestation.yml already follows this hardening
+# pattern; this script proves the consumer template matches it.
+#
+# Usage:
+#     ci/check-workflow-template.sh <path-to-template>
+
+usage() {
+    echo "usage: ci/check-workflow-template.sh <path-to-template>" >&2
+    exit 2
+}
+
+[[ $# -ne 1 ]] && usage
+TMPL="$1"
+[[ -f "$TMPL" ]] || { echo "error: $TMPL not found" >&2; exit 2; }
+
+FAIL=0
+
+fail() {
+    echo "FAIL: $1" >&2
+    FAIL=1
+}
+
+grep -qE '^concurrency:' "$TMPL" || fail "no top-level concurrency: group (overlapping pushes queue stale deploys)"
+grep -qE '^permissions:' "$TMPL" || fail "no top-level permissions: block (job defaults to broad GITHUB_TOKEN scope)"
+grep -qE '^\s*persist-credentials:\s*false' "$TMPL" || fail "no persist-credentials: false on checkout"
+
+# Every `uses: owner/repo@REF` must pin REF to a 40-char commit SHA, not a
+# mutable tag/branch. A trailing `# vX` comment naming the human-readable
+# version is fine and expected.
+while IFS= read -r line; do
+    ref="$(printf '%s' "$line" | sed -E 's/^\s*-?\s*uses:\s*[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+@([^ ]+).*/\1/')"
+    if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+        fail "unpinned action ref (not a commit SHA): $line"
+    fi
+done < <(grep -E '^\s*-?\s*uses:\s*[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@' "$TMPL")
+
+if [[ "$FAIL" -eq 0 ]]; then
+    echo '{"checked":"'"$TMPL"'","status":"pass"}'
+fi
+
+exit "$FAIL"

--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -14,6 +14,10 @@
 # Secrets the consumer must set in GitHub repo settings:
 #   - CLOUDFLARE_API_TOKEN
 #   - CLOUDFLARE_ACCOUNT_ID
+#
+# NOTE: third-party actions are pinned to a commit SHA with a `# vX` comment,
+# not a mutable tag. Refresh via:
+#   gh api repos/<owner>/<repo>/tags --jq '.[] | select(.name=="vX") | .commit.sha'
 
 name: Deploy to Cloudflare Pages
 
@@ -23,13 +27,26 @@ on:
   pull_request:
     branches: [main, master]
 
+# WHY: without this, a rapid succession of pushes to the same branch queues
+# overlapping deploys of stale commits; cancel-in-progress keeps only the
+# latest push's run alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# WHY: least privilege — this job only reads the repo and deploys via the
+# Cloudflare API/wrangler using repo secrets, never the GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   gate-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: recursive  # Pulls typikon as themes/typikon/
+          persist-credentials: false
 
       # ── Tooling install ────────────────────────────────────────
       - name: Install Zola
@@ -50,7 +67,7 @@ jobs:
           python3 -m pip install --user jsonschema
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -5,5 +5,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+python3 "$ROOT/ci/check-triad-schema.py"
+
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-blog"
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-shop"

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 python3 "$ROOT/ci/check-triad-schema.py"
+"$ROOT/ci/check-workflow-template.sh" "$ROOT/ci/github-workflow.yml.tmpl"
 
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-blog"
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-shop"

--- a/schemas/section.schema.json
+++ b/schemas/section.schema.json
@@ -61,15 +61,16 @@
             "greek": {
               "type": "array",
               "items": { "type": "string" },
-              "minItems": 2,
-              "maxItems": 4,
-              "description": "Greek terms cycled by the triad-mark component."
+              "minItems": 3,
+              "maxItems": 3,
+              "description": "Greek terms cycled by the triad-mark component. Fixed at three: templates/index.html pairs each entry with english[loop.index0] by position, and static/js/triad.js + the .triad-1/.triad-2/.triad-3 CSS rules are hard-coded for a three-term lifecycle."
             },
             "english": {
               "type": "array",
               "items": { "type": "string" },
-              "minItems": 2,
-              "maxItems": 4
+              "minItems": 3,
+              "maxItems": 3,
+              "description": "English glosses, positionally paired with greek. Same length as greek by construction (both fixed at exactly three) so templates/index.html's english[loop.index0] lookup can never go out of bounds."
             },
             "target": {
               "type": "string",


### PR DESCRIPTION
`Refs #27`

Two substrate defects that both leak out of this repo into consuming sites.

## The consumer workflow template shipped unhardened

`ci/github-workflow.yml.tmpl` is copied verbatim into every typikon-consuming
site's `.github/workflows/deploy.yml` during scaffolding. It shipped without a
concurrency group, without a least-privilege `permissions` block, with
`actions/checkout` and `actions/setup-node` pinned to mutable major-version tags
instead of commit SHAs, and without `persist-credentials: false` on checkout.
**Every consumer inherited all five gaps.**

This is conformance, not a new policy call: typikon's own
`.github/workflows/gate-attestation.yml` already follows exactly this pattern.
The consumer template simply did not match the standard the repo already holds
itself to.

## `extra.triad` allowed shapes the renderer cannot render

`section.schema.json` validated `greek` and `english` independently at 2-4 items
with no equal-length constraint. But `templates/index.html` indexes
`english[loop.index0]` for every `greek` entry, and `static/js/triad.js` plus the
`.triad-1/-2/-3` CSS are hard-coded for exactly three terms. A schema-valid
fixture with 4 greek / 2 english passed `bin/typikon-validate` and then failed
Zola's render on an out-of-bounds index — so schema-valid input could not be
trusted as the authoring boundary, which is the entire job of the schema.

Both arrays are now pinned `minItems = maxItems = 3`, making mismatched
cardinality and non-triad shapes unrepresentable rather than merely discouraged.

## The check that would have caught it

`ci/check-workflow-template.sh`, wired into `ci/run-fixtures.sh` (already run by
`.kanon-ci.toml`'s `fixtures-gate`). It asserts the template's actual bytes carry
a `concurrency:` block, a `permissions:` block, `persist-credentials: false`, and
that every `uses:` ref is a 40-char commit SHA.

Demonstrated to fail before it passes, on this box:

    $ ci/check-workflow-template.sh <pre-fix template>
    FAIL: no top-level concurrency: group
    FAIL: no top-level permissions: block
    FAIL: no persist-credentials: false on checkout
    FAIL: unpinned action ref (not a commit SHA):   - uses: actions/checkout@v4
    FAIL: unpinned action ref (not a commit SHA):     uses: actions/setup-node@v4
    exit 1

    $ ci/check-workflow-template.sh ci/github-workflow.yml.tmpl
    exit 0

Exactly the five findings #27 reported, then silent on the fix.

## Verification

`kanon gate --full --stamp` on verda: **lint PASS, fixtures-gate PASS**;
trailer on the merge commit that brought `main` in, so nothing published was
rewritten.

**Stated plainly rather than glossed:** `zola-check`, `zola-build`,
`csp-enforce`, `lychee`, `pa11y` and `playwright-smoke` all reported `skip` —
those binaries are not installed on this box. The render path that motivates the
triad cardinality pin is therefore **not** exercised here; the schema change is
verified by the fixture suite and by reading the template/JS/CSS, not by a real
Zola build. Worth a reviewer's eye on that specifically.

Also note the trailer's `+stages:fmt,check,clippy,nextest,lint` token is read
from config, not from the stages that ran — typikon has no Cargo workspace, so
four of those five are vacuous here. That token defect is forkwright/kanon#2669.