### PR TITLE
fix(ci): serve a loopback-base_url build to browser-based gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Zola build output (consumers, not theme itself)
 public/
+public-local/
 .zola-cache/
 
 # Editor / OS

--- a/bin/typikon-check
+++ b/bin/typikon-check
@@ -10,14 +10,25 @@
 # Stages (fail-fast, emitted as JSONL):
 #     1. typikon-validate        frontmatter against JSON Schema
 #     2. zola check              internal links + asset references
-#     3. zola build              clean build with no warnings
-#     4. csp-enforce             grep public/ for inline script/style/on*= handlers
-#     5. lychee                  external link integrity (requires lychee binary)
-#     6. pa11y                   WCAG 2.1 AA accessibility (requires pa11y-ci)
-#     7. playwright              per-route smoke assertions (requires npx + tests/smoke/*.spec.ts)
+#     3. zola build              clean build with no warnings, output public/
+#     4. zola build (local base) rebuild to public-local/ with a loopback
+#                                 base_url — the copy browser gates serve
+#     5. csp-enforce             grep public/ for inline script/style/on*= handlers
+#     6. lychee                  external link integrity (requires lychee binary)
+#     7. pa11y                   WCAG 2.1 AA accessibility (requires pa11y-ci)
+#     8. playwright              per-route smoke assertions (requires npx + tests/smoke/*.spec.ts)
 #
-# Stages 5-7 emit `skip` when the underlying tool isn't installed; CI
+# Stages 6-8 emit `skip` when the underlying tool isn't installed; CI
 # always has them, local dev may not.
+#
+# Why public-local/ (forkwright/typikon#29): Zola renders every absolute
+# reference (get_url() output, canonical/og:url meta, JSON-LD, sitemap,
+# atom, robots.txt) from config.toml's production base_url. Serving the
+# public/ build straight to pa11y/playwright means those gates load a mix
+# of localhost HTML and production-origin resources for anything a
+# consumer template built with get_url() — validating the deployed site,
+# not the commit under test. public/ still deploys unmodified; only the
+# copy served to browser gates is rebuilt against a loopback origin.
 #
 # Output:
 #     One JSONL line per stage on stdout:
@@ -108,14 +119,29 @@ else
     emit "zola-build" "skip" 0 "zola binary not found on PATH"
 fi
 
-# Stage 4 — CSP enforcement against built public/.
+# Stage 4 — rebuild to public-local/ with a loopback base_url. This is
+# the copy pa11y/playwright serve (stages 7-8); public/ is left untouched
+# for csp-enforce/lychee and deploy. Unconditional (not gated on
+# pa11y-ci/npx presence) so the fixture always exists to verify against.
+if command -v zola >/dev/null 2>&1; then
+    # --force: unlike the default public/ (always cleaned), zola refuses
+    # to reuse an existing --output-dir. typikon-check is re-run
+    # repeatedly against the same checkout in local dev, so public-local/
+    # already existing from the prior run is the common case, not an
+    # error.
+    run_stage "zola-build-local" zola build --base-url "http://127.0.0.1:8080" --output-dir public-local --force || FAIL=1
+else
+    emit "zola-build-local" "skip" 0 "zola binary not found on PATH"
+fi
+
+# Stage 5 — CSP enforcement against built public/.
 if [[ -d public ]]; then
     run_stage "csp-enforce" "$TYPIKON_ROOT/ci/csp-enforce.sh" "$ROOT/public" || FAIL=1
 else
     emit "csp-enforce" "skip" 0 "no public/ dir (zola-build did not run)"
 fi
 
-# Stage 5 — external links via lychee. Skip if binary absent.
+# Stage 6 — external links via lychee. Skip if binary absent.
 if command -v lychee >/dev/null 2>&1; then
     if [[ -d public ]]; then
         BASE_HOST="$(base_host)"
@@ -136,41 +162,47 @@ else
     emit "lychee" "skip" 0 "lychee binary not on PATH (install: cargo install lychee or curl release)"
 fi
 
-# Stage 6 — pa11y a11y. Requires the built public/ to be served; we spin
-# up a quick http.server in the background. Skip if pa11y-ci not present.
+# Stage 7 — pa11y a11y. Requires public-local/ (built with a loopback
+# base_url — see stage 4) to be served; we spin up a quick http.server in
+# the background. Skip if pa11y-ci not present.
 if command -v pa11y-ci >/dev/null 2>&1; then
-    if [[ -d public ]]; then
-        cd public && python3 -m http.server 8080 >"$LOGDIR/server.log" 2>&1 &
+    if [[ -d public-local ]]; then
+        cd public-local && python3 -m http.server 8080 >"$LOGDIR/server.log" 2>&1 &
         SRV_PID=$!
         cd "$ROOT"
         sleep 1
         run_stage "pa11y" pa11y-ci --config "$TYPIKON_ROOT/ci/pa11y.config.js" || FAIL=1
         kill "$SRV_PID" 2>/dev/null || true
     else
-        emit "pa11y" "skip" 0 "no public/ dir"
+        emit "pa11y" "skip" 0 "no public-local/ dir"
     fi
 else
     emit "pa11y" "skip" 0 "pa11y-ci not on PATH (install: npm i -g pa11y-ci)"
 fi
 
-# Stage 7 — Playwright smoke tests, only when consumer ships any *.spec.ts
-# under tests/smoke/.
+# Stage 8 — Playwright smoke tests, only when consumer ships any *.spec.ts
+# under tests/smoke/. Serves public-local/ (see stage 4) for the same
+# reason as pa11y above.
 if [[ -d "$ROOT/tests/smoke" ]] && find "$ROOT/tests/smoke" -name '*.spec.ts' -print -quit | grep -q .; then
     if command -v npx >/dev/null 2>&1; then
-        # WARNING: never write to $ROOT/playwright.config.ts — a consumer may
-        # track its own. Stage the theme's config at a unique path and pass
-        # it explicitly so a pre-existing consumer config is never touched.
-        PW_CONFIG="$(mktemp -t typikon-playwright-config.XXXXXX.ts)"
-        cp "$TYPIKON_ROOT/ci/playwright.config.ts" "$PW_CONFIG"
-        cd public && python3 -m http.server 8080 >"$LOGDIR/pw-server.log" 2>&1 &
-        PW_SRV_PID=$!
-        cd "$ROOT"
-        sleep 1
-        run_stage "playwright-smoke" npx playwright test --config "$PW_CONFIG" || FAIL=1
-        kill "$PW_SRV_PID" 2>/dev/null || true
-        rm -f "$PW_CONFIG"
-        PW_SRV_PID=""
-        PW_CONFIG=""
+        if [[ -d public-local ]]; then
+            # WARNING: never write to $ROOT/playwright.config.ts — a consumer may
+            # track its own. Stage the theme's config at a unique path and pass
+            # it explicitly so a pre-existing consumer config is never touched.
+            PW_CONFIG="$(mktemp -t typikon-playwright-config.XXXXXX.ts)"
+            cp "$TYPIKON_ROOT/ci/playwright.config.ts" "$PW_CONFIG"
+            cd public-local && python3 -m http.server 8080 >"$LOGDIR/pw-server.log" 2>&1 &
+            PW_SRV_PID=$!
+            cd "$ROOT"
+            sleep 1
+            run_stage "playwright-smoke" npx playwright test --config "$PW_CONFIG" || FAIL=1
+            kill "$PW_SRV_PID" 2>/dev/null || true
+            rm -f "$PW_CONFIG"
+            PW_SRV_PID=""
+            PW_CONFIG=""
+        else
+            emit "playwright-smoke" "skip" 0 "no public-local/ dir"
+        fi
     else
         emit "playwright-smoke" "skip" 0 "npx not on PATH"
     fi

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -22,10 +22,11 @@ stages = [
   "typikon-validate",
   "zola-check",
   "zola-build",
+  "zola-build-local",
   "copy-cloudflare-files",
   "csp-enforce",
   "lychee",
-  "serve-public",
+  "serve-public-local",
   "pa11y",
   "playwright",
   "teardown-static-server",
@@ -90,6 +91,24 @@ PATH="$PWD/.kanon-ci/bin:$PATH" zola build
 """
 timeout_secs = 120
 
+# pa11y and playwright render pages in a real browser, so any
+# get_url()-derived absolute asset href in the HTML resolves against
+# base_url — the real deployed domain, not the server serve-public-local
+# spins up below. Without this second build, the browser gates fetch
+# CSS/JS from the LIVE site and validate whatever's already deployed
+# there instead of the commit under test. This build, output separately,
+# is the only copy the browser gates ever see; public/ (above) stays
+# untouched for csp-enforce, lychee, and the Cloudflare deploy stage.
+[stages.zola-build-local]
+cmd = """
+set -euo pipefail
+# --force: unlike the default public/ (always cleaned), zola refuses to
+# reuse an existing --output-dir — a persistent forge-runner workspace
+# reusing this checkout across runs would otherwise fail on the second run.
+PATH="$PWD/.kanon-ci/bin:$PATH" zola build --base-url http://127.0.0.1:8080 --output-dir public-local --force
+"""
+timeout_secs = 120
+
 [stages.copy-cloudflare-files]
 cmd = """
 set -euo pipefail
@@ -118,10 +137,13 @@ PATH="$PWD/.kanon-ci/bin:$PATH" lychee --config themes/typikon/ci/lychee.toml --
 """
 timeout_secs = 300
 
-[stages.serve-public]
+# Serves the loopback-base_url build (zola-build-local above), not
+# public/ — csp-enforce and lychee already ran against public/ above and
+# are unaffected by this substitution.
+[stages.serve-public-local]
 cmd = """
 set -euo pipefail
-cd public
+cd public-local
 python3 -m http.server 8080 > ../.kanon-ci/http-server.log 2>&1 &
 echo $! > ../.kanon-ci/server.pid
 sleep 2

--- a/ci/local-base-gate-check.sh
+++ b/ci/local-base-gate-check.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# local-base-gate-check — prove the browser-based gates (pa11y, playwright)
+# are pointed at a loopback build, not the site's production origin.
+#
+# Usage:
+#     ci/local-base-gate-check.sh <consumer-site-root>
+#
+# Regression coverage for forkwright/typikon#29: the CI/local gate used
+# to build once with the site's production base_url and serve that same
+# public/ to pa11y and playwright. Any get_url()-derived absolute
+# reference baked into the rendered HTML (canonical link, og:url,
+# JSON-LD, a consumer's own get_url()'d asset href, ...) then pointed
+# the browser at the LIVE deployed site instead of the commit under
+# test — a change could pass browser gates by matching what's already
+# in production, or fail them by mismatching a local-only fix.
+#
+# bin/typikon-check and the CI templates now build a second copy,
+# public-local/, with --base-url http://127.0.0.1:8080 — the only copy
+# the browser gates ever see. This script proves that copy exists and
+# that its HTML carries no reference to the site's configured
+# production origin.
+#
+# Scoped to *.html, same rationale as ci/csp-enforce.sh: a browser
+# rendering a page only loads what an HTML reference points it at.
+# Non-HTML output (atom.xml, sitemap.xml, robots.txt) can legitimately
+# carry an absolute production URL — an Atom <author><uri> is a portable
+# identifier by convention, not a resource the browser gates fetch — so
+# checking those would flag correct output as a regression.
+#
+# Exit:
+#   0  public-local/ exists, contains *.html files, and none of them
+#      reference the site's configured production base_url host
+#   1  regression: public-local/ missing/empty, or its HTML leaks the
+#      production origin
+#   2  invocation error
+
+set -uo pipefail
+
+usage() {
+    echo "usage: ci/local-base-gate-check.sh <consumer-site-root>" >&2
+    exit 2
+}
+
+[[ $# -ne 1 ]] && usage
+ROOT="$(realpath "$1")"
+[[ -f "$ROOT/config.toml" ]] || { echo "error: $ROOT has no config.toml" >&2; exit 2; }
+
+LOCAL_DIR="$ROOT/public-local"
+if [[ ! -d "$LOCAL_DIR" ]]; then
+    echo "local-base-gate-check: $LOCAL_DIR does not exist — the loopback-base_url" >&2
+    echo "  build never ran. Browser gates would fall back to serving public/," >&2
+    echo "  the production build (forkwright/typikon#29)." >&2
+    exit 1
+fi
+
+mapfile -t FILES < <(find "$LOCAL_DIR" -type f -name '*.html')
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    echo "local-base-gate-check: no *.html files under $LOCAL_DIR" >&2
+    exit 1
+fi
+
+BASE_URL=$(grep -E '^base_url\s*=' "$ROOT/config.toml" \
+    | head -1 \
+    | sed -E 's/^base_url\s*=\s*"([^"]+)".*/\1/' \
+    | sed 's:/$::')
+BASE_HOST=$(printf '%s' "$BASE_URL" | sed -E 's|^https?://||' | sed -E 's|/.*$||')
+
+if [[ -z "$BASE_HOST" ]]; then
+    echo "local-base-gate-check: could not read base_url from $ROOT/config.toml" >&2
+    exit 2
+fi
+
+LEAKS=$(grep -rlF "$BASE_HOST" "${FILES[@]}" 2>/dev/null || true)
+if [[ -n "$LEAKS" ]]; then
+    echo "local-base-gate-check: public-local/ references production host '$BASE_HOST':" >&2
+    echo "$LEAKS" >&2
+    echo "" >&2
+    echo "The build served to pa11y/playwright must be built with a loopback" >&2
+    echo "base_url so nothing in it resolves to the deployed site." >&2
+    exit 1
+fi
+
+if ! grep -rlF "127.0.0.1:8080" "${FILES[@]}" >/dev/null 2>&1; then
+    echo "local-base-gate-check: no file under public-local/ references" >&2
+    echo "  127.0.0.1:8080 — the loopback rebuild does not look like it ran" >&2
+    echo "  with --base-url http://127.0.0.1:8080." >&2
+    exit 1
+fi
+
+echo "local-base-gate-check: ok (${#FILES[@]} *.html files under public-local/, no production-host references, loopback references present)"
+exit 0

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -10,3 +10,9 @@ python3 "$ROOT/ci/check-triad-schema.py"
 
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-blog"
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-shop"
+
+# typikon-check's zola-build-local stage must have populated public-local/
+# with a loopback-base_url rebuild for the two lines above to have made
+# this a meaningful check — see ci/local-base-gate-check.sh.
+"$ROOT/ci/local-base-gate-check.sh" "$ROOT/examples/sample-blog"
+"$ROOT/ci/local-base-gate-check.sh" "$ROOT/examples/sample-shop"

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -53,12 +53,14 @@ bin/typikon-check <consumer-site-root>
 
 Runs (in order, fail-fast):
 
-1. `zola check` (internal links + assets)
-2. `zola build` (no warnings tolerated)
-3. `csp-enforce.sh` (greps `public/` for inline `<script>`, `<style>`, `on*=` handlers)
-4. `lychee public/ --config ci/lychee.toml` (external links)
-5. `pa11y-ci --config ci/pa11y.config.js` (WCAG 2.1 AA)
-6. `playwright test` (per-route smoke assertions)
+1. `typikon-validate` (frontmatter against JSON Schema)
+2. `zola check` (internal links + assets)
+3. `zola build` (no warnings tolerated, output `public/`)
+4. `zola build --base-url http://127.0.0.1:8080 --output-dir public-local` (the copy browser gates serve — `public/` retains the real `base_url` for deploy)
+5. `csp-enforce.sh` (greps `public/` for inline `<script>`, `<style>`, `on*=` handlers)
+6. `lychee public/ --config ci/lychee.toml` (external links)
+7. `pa11y-ci --config ci/pa11y.config.js` (WCAG 2.1 AA, against `public-local/`)
+8. `playwright test` (per-route smoke assertions, against `public-local/`)
 
 Output is JSONL summarizing each gate. If anything fails, fix; do not push to bypass.
 


### PR DESCRIPTION
## Finding

`ci/github-workflow.yml.tmpl` already builds a `public-local/` copy with `--base-url http://127.0.0.1:8080` and serves that to pa11y/playwright — but `ci/kanon-ci.toml.tmpl` (which its own header claims "mirrors `ci/github-workflow.yml.tmpl` stage-for-stage") and `bin/typikon-check` (the local pre-push gate) both still build once and serve `public/`, the production build, to the browser-based gates.

## Evidence

- `ci/kanon-ci.toml.tmpl` `[stages.serve-public]` still `cd public` — the production build — before pa11y/playwright run.
- `bin/typikon-check` stages 6-7 (pre-fix numbering) still `cd public && python3 -m http.server 8080` for both pa11y and playwright.
- Confirmed empirically: building `examples/sample-blog` and rebuilding with `--base-url http://127.0.0.1:8080 --output-dir public-local` shows every `get_url()`-derived reference (canonical, `og:url`, JSON-LD, sitemap) correctly rebases to loopback in the second build but not the first — proving the two builds genuinely differ, and confirming which one browser gates need to see.

## Correction

Mirrors the already-fixed GH Actions recipe into both remaining implementations: a `zola-build-local` stage builds `public-local/` (`--force`, since `typikon-check` reruns against the same checkout on every local invocation and `zola` refuses to reuse an existing `--output-dir` unprompted — caught by the new test below), and pa11y/playwright now serve that copy. `public/` is untouched for `csp-enforce`, `lychee`, and deploy. `public-local/` added to `.gitignore` alongside `public/`. `docs/AGENTIC.md`'s stage list updated to match.

## Test

New `ci/local-base-gate-check.sh`, wired into `ci/run-fixtures.sh` (which CI already runs via `.github/workflows/gate-attestation.yml` and `.kanon-ci.toml`): asserts `public-local/` exists and its `*.html` files carry zero references to the site's configured production host. Scoped to `.html` (same rationale as `ci/csp-enforce.sh`) — `atom.xml`'s `<author><uri>` is a legitimate hand-authored absolute URL by Atom convention and isn't fetched by a browser gate, so checking it would flag correct output as a regression.

Verified locally: on the pre-fix `bin/typikon-check`, `public-local/` is never created and the new check fails with `exit 1` (`does not exist — the loopback-base_url build never ran`); against this branch it passes for both `examples/sample-blog` and `examples/sample-shop`, and reruns idempotently against a leftover `public-local/` from a prior run.

Refs #29