### PR TITLE
docs: state the push authority this repo actually has

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ All decisions are in [CLAUDE.md](CLAUDE.md) under "Locked decisions". Key ones:
 - **Static SSG**: Zola 0.22.x. No JavaScript build step in site build path.
 - **Strict CSP**: no `unsafe-inline` anywhere. CSP-enforce CI gate fails the build on inline script/style/handler.
 - **Self-hosted fonts**: WOFF2 under `static/fonts/`. Zero external CDN at visitor runtime.
-- **Forge-primary**: origin points at forkwright forge; GitHub is push-mirror only.
+- **Push authority**: `origin` is GitHub; no forge remote is configured. forkwright/kanon#3045 owns the typed authority split.
 - **License**: AGPL-3.0-or-later. AI-training prohibited (NOTICE).
 
 ## Boundaries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Web-property-specific standards live alongside as kanon STANDARDS/WEB.md (filed 
 - **Theme distribution**: git submodule under consumer's `themes/typikon/`. (Zola has no theme registry; submodule is current best practice.)
 - **Strict CSP**: no `unsafe-inline` anywhere. CSP-enforce CI gate fails the build on any inline script, style, or `on*=` handler.
 - **Self-hosted fonts**: WOFF2 under `static/fonts/`. Zero external CDN at visitor runtime. OFL families only.
-- **Forge-primary**: `origin` points at the forkwright forge (`http://127.0.0.1:7878/forkwright/typikon.git`). GitHub is push-mirror only via `kanon forge set-mirror`.
+- **Push authority**: `origin` is GitHub (`forkwright/typikon`); no forge remote is configured. The typed forge/GitHub authority split is unresolved — forkwright/kanon#3045 owns it.
 - **License**: AGPL-3.0-or-later. Matches dioptron, aletheia. AI-training prohibition in NOTICE.
 
 ## How an agent operates here
@@ -63,7 +63,7 @@ Web-property-specific standards live alongside as kanon STANDARDS/WEB.md (filed 
 
 ## Boundaries
 
-- **Push to `origin` (forge), not `github`.** Mirror handles GitHub. Verify with `git remote -v`.
+- **Push to `origin`.** It is GitHub; there is no mirror step. Verify with `git remote -v` rather than assuming.
 - **Never bypass the CI gate.** No `--no-verify`, no `[skip ci]`, no commit on green failure.
 - **Schema changes are migrations.** When a schema changes incompatibly, the change PR ships a migration script for existing consumers in `bin/`.
 

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -94,11 +94,11 @@ When a schema field is renamed, removed, or changed incompatibly, the typikon PR
 
 The PR description must list every consumer affected and link the migration runs.
 
-### 8. Repos are forge-primary
+### 8. Check the push authority before pushing
 
-`origin` is the forkwright forge (`http://127.0.0.1:7878/forkwright/typikon.git`). `github` is the GitHub mirror (push only). Check with `git remote -v` before push.
+`origin` is GitHub (`forkwright/typikon`). No forge remote is configured and there is no mirror step, so a push to `origin` is a push to GitHub. Check with `git remote -v` rather than assuming either shape — this repo previously documented a forge-primary topology it did not have.
 
-`kanon forge set-mirror` configures the mirror push. Do not push directly to GitHub — the mirror handles it.
+Whether the fleet returns to a forge-primary split is an open question that forkwright/kanon#3045 owns.
 
 ### 9. Photography goes in `page.extra.images`
 


### PR DESCRIPTION
The repo documented a forge-primary topology it does not have, in five places:

- `CLAUDE.md` locked decisions — `origin` points at `http://127.0.0.1:7878/forkwright/typikon.git`, GitHub is push-mirror only
- `CLAUDE.md` boundaries — "Push to `origin` (forge), not `github`"
- `AGENTS.md` decision list — the same claim in short form
- `docs/AGENTIC.md` §8 — "Repos are forge-primary", plus a `kanon forge set-mirror` instruction and "Do not push directly to GitHub"
- `CLAUDE.md` preamble `tightens:` — corrected in an earlier pass, which is how the others were found

`git remote -v` in every live clone shows a single `origin` on GitHub and no forge remote. So the instruction was not merely stale, it was unfollowable: an agent obeying `docs/AGENTIC.md` would look for a `github` remote that does not exist and decline to push to the one that does.

All four live surfaces now state the verified topology and point at forkwright/kanon#3045, which owns the typed authority split, rather than asserting an answer this repo cannot give. `docs/AGENTIC.md` additionally says *why* to run `git remote -v` instead of trusting the doc — the failure here was a reader believing a documented topology over the tree.

The `CHANGELOG.md` mention is left alone: it records the title of a past PR, and history is not a living instruction.