### PR TITLE
fix(ci): refuse lifecycle scripts on the browser-gate install too

### DIFF
--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -80,7 +80,7 @@ jobs:
           # non-reproducible, and a browser-gate result is only meaningful if
           # the tool that produced it is known. Versions match what the fleet
           # consumer ardent-tools-site already locks in its package.json.
-          npm install -g pa11y-ci@4.1.1 @playwright/test@1.61.1
+          npm install -g --ignore-scripts pa11y-ci@4.1.1 @playwright/test@1.61.1
           npx playwright install --with-deps chromium
           curl -L --proto '=https' --tlsv1.2 "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
             -o lychee.tar.gz

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -63,7 +63,7 @@ LYCHEE_SHA256=1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
 # non-reproducible, and a browser-gate result is only meaningful if
 # the tool that produced it is known. Versions match what the fleet
 # consumer ardent-tools-site already locks in its package.json.
-npm install -g pa11y-ci@4.1.1 @playwright/test@1.61.1
+npm install -g --ignore-scripts pa11y-ci@4.1.1 @playwright/test@1.61.1
 npx playwright install --with-deps chromium
 curl -L "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" -o lychee.tar.gz
 echo "${LYCHEE_SHA256}  lychee.tar.gz" | sha256sum -c


### PR DESCRIPTION
#96 deliberately left `--ignore-scripts` off the `pa11y-ci` / `@playwright/test` install, on the grounds that it was not established their trees install cleanly without it. It now is.

## Evidence

Registry metadata:

- `pa11y-ci@4.1.1` — `hasInstallScript` unset
- `@playwright/test@1.61.1` — `hasInstallScript` unset, `scripts` block empty

Installed both into a throwaway prefix with the flag:

```
$ npm install -g --prefix <tmp> --ignore-scripts pa11y-ci@4.1.1 @playwright/test@1.61.1
added 165 packages
$ <tmp>/bin/pa11y-ci --version   -> 4.1.1
$ <tmp>/bin/playwright --version -> Version 1.61.1
```

## Chromium is unaffected

The browser arrives through the explicit `npx playwright install --with-deps chromium` line immediately below — a command this workflow runs, not an npm lifecycle hook. Refusing hooks does not skip it.

## Result

No `npm install` in either template is now unpinned or script-executing. Surfaced by SonarCloud on a consumer running the freshly rendered workflow, which is a reasonable argument for the consumer-side scanner earning its place.

Refs #58