### PR TITLE
chore(gitignore): ignore the bytecode this repo's own scripts produce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ public-local/
 .vscode/
 .idea/
 
+# Python bytecode (ci/ and bin/ ship .py; running them leaves __pycache__)
+__pycache__/
+*.py[cod]
+
 # Test artifacts
 test-results/
 playwright-report/


### PR DESCRIPTION
This repo ships Python that is meant to be executed — `ci/check-triad-schema.py`, plus the `bin/` lifecycle scripts — and its `.gitignore` had no Python entry at all. Running the gate locally therefore leaves `bin/__pycache__/` as untracked noise, which is one careless `git add -A` away from being committed.

`ardent-tools-site`, a consumer, already ignores `__pycache__`. The repo that owns the Python did not.

Placed under the existing "Test artifacts" grouping with the reason stated, matching how the rest of the file explains itself.