### PR TITLE
docs(ci): stop asserting a port bin/typikon-check no longer uses

### DIFF
--- a/ci/local-base-gate-check.sh
+++ b/ci/local-base-gate-check.sh
@@ -8,17 +8,22 @@
 # WHY: the browser gates (pa11y, playwright) must exercise the commit
 # under test, not the site's live production origin — see #29 for the
 # regression this guards against. bin/typikon-check and the CI templates
-# build a second copy, public-local/, with --base-url http://127.0.0.1:8080
-# for the browser gates to consume; this script proves that copy exists
-# and that its HTML carries no reference to the site's configured
-# production origin.
+# each build a second copy, public-local/, against a loopback base_url for
+# the browser gates to consume; this script proves that copy exists and
+# that its HTML carries no reference to the site's configured production
+# origin.
 #
-# Scoped to *.html, same rationale as ci/csp-enforce.sh: a browser
-# rendering a page only loads what an HTML reference points it at.
-# Non-HTML output (atom.xml, sitemap.xml, robots.txt) can legitimately
-# carry an absolute production URL — an Atom <author><uri> is a portable
-# identifier by convention, not a resource the browser gates fetch — so
-# checking those would flag correct output as a regression.
+# NOTE: the two producers do not agree on the port, and this check does not
+# require them to. bin/typikon-check allocates a free one per run (#51); the
+# CI templates pass a fixed 127.0.0.1:8080. What is asserted here is the
+# absence of the production origin, which holds for either.
+#
+# NOTE: scoped to *.html, same rationale as ci/csp-enforce.sh: a browser
+# rendering a page only loads what an HTML reference points it at. Non-HTML
+# output (atom.xml, sitemap.xml, robots.txt) can legitimately carry an
+# absolute production URL — an Atom <author><uri> is a portable identifier
+# by convention, not a resource the browser gates fetch — so checking those
+# would flag correct output as a regression.
 #
 # Exit:
 #   0  public-local/ exists, contains *.html files, and none of them


### PR DESCRIPTION
## Finding

`ci/local-base-gate-check.sh:10-11` asserted that both producers build `public-local/` the same way:

> `bin/typikon-check and the CI templates build a second copy, public-local/, with --base-url http://127.0.0.1:8080`

That is true of the templates and false of `typikon-check`.

## Evidence

| producer | port | source |
|---|---|---|
| `bin/typikon-check` | allocated free per run | `bin/typikon-check:174` — `LOOPBACK_PORT="$(python3 -c …)"`, and the header at `:44-46` states it outright: "an OS-assigned free port, not a fixed number" |
| `ci/github-workflow.yml.tmpl` | fixed `8080` | `:146` |
| `ci/kanon-ci.toml.tmpl` | fixed `8080` | `:118` |

`typikon-check` stopped using a fixed port in #51. The comment was not updated with it.

## Why this matters

This file exists to prove a build is pointed somewhere specific, so a reader consults its header precisely when reasoning about which origin a gate exercised. A stated port that one of the two producers does not use sends that reader looking for an 8080 that a `typikon-check` run never binds — and the same header is what a consumer reads before wiring their own gate.

The divergence is genuine and harmless: this check asserts the *absence of the production origin*, which holds at any port. Recording that is more useful than forcing the two producers to agree, so the note says so explicitly rather than leaving the next reader to rediscover it as a bug.

## Desired correction

The `WHY` block states the loopback property without naming a port. A `NOTE` records the actual per-producer difference and why the check does not depend on it.

The adjacent `*.html`-scoping paragraph carried no structured tag, which is why it read as narration sitting beside a tagged block — `basanos` permits `WHY / WARNING / NOTE / PERF / SAFETY / INVARIANT / TODO / FIXME` only. Tagged `NOTE`; wording otherwise unchanged.

`Done when:` no comment in this file names a port as shared between the two producers.

## Verification

`bash -n ci/local-base-gate-check.sh` passes. No executable line changed — `git diff` touches only the comment header.

## Provenance

Found while verifying #74, which asked for exactly this file's incident narration to be compressed. That work had already landed in #106 (`fc88f70`) without a closing keyword; #74 is closed separately citing it. This is the adjacent defect that verification surfaced, not a re-fix of #74.
