### PR TITLE
fix(templates): close product-schema gap and drop invented HowTo duration

### DIFF
--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -27,9 +27,9 @@ Top-level pages and section children that aren't journal entries or products.
 
 **Optional core:** `description`, `date`, `updated`, `path`, `template`, `weight`, `draft`.
 
-**Optional `[extra]`:** `seo_title`, `body_class`, `og_image`, `og_type`.
+**Optional `[extra]`:** `seo_title`, `body_class`, `og_image`, `og_type`, `audience`, `price`, `price_source`, `stripe_url`.
 
-**Constraints:** title ≤80 chars; description ≤200; path matches `^/[a-z0-9/_-]*/?$`; template matches `^[a-z0-9_-]+\.html$`; og_image ends in `.svg|.png|.jpg|.webp`.
+**Constraints:** title ≤80 chars; description ≤200; path matches `^/[a-z0-9/_-]*/?$`; template matches `^[a-z0-9_-]+\.html$`; og_image ends in `.svg|.png|.jpg|.webp`. Setting any one of `price`, `stripe_url`, or `price_source` triggers `ld-product` JSON-LD in `page.html`, which then requires all four of `audience`, `price`, `price_source`, and `stripe_url` together (enforced by the schema's `if`/`then` on `extra`, matching the template's assertions exactly). A dedicated product page under `content/products/` should use the `product` schema instead — these fields exist here for the rare non-product-section page that still needs a buy block.
 
 **Example:**
 
@@ -190,6 +190,7 @@ Any page with `template = "sizing-guide.html"`. Renders a measurement table, an 
 - size_table rows: required `size`; optional `waist`, `length`, `width`, `note`; column rendering is conditional on the first row's keys
 - diagram (optional): path under static/ to an `.svg` file; loaded inline via `load_data`
 - decision_tree (optional): array of strings, rendered as ordered list
+- duration (optional): ISO 8601 duration, hours/minutes/seconds only (e.g. `PT2M`); requires duration_source; emitted as HowTo `totalTime` only when both are set — never guessed
 
 **Example:**
 

--- a/schemas/page.schema.json
+++ b/schemas/page.schema.json
@@ -79,15 +79,27 @@
           "type": "string",
           "description": "Override the brand author for this page. Falls back to config.extra.author.name."
         },
+        "audience": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 120,
+          "description": "Intended buyer or reader context. Required alongside price, price_source, and stripe_url when any one of the three is set — see the extra-level dependency below."
+        },
         "price": {
           "type": "string",
           "pattern": "^\\$?\\d{1,5}(\\.\\d{2})?$",
-          "description": "Used in product context. Triggers ld-product JSON-LD when paired with stripe_url."
+          "description": "Display price with optional leading $ (e.g. '$150', '85'). Setting price, stripe_url, or price_source triggers ld-product JSON-LD, which requires all four of audience, price, price_source, and stripe_url together."
+        },
+        "price_source": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 200,
+          "description": "Source for the rendered price claim, e.g. the Stripe price object, SKU ledger, or fixture note. Required alongside audience, price, and stripe_url when any one of the three is set — see the extra-level dependency below."
         },
         "stripe_url": {
           "type": "string",
           "pattern": "^https://buy\\.stripe\\.com/[A-Za-z0-9_]+$",
-          "description": "Used in product context. Triggers ld-product JSON-LD when paired with price."
+          "description": "Stripe direct-checkout URL. Setting price, stripe_url, or price_source triggers ld-product JSON-LD, which requires all four of audience, price, price_source, and stripe_url together."
         },
         "video": {
           "type": "object",
@@ -123,6 +135,16 @@
             }
           }
         }
+      },
+      "if": {
+        "anyOf": [
+          { "required": ["price"] },
+          { "required": ["stripe_url"] },
+          { "required": ["price_source"] }
+        ]
+      },
+      "then": {
+        "required": ["audience", "price", "price_source", "stripe_url"]
       }
     }
   }

--- a/schemas/sizing-guide.schema.json
+++ b/schemas/sizing-guide.schema.json
@@ -78,11 +78,26 @@
             "maxLength": 300
           }
         },
+        "duration": {
+          "type": "string",
+          "pattern": "^PT(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?$",
+          "description": "ISO 8601 duration for how long the decision_tree steps take (e.g. 'PT2M'). Emitted as HowTo totalTime only when both duration and duration_source are set — omitted otherwise rather than guessed."
+        },
+        "duration_source": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 200,
+          "description": "Source for the duration claim, e.g. a timed run of the steps or an operator estimate stated as such. Required alongside duration."
+        },
         "seo_title": { "type": "string", "maxLength": 80 },
         "body_class": { "type": "string", "pattern": "^[a-z][a-z0-9 -]*$" },
         "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|jpeg|webp)$" },
         "skip_sitemap": { "type": "boolean" },
         "author": { "type": "string" }
+      },
+      "dependentRequired": {
+        "duration": ["duration_source"],
+        "duration_source": ["duration"]
       }
     }
   }

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -36,7 +36,7 @@
     {%- set anchor = item.anchor | default(value=item.q | slugify) %}
     <div class="faq-item" id="{{ anchor }}">
       <dt class="faq-question">
-        <a href="#{{ anchor }}" class="faq-anchor" aria-label="Link to this question">{{ item.q }}</a>
+        <a href="#{{ anchor }}" class="faq-anchor">{{ item.q }}</a>
       </dt>
       <dd class="faq-answer">
         {%- for paragraph in item.a | split(pat="\n\n") %}

--- a/templates/partials/ld-howto.html
+++ b/templates/partials/ld-howto.html
@@ -7,8 +7,12 @@
    surface in Google search.
 
    Inputs:
-     page.extra.product_type  — what the guide sizes (becomes part of name)
-     page.extra.decision_tree — array of strings, one step per item
+     page.extra.product_type     — what the guide sizes (becomes part of name)
+     page.extra.decision_tree    — array of strings, one step per item
+     page.extra.duration         — optional, ISO 8601 (e.g. "PT2M"); requires
+                                    duration_source (schema dependentRequired).
+                                    totalTime is omitted, not guessed, when unset.
+     page.extra.duration_source  — optional; provenance for the duration claim
 
    Schema reference: https://schema.org/HowTo
 #}
@@ -24,7 +28,9 @@
   "@type": "HowTo",
   "name": {{ howto_name | json_encode | safe }},
   "description": {{ page.description | json_encode | safe }},
-  "totalTime": "PT2M",
+  {%- if page.extra.duration is defined and page.extra.duration %}
+  "totalTime": {{ page.extra.duration | json_encode | safe }},
+  {%- endif %}
   "step": [
     {%- for line in page.extra.decision_tree -%}
     {


### PR DESCRIPTION
Fan-out unit `fix/ty-templates`. Under review by the orchestrator; see the commit body for what changed and how it was verified.