### PR TITLE
fix(ci): pin the transport on toolchain downloads

### DIFF
--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -55,7 +55,7 @@ jobs:
           #   curl -sL https://github.com/getzola/zola/releases/download/v<X>/zola-v<X>-x86_64-unknown-linux-gnu.tar.gz | sha256sum
           ZOLA_SHA256: 0ca09aa40376aaa9ddfb512ff9ad963262ef95edb0d0f2d5ec6961b6f5cf22ef
         run: |
-          curl -L "https://github.com/getzola/zola/releases/download/v{{ ZOLA_VERSION }}/zola-v{{ ZOLA_VERSION }}-x86_64-unknown-linux-gnu.tar.gz" \
+          curl -L --proto '=https' --tlsv1.2 "https://github.com/getzola/zola/releases/download/v{{ ZOLA_VERSION }}/zola-v{{ ZOLA_VERSION }}-x86_64-unknown-linux-gnu.tar.gz" \
             -o zola.tar.gz
           echo "${ZOLA_SHA256}  zola.tar.gz" | sha256sum -c
           tar -xzf zola.tar.gz
@@ -81,7 +81,7 @@ jobs:
         run: |
           npm install -g pa11y-ci@latest @playwright/test@latest
           npx playwright install --with-deps chromium
-          curl -L "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
+          curl -L --proto '=https' --tlsv1.2 "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
             -o lychee.tar.gz
           echo "${LYCHEE_SHA256}  lychee.tar.gz" | sha256sum -c
           mkdir -p lychee-extract


### PR DESCRIPTION
Both toolchain installs in the consumer workflow template follow redirects with `-L` and nothing constraining where a redirect may lead, so a redirect off HTTPS would be followed silently.

The `sha256sum -c` beside each download is unchanged and remains the control that proves the artifact — tampered bytes still fail closed. This closes a different gap: the digest cannot stop the request itself being downgraded and observed, only stop the result being used.

Scoped to the two invocations that pass `-L`. The Cloudflare PATCH later in the file uses `-fsS` with no `-L`, so it never follows a redirect and needs nothing.

Consumers inherit this at their next pin bump; the template is the origin, which is why the fix lands here rather than in each site.

Closes the finding behind #79.