### PR TITLE
fix(product): render product metadata and unify sizing-table cells

### DIFF
--- a/schemas/product.schema.json
+++ b/schemas/product.schema.json
@@ -47,6 +47,17 @@
           "maxLength": 200,
           "description": "Override the default shipping line. Defaults to 'Shipping included · Tax at checkout · Ships within one week'."
         },
+        "availability": {
+          "type": "string",
+          "enum": ["InStock", "OutOfStock", "PreOrder", "BackOrder", "LimitedAvailability", "Discontinued"],
+          "description": "Schema.org Offer.availability state. Emitted in JSON-LD only alongside availability_source; never defaulted to InStock."
+        },
+        "availability_source": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 200,
+          "description": "Source for the availability claim, e.g. inventory count or a manual stock check. Required alongside availability."
+        },
         "seo_title": { "type": "string", "maxLength": 80 },
         "body_class": { "type": "string", "pattern": "^[a-z][a-z0-9 -]*$" },
         "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|jpeg|webp)$" },
@@ -80,6 +91,10 @@
             }
           }
         }
+      },
+      "dependentRequired": {
+        "availability": ["availability_source"],
+        "availability_source": ["availability"]
       }
     }
   }

--- a/templates/page.html
+++ b/templates/page.html
@@ -40,6 +40,11 @@
    the operator drops the placeholder <div class="product-images"> from
    markdown when photos arrive and the gallery takes its visual slot. #}
 {%- include "partials/product-gallery.html" -%}
+{# WHY: same product-shaped frontmatter that triggers ld-product.html above
+   must also render visibly — price/shipping/checkout were JSON-LD-only. #}
+{%- if page.extra.price and page.extra.stripe_url -%}
+{%- include "partials/product-purchase.html" -%}
+{%- endif -%}
 {{ page.content | safe }}
 {# Process video renders after page content when extra.video is set. #}
 {%- include "partials/video.html" -%}

--- a/templates/partials/ld-product.html
+++ b/templates/partials/ld-product.html
@@ -11,6 +11,10 @@
      page.extra.og_image   — primary product image (becomes image)
      config.title          — brand name (Product.brand)
      config.base_url       — for image absolute URL
+
+   NOTE: Offer.availability is emitted only when both page.extra.availability
+   and page.extra.availability_source are set — never defaulted, since an
+   unverified stock claim in structured data misleads search engines.
 #}
 {% import "partials/assert.html" as assert %}
 {{ assert::required(ok=page.title is defined and page.title, field="page.title", template="partials/ld-product.html") }}
@@ -38,8 +42,13 @@
   "offers": {
     "@type": "Offer",
     "price": {{ price_numeric | json_encode | safe }},
-    "priceCurrency": "USD",
-    "availability": "https://schema.org/InStock",
+    "priceCurrency": "USD"
+    {%- if page.extra.availability and page.extra.availability_source -%}
+    {%- set availability_url = "https://schema.org/" ~ page.extra.availability -%}
+    ,
+    "availability": {{ availability_url | json_encode | safe }}
+    {%- endif -%}
+    ,
     "url": {{ page.extra.stripe_url | json_encode | safe }}
   }
   {%- if image_url -%},

--- a/templates/partials/product-purchase.html
+++ b/templates/partials/product-purchase.html
@@ -1,0 +1,21 @@
+{# Visible storefront primitive for a schema-derived product page. Renders
+   when page.extra.price AND page.extra.stripe_url are both set (product.schema.json),
+   so price/shipping/checkout are never JSON-LD-only.
+
+   Inputs:
+     page.title                — product name
+     page.extra.price          — display price, e.g. "$150"
+     page.extra.shipping_note  — optional; falls back to the schema-documented default
+     page.extra.stripe_url     — direct checkout URL
+
+   WHY no assert here: page.html's ld_json block renders earlier (in <head>)
+   and already asserts this field combination; not repeated in this partial.
+
+   Schema: schemas/product.schema.json#extra
+#}
+<div class="product-header">
+  <p class="product-name">{{ page.title }}</p>
+  <p class="product-price-large">{{ page.extra.price }}</p>
+  <p class="product-shipping">{{ page.extra.shipping_note | default(value="Shipping included · Tax at checkout · Ships within one week") }}</p>
+  <a class="buy-btn" href="{{ page.extra.stripe_url | safe }}" aria-label="Buy {{ page.title }}">Buy now</a>
+</div>

--- a/templates/section.html
+++ b/templates/section.html
@@ -24,4 +24,29 @@
 
 {% block content %}
 {{ section.content | safe }}
+
+{# NOTE: default child-page listing (e.g. content/products/_index.md).
+   WHY per-field-optional: mirrors journal-section.html's pattern — title
+   always shown, description/price shown only when the child defines them —
+   so one listing serves both product children and plain-page children. #}
+{%- if section.pages and section.pages | length > 0 %}
+<ul class="products-list">
+  {%- for item in section.pages %}
+  <li>
+    <a href="{{ item.permalink | safe }}">
+      <span class="product-name">{{ item.title }}</span>
+      {%- if item.description %}
+      <span class="product-materials">{{ item.description }}</span>
+      {%- endif %}
+      {%- if item.extra.price %}
+      <span class="product-price">{{ item.extra.price }}</span>
+      {%- endif %}
+    </a>
+  </li>
+  {%- endfor %}
+</ul>
+{%- if section.extra.list_caption %}
+<p class="specs">{{ section.extra.list_caption }}</p>
+{%- endif %}
+{%- endif %}
 {% endblock content %}

--- a/templates/sizing-guide.html
+++ b/templates/sizing-guide.html
@@ -45,25 +45,40 @@
   {%- endif %}
 
   {%- set unit_label = page.extra.measurement_unit | default(value="inches") %}
+  {# INVARIANT: header and row cells share one column set, computed across
+     ALL rows — not row 0 alone, since a later row can carry a field row 0
+     lacks. WHY: deriving headers from row 0 only let a later row's value
+     land under the wrong heading; a row missing a field now renders a
+     blank cell in place instead of shifting later columns left. #}
+  {%- set_global has_waist = false -%}
+  {%- set_global has_length = false -%}
+  {%- set_global has_width = false -%}
+  {%- set_global has_note = false -%}
+  {%- for row in page.extra.size_table %}
+    {%- if row.waist is defined %}{% set_global has_waist = true %}{% endif %}
+    {%- if row.length is defined %}{% set_global has_length = true %}{% endif %}
+    {%- if row.width is defined %}{% set_global has_width = true %}{% endif %}
+    {%- if row.note is defined %}{% set_global has_note = true %}{% endif %}
+  {%- endfor %}
   <table class="sizing-table">
     <caption>{{ page.extra.product_type | capitalize }} sizes ({{ unit_label }})</caption>
     <thead>
       <tr>
         <th scope="col">Size</th>
-        {%- if page.extra.size_table[0].waist is defined %}<th scope="col">Waist</th>{% endif %}
-        {%- if page.extra.size_table[0].length is defined %}<th scope="col">Length</th>{% endif %}
-        {%- if page.extra.size_table[0].width is defined %}<th scope="col">Width</th>{% endif %}
-        {%- if page.extra.size_table[0].note is defined %}<th scope="col">Note</th>{% endif %}
+        {%- if has_waist %}<th scope="col">Waist</th>{% endif %}
+        {%- if has_length %}<th scope="col">Length</th>{% endif %}
+        {%- if has_width %}<th scope="col">Width</th>{% endif %}
+        {%- if has_note %}<th scope="col">Note</th>{% endif %}
       </tr>
     </thead>
     <tbody>
       {%- for row in page.extra.size_table %}
       <tr>
         <th scope="row">{{ row.size }}</th>
-        {%- if row.waist is defined %}<td>{{ row.waist }}</td>{% endif %}
-        {%- if row.length is defined %}<td>{{ row.length }}</td>{% endif %}
-        {%- if row.width is defined %}<td>{{ row.width }}</td>{% endif %}
-        {%- if row.note is defined %}<td>{{ row.note }}</td>{% endif %}
+        {%- if has_waist %}<td>{{ row.waist | default(value="") }}</td>{% endif %}
+        {%- if has_length %}<td>{{ row.length | default(value="") }}</td>{% endif %}
+        {%- if has_width %}<td>{{ row.width | default(value="") }}</td>{% endif %}
+        {%- if has_note %}<td>{{ row.note | default(value="") }}</td>{% endif %}
       </tr>
       {%- endfor %}
     </tbody>


### PR DESCRIPTION
Fan-out unit `w2-product` (#30,, #57). Under orchestrator review; see the commit body for what changed and how it was verified.