### PR TITLE
fix(check): assert the gate's own artifacts are ignored, before it writes them

### DIFF
--- a/bin/typikon-check
+++ b/bin/typikon-check
@@ -9,6 +9,8 @@
 # surfaces every problem rather than only the earliest one.
 #
 # Stages (emitted as JSONL):
+#     0. gate-artifacts-ignored  the working-tree paths this script writes are
+#                                 ignored by the consumer and not already tracked
 #     1. typikon-validate        frontmatter against JSON Schema
 #     2. zola check              internal links + asset references
 #     3. zola build              clean build with no warnings, output public/
@@ -206,6 +208,52 @@ sys.exit(0 if body == os.environ["TYPIKON_WAIT_TOKEN"] else 1)
     done
     return 1
 }
+
+# Stage 0 — the working-tree paths this script writes must be ignored, and must
+# not already be tracked. Runs before any stage writes, so a consumer is told
+# what to ignore rather than discovering it from the commit that swept it in.
+#
+# WHY this is checked rather than left to each consumer's .gitignore: the list of
+# artifacts is knowable only here, by the script that creates them, so a consumer
+# maintaining its own copy of that list is guessing. Two consumers guessed
+# `.lychee_cache/`, which is not a name lychee has ever written — the real
+# `.lycheecache` went unignored in both.
+#
+# What a miss costs: `git add -A` commits public-local/, and CI's own
+# `zola build --output-dir public-local` then aborts with "Directory
+# 'public-local' already exists" — a green local gate producing a red CI run
+# whose error names the directory instead of the missing ignore rule.
+# WARNING: a directory artifact MUST keep its trailing slash here. `git
+# check-ignore public-local` consults the filesystem to decide whether the path
+# is a directory, so a `public-local/` ignore rule does not match it while the
+# directory happens to be absent — the same repository then reports "ignored"
+# after a build and "not ignored" before one. `public-local/` is matched from
+# the pattern alone, so the verdict describes the repository rather than the
+# moment. Verified both ways against a fixture repo.
+GATE_ARTIFACTS=(public-local/ .lycheecache)
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    ARTIFACT_PROBLEMS=()
+    for artifact in "${GATE_ARTIFACTS[@]}"; do
+        if [[ -n "$(git ls-files -- "$artifact")" ]]; then
+            ARTIFACT_PROBLEMS+=("$artifact is tracked (git rm -r --cached $artifact)")
+        elif ! git check-ignore -q "$artifact"; then
+            ARTIFACT_PROBLEMS+=("$artifact is not ignored (add '$artifact' to .gitignore)")
+        fi
+    done
+    if (( ${#ARTIFACT_PROBLEMS[@]} > 0 )); then
+        # NOTE: IFS joins on its FIRST character only, so a two-character
+        # separator has to be applied by hand rather than via IFS='; '.
+        printf -v artifact_detail '%s; ' "${ARTIFACT_PROBLEMS[@]}"
+        emit "gate-artifacts-ignored" "fail" 0 "${artifact_detail%; }"
+        FAIL=1
+    else
+        emit "gate-artifacts-ignored" "pass" 0 "ok"
+    fi
+else
+    # Not a taint: no work tree means nothing can be committed, so the property
+    # holds vacuously. This is absence of the hazard, not absence of an instrument.
+    emit "gate-artifacts-ignored" "skip" 0 "not a git work tree — nothing can be committed here"
+fi
 
 # Stage 1 — frontmatter schemas.
 run_stage "typikon-validate" "$TYPIKON_ROOT/bin/typikon-validate" "$ROOT" || FAIL=1


### PR DESCRIPTION
## Finding

`typikon-check` writes `public-local/` into the consumer's working tree, and lychee writes `.lycheecache` beside it. Nothing checked that the consumer ignores either one, so the list of gate artifacts lived as a hand-authored guess in each consumer's `.gitignore` — and drifted from what the gate actually creates.

Two consumers guessed `.lychee_cache/`, which is not a name lychee has ever written. The real `.lycheecache` was unignored in both.

## Evidence

ardent-site paid for it this week. `git add -A` swept 45 build-output files into a commit, and CI's own `zola build --base-url … --output-dir public-local` then aborted:

```
ERROR Failed to build the site
ERROR Directory 'public-local' already exists. Use --force to overwrite.
```

A green local gate producing a red CI run whose error named the directory rather than the missing ignore rule.

## Why this matters

The artifact list is knowable only here, in the script that creates them. A consumer maintaining its own copy of that list is guessing at another repo's behaviour — so the check belongs where the fact lives.

## Desired correction

Stage 0, before any stage writes: each declared artifact must be ignored and not already tracked, with the exact remedy in the failure detail.

### One subtlety, verified rather than assumed

A directory artifact keeps its trailing slash in the declaration. `git check-ignore public-local` consults the filesystem to decide whether the path is a directory, so a `public-local/` rule does **not** match while the directory happens to be absent — the same repository reports `ignored` after a build and `not ignored` before one. Confirmed against a fixture repo in both states:

| probe | dir absent | dir present |
|---|---|---|
| `public-local` | NOT-ignored | ignored |
| `public-local/` | ignored | ignored |

The trailing-slash form is matched from the pattern alone, so the verdict describes the repository rather than the moment.

`Done when:` a consumer missing either ignore rule fails the gate locally, naming the line to add.

## Verification

| root | verdict |
|---|---|
| `examples/sample-blog` | pass |
| `examples/sample-shop` | pass |
| `ardent-site` | pass |
| `ardent-tools-site` | **fail** — names both real gaps |

A non-git tree emits `skip` without tainting the run: no work tree means nothing can be committed, so the property holds vacuously. That is absence of the hazard, not absence of an instrument.
