### PR TITLE
fix(ci): pair the shipped Node with the pinned wrangler, and check it

### DIFF
--- a/ci/check-workflow-template.sh
+++ b/ci/check-workflow-template.sh
@@ -72,6 +72,33 @@ while IFS= read -r line; do
     esac
 done < <(grep -E '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]' "$TMPL")
 
+# WHY this check: wrangler's engines floor and the Node version this template
+# ships are independent values that must agree. When they drifted, a consumer's
+# deploy failed AFTER a green build with a message about Node, and nothing in
+# the repo related the two. The floor is read from the registry so the check
+# tracks the pinned version instead of a second copy of its requirement.
+#
+# WARNING: every probe below is `|| true`. This script runs under `set -e` with
+# pipefail, and a grep that matches nothing exits non-zero — which would abort
+# the whole check silently, turning a hardening step into a no-op.
+node_major="$(grep -oE "node-version: '[0-9]+'" "$TMPL" 2>/dev/null | head -1 | grep -oE '[0-9]+' || true)"
+wrangler_pin="$(grep -oE 'wrangler@[0-9]+\.[0-9]+\.[0-9]+' "$TMPL" 2>/dev/null | head -1 | cut -d@ -f2 || true)"
+if [[ -z "$wrangler_pin" ]]; then
+    # The template carries a {{ WRANGLER_VERSION }} placeholder; a rendered
+    # instance carries the literal. Resolve the placeholder from the defaults.
+    defaults="$(dirname "$0")/../bin/typikon-defaults.sh"
+    wrangler_pin="$(grep -oE 'WRANGLER_VERSION:=[0-9.]+' "$defaults" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)"
+fi
+if [[ -n "$node_major" && -n "$wrangler_pin" ]]; then
+    floor="$(curl -fsS --max-time 10 "https://registry.npmjs.org/wrangler/${wrangler_pin}" 2>/dev/null \
+        | grep -oE '"node":"[^"]*"' | grep -oE '[0-9]+' | head -1 || true)"
+    if [[ -z "$floor" ]]; then
+        echo "note: npm registry unreachable; wrangler/Node pairing unverified" >&2
+    elif [[ "$node_major" -lt "$floor" ]]; then
+        fail "Node ${node_major} is below wrangler@${wrangler_pin} engines floor (>=${floor}) — the deploy fails after a green build"
+    fi
+fi
+
 if [[ "$FAIL" -eq 0 ]]; then
     echo '{"checked":"'"$TMPL"'","status":"pass"}'
 fi

--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -77,7 +77,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          # WARNING: must stay >= the engines floor of the wrangler pinned below.
+          # wrangler 4.112.0 requires Node >=22; on 20 it refuses to run and the
+          # deploy fails AFTER a green build, which reads as a deploy problem
+          # rather than a version pairing. Raise both together or neither.
+          node-version: '22'
 
       - name: Install pa11y-ci, lychee, playwright
         # WHY 15: mirrors ci/kanon-ci.toml.tmpl's setup-node-tooling


### PR DESCRIPTION
Pinning the wrangler version (#93, mine) left the template shipping **Node 20** alongside **wrangler 4.112.0**, whose engines floor is `>=22.0.0`.

`forkwright/ardent-site` re-rendered and its main went red:

```
Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.
```

| | engines floor |
|---|---|
| `wrangler@4.86.0` | `>=20.3.0` |
| `wrangler@4.112.0` | `>=22.0.0` |

`a2z-tree-site` is unaffected (pins 4.86.0). `ardent-tools-site` had already moved to Node 22 on its own.

## Not just the instance

Bumping the template alone leaves the next version bump free to re-break it. `check-workflow-template.sh` now reads the pinned wrangler's engines floor **from the npm registry** and fails when the shipped Node is below it — reading the registry rather than hard-coding the floor keeps the check tracking whatever is pinned, instead of becoming a second copy of the requirement.

It resolves the `{{ WRANGLER_VERSION }}` placeholder from `typikon-defaults.sh`, so it works on the template as well as on a rendered instance.

## One trap worth naming

Every probe is guarded with `|| true`. The script runs under `set -euo pipefail`, and a `grep` matching nothing exits non-zero — my first version aborted the entire check silently and still exited 0 on the caller's path, turning a hardening step into a no-op. That is precisely the failure mode this file exists to prevent, so the guard carries a WARNING.

## Verified it discriminates

```
node 20 + wrangler 4.112.0 -> FAIL: Node 20 is below wrangler@4.112.0 engines floor (>=22) ... exit=1
node 22 + wrangler 4.112.0 -> {"checked":"...","status":"pass"}
```

Refs #58