### PR TITLE
docs(ci): record why the pa11y install must keep its lifecycle scripts

### DIFF
--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -76,6 +76,12 @@ jobs:
           LYCHEE_VERSION: 0.24.2
           LYCHEE_SHA256: 1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
         run: |
+          # NOT --ignore-scripts here, unlike the wrangler install below. pa11y-ci
+          # depends on puppeteer, whose postinstall downloads the Chrome build that
+          # pa11y-ci launches. Refusing scripts installs cleanly and even lets
+          # `pa11y-ci --version` succeed, then fails at gate time with 'Could not
+          # find Chrome'. The scripts are load-bearing; a scanner warning on this
+          # line is a false positive.
           # Pinned for the same reason lychee is: @latest makes a gate run
           # non-reproducible, and a browser-gate result is only meaningful if
           # the tool that produced it is known. Versions match what the fleet

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -59,6 +59,12 @@ cmd = """
 set -euo pipefail
 LYCHEE_VERSION=0.24.2
 LYCHEE_SHA256=1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
+# NOT --ignore-scripts here, unlike the wrangler install below. pa11y-ci
+# depends on puppeteer, whose postinstall downloads the Chrome build that
+# pa11y-ci launches. Refusing scripts installs cleanly and even lets
+# `pa11y-ci --version` succeed, then fails at gate time with 'Could not
+# find Chrome'. The scripts are load-bearing; a scanner warning on this
+# line is a false positive.
 # Pinned for the same reason lychee is: @latest makes a gate run
 # non-reproducible, and a browser-gate result is only meaningful if
 # the tool that produced it is known. Versions match what the fleet


### PR DESCRIPTION
Replaces the closed #97, which added `--ignore-scripts` to this line and broke the gate.

## What happens with the flag

```
Error: Could not find Chrome (ver. 148.0.7778.97).
    at ChromeLauncher.resolveExecutablePath (.../pa11y-ci/node_modules/puppeteer-core/...)
```

`pa11y-ci` depends on **puppeteer**, whose postinstall downloads the Chrome build pa11y-ci later launches.

## Why the comment is the deliverable

Every cheap check passes with the flag on:

| check | result | why it is blind |
|---|---|---|
| `hasInstallScript` on `pa11y-ci@4.1.1` | unset | describes that package, not puppeteer in its tree |
| `npm install -g --ignore-scripts …` | `added 165 packages` | a skipped script is not an error |
| `pa11y-ci --version` | `4.1.1` | version reporting never launches a browser |

So the next person to see the scanner warning runs the same checks, gets the same green, and reintroduces the same failure. The line needs to carry its own reason.

The `wrangler` install below keeps `--ignore-scripts` (#96) — that one was verified against `wrangler pages deploy --help`, which loads the real deploy path, and wrangler fetches no browser.

No behaviour change: comments only. Both templates still render to valid YAML / TOML.