### PR TITLE
fix(gate): stop the internal-link stage from failing on a third party

### DIFF
--- a/bin/typikon-check
+++ b/bin/typikon-check
@@ -107,7 +107,7 @@ run_stage "typikon-validate" "$TYPIKON_ROOT/bin/typikon-validate" "$ROOT" || FAI
 
 # Stage 2 — zola check (internal links + assets).
 if command -v zola >/dev/null 2>&1; then
-    run_stage "zola-check" zola check || FAIL=1
+    run_stage "zola-check" zola check --skip-external-links || FAIL=1
 else
     emit "zola-check" "skip" 0 "zola binary not found on PATH"
 fi

--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -94,7 +94,7 @@ jobs:
         run: themes/typikon/bin/typikon-validate .
 
       - name: zola check (internal links + assets)
-        run: zola check
+        run: zola check --skip-external-links
 
       - name: zola build
         run: zola build


### PR DESCRIPTION
The stage named "zola check (internal links + assets)" ran bare `zola check`, which also resolves external links. It sits ahead of the lychee stage — the one actually built to tolerate an upstream blip — so a rate limit or outage on any linked host failed the whole gate at a point with no retry and no status-class handling.

Observed: `https://www.lesswrong.com/` returned 429 and failed an ardent-site run whose diff was comment-only. A 429 is a rate limit, not a dead link.

External coverage is unchanged. The lychee stage already checks `public/` with only the self-host excluded, and its own comment records that this division of labour was the intent: "zola check covers internal-link integrity at source-tree level, so we don`t lose coverage by skipping them here." This makes the stage do what its name already claimed.

Applied in both places the stage is defined — `ci/github-workflow.yml.tmpl:97` for consumers, and `bin/typikon-check:110` for the local gate.

Consumers do not auto-resync from the template, so each instantiated `deploy.yml` needs the same one-line change; ardent-site is being fixed in forkwright/ardent-site#14.