### PR TITLE
fix(ci): replace the line-regex CSP gate with an HTML-aware scanner

### DIFF
--- a/ci/csp-enforce.sh
+++ b/ci/csp-enforce.sh
@@ -5,13 +5,22 @@ set -euo pipefail
 # Usage:
 #     ci/csp-enforce.sh <built-public-dir>
 #
-# Greps the rendered HTML output for shapes that the strict CSP
+# Scans the rendered HTML output for shapes that the strict CSP
 # (default-src 'self'; script-src 'self'; style-src 'self'; ...) would
 # block at runtime. Any hit fails the build with the offending file
 # path. Without this gate, a stray inline <script> ships to production
 # and the visitor sees a broken page (CSP refuses, no fallback).
 #
-# Patterns checked:
+# WHY an HTML parser (ci/csp-scan.py) and not line-oriented regex: a
+# regex gate reads the file one line at a time and only recognizes
+# double-quoted attribute values, so a script body spanning multiple
+# lines, a single-quoted or unquoted attribute, an uppercase tag/handler
+# name, or an HTML-entity-encoded value all pass unflagged even though
+# a browser under this CSP blocks every one of them. csp-scan.py parses
+# with the stdlib html.parser, so it reasons about elements and
+# normalized attribute values instead of line shapes.
+#
+# Patterns checked (see csp-scan.py for the authoritative language):
 #   1. <script>...non-empty content...</script>           inline JS
 #   2. <style>...non-empty content...</style>             inline CSS
 #   3. on<event>="..."                                    event handler
@@ -21,14 +30,12 @@ set -euo pipefail
 # Allowlisted (no false positive):
 #   - <script src="..." defer></script>      external script ref (no body)
 #   - <style></style>                         empty inline style (rare; allowed)
+#   - <link rel="stylesheet" href="...">      external stylesheet ref
 #
 # Exit:
 #   0  no violations
 #   1  violations found (printed with file path + matched line)
 #   2  invocation error
-
-# Strict mode globally; the counting section below drops `-e` locally because
-# its greps intentionally exit nonzero on no-match and must not abort.
 
 usage() {
     echo "usage: ci/csp-enforce.sh <built-public-dir>" >&2
@@ -38,6 +45,8 @@ usage() {
 [[ $# -ne 1 ]] && usage
 ROOT="$(realpath "$1")"
 [[ -d "$ROOT" ]] || { echo "error: $ROOT is not a directory" >&2; exit 2; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Restrict to HTML output. Other built artifacts (CSS, JS, fonts) are
 # self-evidently first-party because the browser only loads them when
@@ -50,66 +59,19 @@ mapfile -t FILES < <(find "$ROOT" -type f -name '*.html')
     exit 0
 }
 
-VIOLATIONS=0
-set +e  # count-and-continue: no-match greps below must not abort under -e
+SCAN_ERR="$(mktemp)"
+trap 'rm -f "$SCAN_ERR"' EXIT
 
-# 1. Inline <script>...body...</script>. The body must contain at least
-#    one non-whitespace char. <script src="..." defer></script> is fine.
-#    We greedy-match-against-line inside one line; then a multi-line check.
-# WHY grep -l and not `grep -c | grep -v ':0$'`: with exactly ONE file in
-# the list, grep -c omits the filename prefix and prints a bare count, so a
-# clean build's `0` does not match the `:0$` filter and is counted as a
-# violation. grep -l prints one line per MATCHING file and nothing otherwise,
-# which is the quantity this check actually wants and needs no filtering.
-inline_script_count=$(grep -lE '<script[^>]*>[[:space:]]*[^[:space:]<]' "${FILES[@]}" 2>/dev/null | wc -l)
-if [[ $inline_script_count -gt 0 ]]; then
-    echo "csp-enforce: inline <script>...content...</script> found:" >&2
-    grep -nHE '<script[^>]*>[[:space:]]*[^[:space:]<]' "${FILES[@]}" >&2
-    VIOLATIONS=$((VIOLATIONS + inline_script_count))
-fi
+status=0
+python3 "$SCRIPT_DIR/csp-scan.py" "${FILES[@]}" 2>"$SCAN_ERR" || status=$?
 
-# 2. Inline <style>...body...</style>.
-# WHY grep -l and not `grep -c | grep -v ':0$'`: with exactly ONE file in
-# the list, grep -c omits the filename prefix and prints a bare count, so a
-# clean build's `0` does not match the `:0$` filter and is counted as a
-# violation. grep -l prints one line per MATCHING file and nothing otherwise,
-# which is the quantity this check actually wants and needs no filtering.
-inline_style_count=$(grep -lE '<style[^>]*>[[:space:]]*[^[:space:]<]' "${FILES[@]}" 2>/dev/null | wc -l)
-if [[ $inline_style_count -gt 0 ]]; then
-    echo "csp-enforce: inline <style>...content...</style> found:" >&2
-    grep -nHE '<style[^>]*>[[:space:]]*[^[:space:]<]' "${FILES[@]}" >&2
-    VIOLATIONS=$((VIOLATIONS + inline_style_count))
-fi
-
-# 3. on<event>= handlers. Tight pattern: matches onclick=, onload=, etc.
-#    Avoid false positives on attribute values that contain 'on' (e.g.,
-#    aria-describedby="region-on-the-front") by anchoring before the `on`
-#    to a tag-character context: whitespace, /, or =.
-handler_count=$(grep -nHE '[[:space:]/]on[a-z]+="' "${FILES[@]}" 2>/dev/null | wc -l)
-if [[ $handler_count -gt 0 ]]; then
-    echo "csp-enforce: on*= event handlers found:" >&2
-    grep -nHE '[[:space:]/]on[a-z]+="' "${FILES[@]}" >&2
-    VIOLATIONS=$((VIOLATIONS + handler_count))
-fi
-
-# 4. Inline style="..." attributes. Strict CSP style-src 'self' blocks
-#    these unless 'unsafe-inline' is in the policy (which typikon refuses).
-inline_style_attr_count=$(grep -nHE '[[:space:]/]style="[^"]+"' "${FILES[@]}" 2>/dev/null | wc -l)
-if [[ $inline_style_attr_count -gt 0 ]]; then
-    echo "csp-enforce: inline style=\"...\" attributes found:" >&2
-    grep -nHE '[[:space:]/]style="[^"]+"' "${FILES[@]}" >&2
-    VIOLATIONS=$((VIOLATIONS + inline_style_attr_count))
-fi
-
-# 5. javascript: URLs (href="javascript:...", src="javascript:...").
-js_url_count=$(grep -nHE '"javascript:' "${FILES[@]}" 2>/dev/null | wc -l)
-if [[ $js_url_count -gt 0 ]]; then
-    echo "csp-enforce: javascript: URLs found:" >&2
-    grep -nHE '"javascript:' "${FILES[@]}" >&2
-    VIOLATIONS=$((VIOLATIONS + js_url_count))
-fi
-
-if [[ $VIOLATIONS -gt 0 ]]; then
+if [[ $status -eq 2 ]]; then
+    cat "$SCAN_ERR" >&2
+    exit 2
+elif [[ $status -eq 1 ]]; then
+    VIOLATIONS=$(wc -l <"$SCAN_ERR")
+    echo "csp-enforce: violations found:" >&2
+    cat "$SCAN_ERR" >&2
     echo "" >&2
     echo "csp-enforce: $VIOLATIONS violation(s) — strict CSP would block in production." >&2
     echo "Fix by extracting to /css/ /js/ files and referencing via <link>/<script src>." >&2

--- a/ci/csp-scan.py
+++ b/ci/csp-scan.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""csp-scan — HTML-aware CSP violation scanner for csp-enforce.sh.
+
+Parses each file with html.parser (stdlib) instead of matching lines with
+regex, so a violation split across lines, spelled with single/unquoted
+attribute values, written in uppercase, or hidden behind an HTML entity is
+still caught. External references (`<script src>`, `<link rel=stylesheet>`)
+are never flagged — only inline bodies and inline attribute values are.
+
+Usage:
+    ci/csp-scan.py <file> [<file> ...]
+
+Exit:
+    0  no violations
+    1  violations found (each printed to stderr as "<path>:<line>: <detail>")
+"""
+
+from __future__ import annotations
+
+import sys
+from html.parser import HTMLParser
+
+# INVARIANT: mirrors the boundary condition the original grep encoded —
+# an attribute literally named on<letters> ("onclick", "onmouseover", ...),
+# not any attribute whose value merely contains the substring "on".
+_HANDLER_PREFIX = "on"
+
+# WHY: browsers strip TAB/CR/LF from a URL scheme before parsing it, which
+# is a known javascript: filter bypass ("java\tscript:"). Stripped before
+# the scheme check so that evasion doesn't slip through unflagged.
+_CONTROL_CHARS = str.maketrans("", "", "\t\r\n")
+
+# WHY: a <script> element's `type` decides whether the browser ever hands
+# its body to the JS engine at all. Per the HTML living standard, a type
+# that isn't empty/a JavaScript MIME type/"module"/"importmap" makes the
+# element an inert data block — the parser never executes it, so CSP's
+# script-src has nothing to block. typikon's own JSON-LD partials
+# (templates/partials/ld-*.html) rely on exactly this: structured-data
+# <script type="application/ld+json"> under strict script-src 'self'
+# with no 'unsafe-inline'. Anything not in this list is treated as
+# executable and flagged — fail-closed on an unrecognized type.
+_INERT_SCRIPT_TYPES = frozenset({"application/json", "application/ld+json"})
+
+
+class CSPScanner(HTMLParser):
+    def __init__(self, path: str):
+        super().__init__(convert_charrefs=True)
+        self.path = path
+        self.violations: list[tuple[int, str]] = []
+        self._body_tag: str | None = None
+        self._body_start_line = 0
+        self._body_chunks: list[str] = []
+        self._body_inert = False
+
+    def _flag(self, detail: str) -> None:
+        line, _ = self.getpos()
+        self.violations.append((line, detail))
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in ("script", "style"):
+            self._body_tag = tag
+            self._body_start_line, _ = self.getpos()
+            self._body_chunks = []
+            script_type = next((v for n, v in attrs if n == "type"), None)
+            self._body_inert = (
+                tag == "script"
+                and script_type is not None
+                and script_type.strip().lower() in _INERT_SCRIPT_TYPES
+            )
+
+        for name, value in attrs:
+            if value is None:
+                continue
+            if name == "style" and value != "":
+                self._flag(f'inline style="..." attribute on <{tag}>')
+            elif name.startswith(_HANDLER_PREFIX) and name[len(_HANDLER_PREFIX):].isalpha():
+                self._flag(f'{name}="..." event handler on <{tag}>')
+
+            scheme_probe = value.translate(_CONTROL_CHARS).strip().lower()
+            if scheme_probe.startswith("javascript:"):
+                self._flag(f'{name}="javascript:..." URL on <{tag}>')
+
+    def handle_data(self, data: str) -> None:
+        if self._body_tag is not None:
+            self._body_chunks.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == self._body_tag:
+            body = "".join(self._body_chunks)
+            if body.strip() and not self._body_inert:
+                self._flag(f"inline <{tag}>...content...</{tag}> body")
+            self._body_tag = None
+            self._body_chunks = []
+            self._body_inert = False
+
+
+def scan(path: str) -> list[tuple[int, str]]:
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        html = fh.read()
+    scanner = CSPScanner(path)
+    scanner.feed(html)
+    scanner.close()
+    return scanner.violations
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: ci/csp-scan.py <file> [<file> ...]", file=sys.stderr)
+        return 2
+
+    total = 0
+    for path in argv:
+        for line, detail in scan(path):
+            print(f"{path}:{line}: {detail}", file=sys.stderr)
+            total += 1
+
+    return 1 if total > 0 else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Closes #33

Measured against **current main**, on one file each:

| case | current regex gate | new scanner |
|---|---|---|
| `<SCRIPT>alert(1)</SCRIPT>` (uppercase tag) | **passes — missed** | caught |
| `onClick='doThing()'` (mixed case, single-quoted) | **passes — missed** | caught |
| `<script>` body spanning lines | **passes — missed** | caught |
| `style='color:red'` (single-quoted) | **passes — missed** | caught |
| clean page with one-line `<script type="application/ld+json">` | **fails — false positive** | passes |

So the gate that exists to block inline script misses every shape of it that is not lowercase and double-quoted, while flagging structured data that is not executable at all. Both directions are wrong, and both come from matching HTML with line-oriented regexes.

The replacement parses the document (`html.parser`, stdlib — no new dependency) and decides on element structure and attribute names rather than on quoting and case. JSON-LD passes because it is typed as data, not because of how it was formatted.

Verified: both `examples/sample-blog` and `examples/sample-shop` still pass, and the adversarial set above discriminates in both directions.