### PR TITLE
fix(ci): pin wrangler, and make rendered template headers true

### DIFF
--- a/bin/typikon-defaults.sh
+++ b/bin/typikon-defaults.sh
@@ -22,3 +22,12 @@ set -euo pipefail
 # against a new Zola release. Consumer-side workflows pick this up on
 # their next `themes/typikon/bin/typikon-refresh` invocation.
 : "${ZOLA_VERSION:=0.22.1}"
+
+# Pinned wrangler version. An unpinned `npm install -g wrangler` runs inside
+# the deploy step, whose environment already holds CLOUDFLARE_API_TOKEN — so a
+# malicious release or install script would execute next to a credential that
+# can mutate the live Pages project. Pinning also makes a deploy reproducible:
+# unpinned, the version reaching production is whichever one the runner
+# happened to cache, and fleet consumers were observed running different ones.
+# Bump when a consumer deploy validates against a newer wrangler.
+: "${WRANGLER_VERSION:=4.112.0}"

--- a/bin/typikon-init
+++ b/bin/typikon-init
@@ -128,11 +128,13 @@ copy_template "$TYPIKON_ROOT/_redirects.tmpl" "_redirects"
 # same shape (`TYPIKON_ZOLA_VERSION=... typikon-init ...`).
 # shellcheck source=./typikon-defaults.sh
 ZOLA_VERSION="${TYPIKON_ZOLA_VERSION:-}"
+WRANGLER_VERSION="${TYPIKON_WRANGLER_VERSION:-}"
 . "$TYPIKON_ROOT/bin/typikon-defaults.sh"
 mkdir -p .github/workflows
 if [[ ! -e .github/workflows/deploy.yml ]]; then
     sed -e "s|{{ PROJECT_NAME }}|${SITE_NAME}|g" \
         -e "s|{{ ZOLA_VERSION }}|${ZOLA_VERSION}|g" \
+        -e "s|{{ WRANGLER_VERSION }}|${WRANGLER_VERSION}|g" \
         "$TYPIKON_ROOT/ci/github-workflow.yml.tmpl" \
         > .github/workflows/deploy.yml
     echo "create .github/workflows/deploy.yml (from ci/github-workflow.yml.tmpl)" >&2
@@ -143,6 +145,7 @@ fi
 if [[ ! -e .kanon-ci.toml ]]; then
     sed -e "s|{{ PROJECT_NAME }}|${SITE_NAME}|g" \
         -e "s|{{ ZOLA_VERSION }}|${ZOLA_VERSION}|g" \
+        -e "s|{{ WRANGLER_VERSION }}|${WRANGLER_VERSION}|g" \
         "$TYPIKON_ROOT/ci/kanon-ci.toml.tmpl" \
         > .kanon-ci.toml
     echo "create .kanon-ci.toml (from ci/kanon-ci.toml.tmpl)" >&2

--- a/bin/typikon-refresh
+++ b/bin/typikon-refresh
@@ -124,6 +124,7 @@ fi
 # shape (`TYPIKON_ZOLA_VERSION=... typikon-refresh`).
 # shellcheck source=./typikon-defaults.sh
 ZOLA_VERSION="${TYPIKON_ZOLA_VERSION:-}"
+WRANGLER_VERSION="${TYPIKON_WRANGLER_VERSION:-}"
 . "$TYPIKON_ROOT/bin/typikon-defaults.sh"
 
 # ----- Step 3 — re-render template instances -----
@@ -155,6 +156,7 @@ for spec in "${TMPL_TARGETS[@]}"; do
     mkdir -p "$(dirname "$dest_path")"
     sed -e "s|{{ PROJECT_NAME }}|${PROJECT_NAME}|g" \
         -e "s|{{ ZOLA_VERSION }}|${ZOLA_VERSION}|g" \
+        -e "s|{{ WRANGLER_VERSION }}|${WRANGLER_VERSION}|g" \
         "$src_path" \
         > "$dest_path"
     RENDERED+=("$dest")
@@ -182,6 +184,7 @@ else
 fi
 echo "  PROJECT_NAME: $PROJECT_NAME"
 echo "  ZOLA_VERSION: $ZOLA_VERSION"
+echo "  WRANGLER_VERSION: $WRANGLER_VERSION"
 echo
 if [[ ${#RENDERED[@]} -gt 0 ]]; then
     echo "  re-rendered:"

--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -1,16 +1,12 @@
-# GitHub Actions workflow for typikon-consuming sites.
+# GitHub Actions deploy workflow for {{ PROJECT_NAME }}.
 #
-# This file is a TEMPLATE. typikon-init copies it to a consumer site as
-# .github/workflows/deploy.yml during scaffolding, substituting the two
-# placeholders below.
+# Runs the strict typikon gate, then deploys to the `{{ PROJECT_NAME }}`
+# Cloudflare Pages project on green pushes to main. Zola is pinned to
+# {{ ZOLA_VERSION }} and wrangler to {{ WRANGLER_VERSION }}.
 #
-# Placeholders (typikon-init replaces during scaffolding):
-#   {{ PROJECT_NAME }}   — Cloudflare Pages project slug (e.g. ardent-site)
-#   {{ ZOLA_VERSION }}   — pinned Zola version (current: 0.22.1)
-#   {{ WRANGLER_VERSION }} — pinned wrangler version (current: 4.112.0)
-#
-# After substitution the workflow performs the strict gate, then deploys
-# to Cloudflare Pages on green pushes to main.
+# NOTE: generated from typikon's ci/github-workflow.yml.tmpl. Changes that
+# belong to every consumer go upstream to the template, not here; re-render
+# an instance with `themes/typikon/bin/typikon-refresh .`.
 #
 # Secrets the consumer must set in GitHub repo settings:
 #   - CLOUDFLARE_API_TOKEN

--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -7,6 +7,7 @@
 # Placeholders (typikon-init replaces during scaffolding):
 #   {{ PROJECT_NAME }}   — Cloudflare Pages project slug (e.g. ardent-site)
 #   {{ ZOLA_VERSION }}   — pinned Zola version (current: 0.22.1)
+#   {{ WRANGLER_VERSION }} — pinned wrangler version (current: 4.112.0)
 #
 # After substitution the workflow performs the strict gate, then deploys
 # to Cloudflare Pages on green pushes to main.
@@ -194,5 +195,5 @@ jobs:
             > /tmp/cf-edit.json
           echo "production_branch set to: $(jq -r '.result.production_branch // .errors' /tmp/cf-edit.json)"
 
-          npm install -g wrangler
+          npm install -g wrangler@{{ WRANGLER_VERSION }}
           wrangler pages deploy public --project-name={{ PROJECT_NAME }} --branch="${BRANCH}"

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -1,11 +1,11 @@
-# kanon-CI pipeline for typikon-consuming sites.
+# kanon-CI pipeline for {{ PROJECT_NAME }}.
 #
-# This file is a TEMPLATE. typikon-init copies it to a consumer site as
-# .kanon-ci.toml during scaffolding, substituting the two placeholders below.
+# Deploys to the `{{ PROJECT_NAME }}` Cloudflare Pages project. Zola is pinned
+# to {{ ZOLA_VERSION }} and wrangler to {{ WRANGLER_VERSION }}.
 #
-# Placeholders:
-#   {{ PROJECT_NAME }}   - Cloudflare Pages project slug (e.g. ardent-site)
-#   {{ ZOLA_VERSION }}   - pinned Zola version (current: 0.22.1)
+# NOTE: generated from typikon's ci/kanon-ci.toml.tmpl. Changes that belong to
+# every consumer go upstream to the template, not here; re-render an instance
+# with `themes/typikon/bin/typikon-refresh .`.
 #
 # Forge runners must provide:
 #   - CLOUDFLARE_API_TOKEN

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -200,7 +200,7 @@ curl -fsS -X PATCH \
   > /tmp/cf-edit.json
 echo "production_branch set to: $(jq -r '.result.production_branch // .errors' /tmp/cf-edit.json)"
 
-npm install -g wrangler
+npm install -g wrangler@{{ WRANGLER_VERSION }}
 wrangler pages deploy public --project-name={{ PROJECT_NAME }} --branch="${BRANCH}"
 """
 timeout_secs = 600

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -17,13 +17,14 @@ Environment overrides:
 | `TYPIKON_THEME_REPO` | `http://127.0.0.1:7878/forkwright/typikon.git` | forge URL for the `themes/typikon` submodule |
 | `TYPIKON_THEME_REPO_GH` | `git@github.com:forkwright/typikon.git` | GitHub remote URL |
 | `TYPIKON_ZOLA_VERSION` | value in `bin/typikon-defaults.sh` | Zola version substituted into CI templates |
+| `TYPIKON_WRANGLER_VERSION` | value in `bin/typikon-defaults.sh` | wrangler version substituted into CI templates |
 
 Behavior:
 
 1. `git init -b main` if `.git` is absent; add `origin` (forge) and `github` (mirror) remotes.
 2. Add `themes/typikon` as a git submodule if missing; otherwise `git pull --ff-only origin main` inside it (best-effort — failure doesn't abort the run).
 3. Copy `_headers.tmpl` → `_headers` and `_redirects.tmpl` → `_redirects` verbatim, skipping either that already exists. These are one-time copies: consumers hand-edit them afterward, and `typikon-init`/`typikon-refresh` never overwrite them again.
-4. Render `ci/kanon-ci.toml.tmpl` → `.kanon-ci.toml` and `ci/github-workflow.yml.tmpl` → `.github/workflows/deploy.yml`, substituting `{{ PROJECT_NAME }}` and `{{ ZOLA_VERSION }}`. Skipped if the destination file already exists — re-rendering an existing consumer's CI files is `typikon-refresh`'s job, not `typikon-init`'s.
+4. Render `ci/kanon-ci.toml.tmpl` → `.kanon-ci.toml` and `ci/github-workflow.yml.tmpl` → `.github/workflows/deploy.yml`, substituting `{{ PROJECT_NAME }}`, `{{ ZOLA_VERSION }}`, and `{{ WRANGLER_VERSION }}`. Skipped if the destination file already exists — re-rendering an existing consumer's CI files is `typikon-refresh`'s job, not `typikon-init`'s.
 5. Write `.gitignore`, `config.toml` (Zola config, `theme = "typikon"`, stub `[extra]` block), `content/_index.md`, `content/about.md`, `content/contact.md`, and `CLAUDE.md` (the consumer-specific operator brief) — each only if absent, so re-running against an existing destination never clobbers consumer-edited content.
 6. Create `static/img/.gitkeep` and `tests/smoke/.gitkeep`.
 7. Force-add `CLAUDE.md` (excluded by the operator's global gitignore by default), stage everything, and commit if this is the first commit; otherwise leave the refresh staged.
@@ -46,12 +47,13 @@ Environment overrides:
 |-----|---------|---------|
 | `TYPIKON_PROJECT_NAME` | basename of `git config remote.origin.url`, `.git` suffix stripped | project slug substituted into CI templates |
 | `TYPIKON_ZOLA_VERSION` | value in `bin/typikon-defaults.sh` (shared with `typikon-init`) | Zola version substituted into CI templates |
+| `TYPIKON_WRANGLER_VERSION` | value in `bin/typikon-defaults.sh` (shared with `typikon-init`) | wrangler version substituted into CI templates |
 
 Behavior:
 
 1. Sanity-check: must run from a consumer root containing `themes/typikon/theme.toml`, from the matching submodule checkout, inside a git repo.
 2. `cd themes/typikon && git pull --ff-only origin main`. Exits 1 if the submodule has diverged from `origin/main` — reconcile manually and re-run.
-3. Derive `PROJECT_NAME` and `ZOLA_VERSION` (env override or default).
+3. Derive `PROJECT_NAME`, `ZOLA_VERSION`, and `WRANGLER_VERSION` (env override or default).
 4. Unconditionally re-render `ci/kanon-ci.toml.tmpl` → `.kanon-ci.toml` and `ci/github-workflow.yml.tmpl` → `.github/workflows/deploy.yml`. This is the only place these two files are re-rendered post-init; hand-edits to them are lost by design (per-site CI deltas belong in sibling files or an operator-authored follow-up commit). `_headers`/`_redirects` are never touched here — they're one-time copies from step 3 of `typikon-init`.
 5. Stage the bumped submodule pointer and each re-rendered file (named `git add`, not `-A`, so unrelated operator-side work isn't swept in).
 6. Print a summary (submodule SHA before/after, `PROJECT_NAME`, `ZOLA_VERSION`, what was rendered/skipped) and the staged diffstat.


### PR DESCRIPTION
Both CI templates ran `npm install -g wrangler` with no version pin — `ci/github-workflow.yml.tmpl:197` and `ci/kanon-ci.toml.tmpl:203` — inside the step whose `env:` already holds `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.

## Why this is the odd one out

Every other third-party download in the same file is pinned *and* verified:

- Zola — exact version, `sha256sum -c`, `--proto =https --tlsv1.2`
- lychee — same treatment

wrangler was the only unpinned install, and the only one running with production deploy credentials in scope. A malicious release or a compromised transitive install script executes right next to a token that can mutate the live Pages project.

## It also made deploys non-reproducible

The version reaching production was whichever one the runner happened to have cached. Observed across the fleet in the same window:

| consumer | wrangler version deployed |
|---|---|
| ardent-tools-site | 4.112.0 |
| a2z-tree-site (pre-fix) | 4.86.0 |
| npm `latest` at the time | 4.120.0 |

Three different answers to "what deployed our site."

## Shape

`WRANGLER_VERSION` follows `ZOLA_VERSION` exactly, so there is one pattern rather than two: default in `bin/typikon-defaults.sh`, `TYPIKON_WRANGLER_VERSION` env override, substituted by both `typikon-init` and `typikon-refresh`, documented in `docs/BOOTSTRAP.md`, and reported in the refresh summary.

Pinned to **4.112.0** — the version a fleet consumer has actually deployed on — rather than newest.

## No sha256 companion, deliberately

npm verifies the tarball against the registry integrity hash, so an exact version already *is* the integrity statement. The Zola and lychee downloads are raw `curl` from GitHub releases with no such channel, which is why they need their own checksum and this does not.

## Verified

Rendered the template with the real defaults: `npm install -g wrangler@4.112.0`, no placeholder survives (the four remaining `{{` are Actions `${{ }}` expressions), and the output parses as YAML.

Deriving every tool version and integrity value from one lock stays open under #58 — this closes the credential-adjacent gap without waiting for it.

Refs #58