### PR TITLE
fix(gate): a rate limit is not link rot

### DIFF
--- a/ci/lychee.toml
+++ b/ci/lychee.toml
@@ -22,7 +22,15 @@ retry_wait_time = 5
 # Stripe's buy.stripe.com endpoints reject HEAD requests with 405; the
 # URL is still valid and clicking it redirects to checkout. Same for
 # Buttondown's embed-subscribe POST endpoint.
-accept = [200, 204, 206, 301, 302, 303, 307, 308, 405]
+#
+# 429 is accepted because it is never evidence about the link. It reports
+# the checker's own request rate back at it; a resource that has actually
+# rotted answers 404 or 410, which stay failures. Treating it as rot makes
+# every deploy hostage to third-party throttling, and the retry settings
+# above do not clear a host that rate-limits regardless of cadence — the
+# instagram exclusion below was the first instance of that, handled per-host
+# until it recurred elsewhere.
+accept = [200, 204, 206, 301, 302, 303, 307, 308, 405, 429]
 
 # Don't follow these — they're known to be rate-limit-heavy or
 # protocol-mismatched.


### PR DESCRIPTION
The external-link stage failed an ardent-site deploy on a `429` from `lesswrong.com`, on a branch whose diff was comment-only.

A 429 reports the checker's own request rate back at it. It carries no information about the link, and a resource that has actually rotted answers 404 or 410 — both of which stay failures, so accepting 429 cannot hide link rot.

The config already carried `max_retries = 3` and `retry_wait_time = 5`; neither clears a host that rate-limits regardless of cadence. That is exactly why `instagram.com` already needed its own per-host exclusion, whose comment reads "returns 429 regardless of cadence... this is link-checker reality, not link rot." This change is that exclusion's general form, so the next host does not need a third one.

Without it, every consumer's deploy is hostage to the uptime and throttling policy of every host the site links to.

Note for consumers: this file reaches a site through its pinned `themes/typikon` submodule, so an existing consumer does not inherit the fix until its pin moves. forkwright/ardent-site#14 is blocked on exactly this and is being unblocked separately rather than by an unreviewed pin bump.