### PR TITLE
docs(agentic): state that added required fields ship no migration

### DIFF
--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -83,7 +83,7 @@ When two consumer sites disagree on a primitive (a field, a layout, a color toke
 
 Do not fork the theme into a consumer to satisfy a one-off need. Forks become permanent and the design family fragments.
 
-### 7. Schema changes are migrations
+### 7. Schema changes are migrations, where a migration is possible
 
 When a schema field is renamed, removed, or changed incompatibly, the typikon PR also ships a migration script in `bin/typikon-migrate-<from>-<to>`. The script:
 
@@ -93,6 +93,27 @@ When a schema field is renamed, removed, or changed incompatibly, the typikon PR
 - Exits 0 on success with summary of files changed
 
 The PR description must list every consumer affected and link the migration runs.
+
+**Adding a required field is the exception, and it is deliberate.** A rename or a
+removal is a transformation of data that already exists, so a script can perform it.
+A new required field asks for information the consumer has never recorded, and no
+script can supply it.
+
+That matters most for the provenance fields — `words_source`, `price_source`,
+`measurement_source`. Each states where a rendered number came from. A migration that
+filled them with a placeholder would be writing a false provenance claim into content,
+which is the exact failure the fields were added to prevent. A schema that guarantees
+"this price is traceable" is worth less than nothing if the guarantee can be satisfied
+by a generated string.
+
+So typikon ships no migration for added required fields. The consequence is real and
+falls on the consumer: it cannot bump the theme submodule until it has authored the
+new fields for every affected content file. Budget that as content work, not as a
+version bump — `themes/typikon/bin/typikon-validate .` names each file and pointer, so
+the work is enumerable before it is started.
+
+The PR adding a required field must say so in its description, and list the consumers
+it blocks.
 
 ### 8. Check the push authority before pushing
 


### PR DESCRIPTION
Closes #95, per the operator's call: keep the fields required, correct the doc that promised what was not delivered.

## The mismatch

`docs/AGENTIC.md` §7 said a migration script accompanies *any* incompatible schema change. Four schemas then gained required `extra` fields — `audience`, `words_source`, `price_source`, `measurement_source` — with no migration. A consumer met that as a gate failure on 9 of 23 content files, not as a documented cost.

## The promise was wrong, not the behaviour

A rename or a removal transforms data that already exists, so a script can perform it. A new required field asks for information the consumer has never recorded, and no script can supply it.

That bites hardest on the three provenance fields, each of which states where a rendered number came from. A migration filling them with a placeholder would write a **false provenance claim** into content — precisely the failure the fields were added to prevent. A schema guaranteeing "this price is traceable" is worth less than nothing if a generated string satisfies the guarantee.

## What §7 now says

- Migrations remain required for renames and removals.
- Added required fields are a stated exception, with the reasoning.
- The cost is named and assigned: the consumer cannot bump the submodule until it authors the fields, and that is **content work**, not a version bump.
- `typikon-validate` enumerates every affected file and pointer, so the work is countable before it is started.
- A PR adding a required field must say so and list the consumers it blocks.

## Consequence, stated plainly

`forkwright/ardent-site` stays pinned at `871669e` until its 9 files carry real provenance. That is tracked as ardent-site#17 and is now a documented cost rather than a surprise.

Docs only — no schema, script, or template change.