### PR TITLE
fix(ci): stop the CSP gate crying wolf and the pinning check skipping silently

### DIFF
--- a/ci/check-workflow-template.sh
+++ b/ci/check-workflow-template.sh
@@ -38,12 +38,39 @@ grep -qE '^\s*persist-credentials:\s*false' "$TMPL" || fail "no persist-credenti
 # Every `uses: owner/repo@REF` must pin REF to a 40-char commit SHA, not a
 # mutable tag/branch. A trailing `# vX` comment naming the human-readable
 # version is fine and expected.
+# WARNING: this loop must see EVERY `uses:` line, and must FAIL on a form it
+# cannot classify rather than skip it. The previous version selected lines with
+# a pattern requiring exactly `owner/repo@ref`, so any other shape matched
+# nothing and was never pin-checked — silently. `owner/repo/subdir@ref` is a
+# real and common action shape (a composite action in a subdirectory), and it
+# fell straight through the check that exists to catch it.
 while IFS= read -r line; do
-    ref="$(printf '%s' "$line" | sed -E 's/^\s*-?\s*uses:\s*[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+@([^ ]+).*/\1/')"
-    if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
-        fail "unpinned action ref (not a commit SHA): $line"
-    fi
-done < <(grep -E '^\s*-?\s*uses:\s*[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@' "$TMPL")
+    spec="$(printf '%s' "$line" \
+        | sed -E 's/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*//' \
+        | sed -E 's/[[:space:]]*#.*$//' \
+        | sed -E 's/^["'"'"']//; s/["'"'"']$//' \
+        | sed -E 's/[[:space:]]*$//')"
+    case "$spec" in
+        ./*|../*)
+            # Local action: its code is in this repository, pinned by the commit under review.
+            ;;
+        docker://*)
+            case "$spec" in
+                *@sha256:*) ;;
+                *) fail "docker action not pinned by digest: $line" ;;
+            esac
+            ;;
+        */*@*)
+            ref="${spec##*@}"
+            if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+                fail "unpinned action ref (not a commit SHA): $line"
+            fi
+            ;;
+        *)
+            fail "unrecognised uses: form, cannot verify pinning: $line"
+            ;;
+    esac
+done < <(grep -E '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]' "$TMPL")
 
 if [[ "$FAIL" -eq 0 ]]; then
     echo '{"checked":"'"$TMPL"'","status":"pass"}'

--- a/ci/csp-enforce.sh
+++ b/ci/csp-enforce.sh
@@ -56,7 +56,12 @@ set +e  # count-and-continue: no-match greps below must not abort under -e
 # 1. Inline <script>...body...</script>. The body must contain at least
 #    one non-whitespace char. <script src="..." defer></script> is fine.
 #    We greedy-match-against-line inside one line; then a multi-line check.
-inline_script_count=$(grep -E -c '<script[^>]*>[[:space:]]*[^[:space:]<]' "${FILES[@]}" 2>/dev/null | grep -vE ':0$' | wc -l)
+# WHY grep -l and not `grep -c | grep -v ':0$'`: with exactly ONE file in
+# the list, grep -c omits the filename prefix and prints a bare count, so a
+# clean build's `0` does not match the `:0$` filter and is counted as a
+# violation. grep -l prints one line per MATCHING file and nothing otherwise,
+# which is the quantity this check actually wants and needs no filtering.
+inline_script_count=$(grep -lE '<script[^>]*>[[:space:]]*[^[:space:]<]' "${FILES[@]}" 2>/dev/null | wc -l)
 if [[ $inline_script_count -gt 0 ]]; then
     echo "csp-enforce: inline <script>...content...</script> found:" >&2
     grep -nHE '<script[^>]*>[[:space:]]*[^[:space:]<]' "${FILES[@]}" >&2
@@ -64,7 +69,12 @@ if [[ $inline_script_count -gt 0 ]]; then
 fi
 
 # 2. Inline <style>...body...</style>.
-inline_style_count=$(grep -E -c '<style[^>]*>[[:space:]]*[^[:space:]<]' "${FILES[@]}" 2>/dev/null | grep -vE ':0$' | wc -l)
+# WHY grep -l and not `grep -c | grep -v ':0$'`: with exactly ONE file in
+# the list, grep -c omits the filename prefix and prints a bare count, so a
+# clean build's `0` does not match the `:0$` filter and is counted as a
+# violation. grep -l prints one line per MATCHING file and nothing otherwise,
+# which is the quantity this check actually wants and needs no filtering.
+inline_style_count=$(grep -lE '<style[^>]*>[[:space:]]*[^[:space:]<]' "${FILES[@]}" 2>/dev/null | wc -l)
 if [[ $inline_style_count -gt 0 ]]; then
     echo "csp-enforce: inline <style>...content...</style> found:" >&2
     grep -nHE '<style[^>]*>[[:space:]]*[^[:space:]<]' "${FILES[@]}" >&2


### PR DESCRIPTION
Two gates that reported the opposite of the truth.

Closes #88
Closes #90

## 1. The CSP gate fails a clean single-file build (#88)

Violations were counted by piping `grep -c` through a `:0$` filter. That filter assumes a filename prefix, which GNU grep emits only for **two or more** files — so a build with exactly one HTML file produces a bare `0` the filter cannot strip.

Measured against the pre-fix code, on a page containing nothing but `<p>clean</p>`:

```
csp-enforce: 2 violation(s) — strict CSP would block in production.
exit=1
```

Two, one from each check using that pattern. A newly scaffolded consumer fails its own CSP gate before it has written anything wrong.

Rewritten to `grep -l`, which prints one line per matching file and nothing otherwise — the quantity the check actually wants, so the filter disappears rather than being repaired.

> The issue suggested adding `-H` to force the prefix. `grep -l` is better: it removes the filtering step entirely instead of making the workaround work.

**Verified it still catches real violations.** A single file containing `<script>alert(1)</script>` still fails with exit 1. A fix that merely silenced the gate would be worse than the bug.

| case | before | after |
|---|---|---|
| 1 clean file | **2 violations, exit 1** | ok, exit 0 |
| 2 clean files | ok, exit 0 | ok, exit 0 |
| 1 file, real inline script | exit 1 | exit 1 |

## 2. The pinning check skipped what it could not parse (#90)

Lines were selected with a pattern requiring exactly `owner/repo@ref`. Any other shape matched nothing and was never checked — silently.

`actions/upload-artifact/merge@v4` is a real, common shape (a composite action in a subdirectory). Pre-fix:

```
$ bash ci/check-workflow-template.sh w.yml
{"checked":"w.yml","status":"pass"}
rc=0
```

A mutable tag, passed by the check that exists to catch mutable tags.

Now every `uses:` line is classified, and an unrecognised form **fails** rather than being skipped:

| form | verdict |
|---|---|
| `actions/checkout@<40-hex>` | pass |
| `actions/checkout@v4` | fail — unpinned |
| `actions/upload-artifact/merge@v4` | fail — **was silently passing** |
| `actions/upload-artifact/merge@<40-hex>` | pass |
| `docker://alpine:3.19` | fail — no digest |
| `./.github/actions/local` | pass — pinned by the commit under review |

> The issue suggested widening the regex to allow more path segments. That alone would have left `docker://` and malformed refs falling through the same hole, so the loop is fail-closed instead: it sees every `uses:` line and refuses anything it cannot classify.
