### PR TITLE
fix(a11y): normalize breadcrumb URLs and keep interactive contrast compliant

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -50,6 +50,11 @@
   --thanatochromia-aged: #382838;
   --aporia: #5C8E63;
   --aporia-aged: #4A7A5A;
+  /* WHY: --aporia is the true dye hue (used for swatches/backgrounds) and
+     only reaches 3.44:1 on --bg, below WCAG 2.2 AA's 4.5:1 for small text.
+     Interactive text uses this darker same-hue token instead; the dye
+     tokens above stay unmutated so swatches keep their accurate color. */
+  --aporia-interactive: #4A7350;
   --natural: #8B5A2B;
   --natural-aged: #5C3A1F;
   
@@ -191,7 +196,7 @@ nav {
 /* Nav links get dye colors on hover */
 .nav-links a:nth-child(1):hover { color: var(--aima); }
 .nav-links a:nth-child(2):hover { color: var(--thanatochromia); }
-.nav-links a:nth-child(3):hover { color: var(--aporia); }
+.nav-links a:nth-child(3):hover { color: var(--aporia-interactive); }
 .nav-links a:nth-child(4):hover { color: var(--text-mid); }
 .nav-links a:nth-child(5):hover { color: var(--natural); }
 .nav-links a:nth-child(6):hover { color: var(--text); }
@@ -1105,7 +1110,7 @@ main hr {
 /* Colors */
 .triad-1 { color: var(--aima); }
 .triad-2 { color: var(--thanatochromia); }
-.triad-3 { color: var(--aporia); }
+.triad-3 { color: var(--aporia-interactive); }
 
 /* Background color shift on hover (only when settled, using :has) */
 .home-page::before,

--- a/templates/partials/ld-breadcrumb.html
+++ b/templates/partials/ld-breadcrumb.html
@@ -9,6 +9,12 @@
 #}
 {% macro breadcrumb(title, permalink, ancestors) %}
 {%- if ancestors and ancestors | length > 0 %}
+{#- WHY: trailing-slash spelling varies (config.base_url is user-entered,
+   ancestor/page permalinks come from Zola); strip the trailing slash before
+   comparing so the root is deduplicated regardless of spelling, instead of
+   comparing one unnormalized slash form. #}
+{%- set base_key = config.base_url | trim_end_matches(pat="/") -%}
+{%- set page_key = permalink | trim_end_matches(pat="/") -%}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -21,9 +27,12 @@
       "item": {{ config.base_url | json_encode | safe }}
     }
     {%- set position = 2 -%}
+    {%- set_global seen = [base_key] -%}
     {%- for ancestor_path in ancestors -%}
       {%- set ancestor = get_section(path=ancestor_path) -%}
-      {%- if ancestor.title and ancestor.permalink and ancestor.permalink != config.base_url ~ "/" -%},
+      {%- if ancestor.title and ancestor.permalink -%}
+        {%- set ancestor_key = ancestor.permalink | trim_end_matches(pat="/") -%}
+        {%- if not ancestor_key in seen and ancestor_key != page_key -%},
     {
       "@type": "ListItem",
       "position": {{ position }},
@@ -31,6 +40,8 @@
       "item": {{ ancestor.permalink | json_encode | safe }}
     }
         {%- set_global position = position + 1 -%}
+        {%- set_global seen = seen | concat(with=ancestor_key) -%}
+        {%- endif -%}
       {%- endif -%}
     {%- endfor -%},
     {


### PR DESCRIPTION
Fan-out unit `w2-a11y` (#62,, #64). Under orchestrator review; see the commit body for what changed and how it was verified.