### PR TITLE
fix(ci): refuse lifecycle scripts on the wrangler install, pin the browser gate tools

### DIFF
--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -76,7 +76,11 @@ jobs:
           LYCHEE_VERSION: 0.24.2
           LYCHEE_SHA256: 1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
         run: |
-          npm install -g pa11y-ci@latest @playwright/test@latest
+          # Pinned for the same reason lychee is: @latest makes a gate run
+          # non-reproducible, and a browser-gate result is only meaningful if
+          # the tool that produced it is known. Versions match what the fleet
+          # consumer ardent-tools-site already locks in its package.json.
+          npm install -g pa11y-ci@4.1.1 @playwright/test@1.61.1
           npx playwright install --with-deps chromium
           curl -L --proto '=https' --tlsv1.2 "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
             -o lychee.tar.gz
@@ -191,5 +195,11 @@ jobs:
             > /tmp/cf-edit.json
           echo "production_branch set to: $(jq -r '.result.production_branch // .errors' /tmp/cf-edit.json)"
 
-          npm install -g wrangler@{{ WRANGLER_VERSION }}
+          # WHY --ignore-scripts: this install runs in the step whose environment
+          # already holds CLOUDFLARE_API_TOKEN, so any lifecycle script in the
+          # dependency tree would execute beside a credential that can mutate the
+          # live Pages project. wrangler declares no install script of its own
+          # (registry hasInstallScript is unset), so nothing is lost by refusing
+          # them — the flag closes the transitive-dependency path.
+          npm install -g --ignore-scripts wrangler@{{ WRANGLER_VERSION }}
           wrangler pages deploy public --project-name={{ PROJECT_NAME }} --branch="${BRANCH}"

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -59,7 +59,11 @@ cmd = """
 set -euo pipefail
 LYCHEE_VERSION=0.24.2
 LYCHEE_SHA256=1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
-npm install -g pa11y-ci@latest @playwright/test@latest
+# Pinned for the same reason lychee is: @latest makes a gate run
+# non-reproducible, and a browser-gate result is only meaningful if
+# the tool that produced it is known. Versions match what the fleet
+# consumer ardent-tools-site already locks in its package.json.
+npm install -g pa11y-ci@4.1.1 @playwright/test@1.61.1
 npx playwright install --with-deps chromium
 curl -L "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" -o lychee.tar.gz
 echo "${LYCHEE_SHA256}  lychee.tar.gz" | sha256sum -c
@@ -200,7 +204,13 @@ curl -fsS -X PATCH \
   > /tmp/cf-edit.json
 echo "production_branch set to: $(jq -r '.result.production_branch // .errors' /tmp/cf-edit.json)"
 
-npm install -g wrangler@{{ WRANGLER_VERSION }}
+# WHY --ignore-scripts: this install runs in the step whose environment
+# already holds CLOUDFLARE_API_TOKEN, so any lifecycle script in the
+# dependency tree would execute beside a credential that can mutate the
+# live Pages project. wrangler declares no install script of its own
+# (registry hasInstallScript is unset), so nothing is lost by refusing
+# them — the flag closes the transitive-dependency path.
+npm install -g --ignore-scripts wrangler@{{ WRANGLER_VERSION }}
 wrangler pages deploy public --project-name={{ PROJECT_NAME }} --branch="${BRANCH}"
 """
 timeout_secs = 600


### PR DESCRIPTION
Two installs the version pin in #93 did not cover. Both surfaced from a consumer's SonarCloud run on the freshly rendered workflow.

## 1. `--ignore-scripts` on wrangler

Pinning a version does not stop npm executing lifecycle scripts from anywhere in the dependency tree, and this install runs in the step whose `env:` already holds `CLOUDFLARE_API_TOKEN`. A compromised transitive dependency therefore executes beside a credential that can mutate the live Pages project.

Nothing is lost by refusing them. wrangler declares no install script of its own — the registry metadata for `4.112.0` leaves `hasInstallScript` unset, and every entry in its `scripts` block is `dev` / `test` / `build`, which npm never runs on install.

**Verified, not assumed:**

```
$ npm install -g --prefix <tmp> wrangler@4.112.0 --ignore-scripts
added 35 packages
$ <tmp>/bin/wrangler --version
4.112.0
$ <tmp>/bin/wrangler pages deploy --help
wrangler pages deploy [directory]
Deploy a directory of static assets as a Pages deployment
```

The deploy code path loads, so the flag is free.

## 2. Pin pa11y-ci and @playwright/test

They were installed at `@latest` — in the same step whose own comment, two lines above, explains why lychee is pinned:

> lychee pinned to a specific version (releases/latest is non-reproducible)

A browser-gate result is only meaningful if the tool that produced it is known. Both now pin to the versions `ardent-tools-site` already locks in its `package.json` (`pa11y-ci 4.1.1`, `@playwright/test 1.61.1`), so this matches a configuration the fleet already runs rather than inventing one.

## Deliberately not done

No `--ignore-scripts` on the playwright install. It is not established that its tree installs cleanly without them, and unlike wrangler it runs in a step holding no credentials — so pinning is the change the evidence supports, and refusing scripts there would be a guess.

## Verified

Both templates render with real defaults; the workflow parses as YAML and `.kanon-ci.toml` as TOML.

Refs #58