### PR TITLE
fix(templates): fixture-prove sourced HowTo duration reproduces exactly

### DIFF
--- a/examples/sample-shop/content/sizing-timed.md
+++ b/examples/sample-shop/content/sizing-timed.md
@@ -1,13 +1,15 @@
 +++
-title = "Sizing"
-description = "Sample sizing guide. Exercises required audience, measurement source, product type, and size table metadata."
+title = "Timed Sizing"
+description = "Sample sizing guide with a sourced duration, proving totalTime reproduces the exact supplied value."
 template = "sizing-guide.html"
 
 [extra]
-audience = "sample shop buyers"
+audience = "sample shop buyers timing the decision tree"
 product_type = "widget"
 measurement_unit = "inches"
 measurement_source = "sample fixture measurement table"
+duration = "PT2M"
+duration_source = "operator timed the two-step decision tree during fixture authoring"
 decision_tree = [
   "Measure the space where the widget will sit.",
   "Choose the smallest widget size that is equal to or larger than that measurement.",
@@ -24,4 +26,4 @@ width = "8"
 note = "Fits standard fixture spaces."
 +++
 
-This sample sizing guide proves the sizing-guide schema and template have a concrete fixture with all required metadata populated, and — carrying no `duration` — that an unsourced guide emits no HowTo `totalTime` at all. See `sizing-timed.md` for the sourced case.
+This sample sizing guide proves a sourced `duration` is reproduced exactly as HowTo `totalTime`, complementing `sizing.md`'s proof that an unsourced guide emits no `totalTime` at all.


### PR DESCRIPTION
## Finding

The core defect — `templates/partials/ld-howto.html` hard-coding `"totalTime": "PT2M"` regardless of source — was already fixed on `main` in #107, which made `totalTime` conditional on `page.extra.duration` and added `duration`/`duration_source` to `schemas/sizing-guide.schema.json` with `dependentRequired` enforcing provenance. What #107 did not add is the fixture coverage the issue's "Desired correction" and "Done when" both name explicitly: a fixture proving the *sourced* case reproduces the value exactly. Only the unsourced case existed (`examples/sample-shop/content/sizing.md`, which has never set `duration`).

## Evidence

- `templates/partials/ld-howto.html:28-30` (already on `main`, verified in this worktree): `totalTime` is only emitted `{%- if page.extra.duration is defined and page.extra.duration %}` — no default, no guess.
- `schemas/sizing-guide.schema.json:81-101` (already on `main`): `duration` is pattern-constrained ISO-8601 (`^PT(?=\d)(?:\d+H)?(?:\d+M)?(?:\d+S)?$`), and `dependentRequired` forces `duration` ⇄ `duration_source` together — a duration without a stated source cannot pass schema validation.
- `examples/sample-shop/content/sizing.md:27` (this PR): clarifies its role as the unsourced-case fixture.
- `examples/sample-shop/content/sizing-timed.md` (this PR, new): sourced-case fixture — `duration = "PT2M"`, `duration_source = "operator timed the two-step decision tree during fixture authoring"`.

Rendered JSON-LD from `TYPIKON_CHECK_MODE=dev bin/typikon-check` against `examples/sample-shop` (`public-local/`), HowTo block only:

Unsourced — `public-local/sizing/index.html`:
```json
{
  "@context": "https://schema.org",
  "@type": "HowTo",
  "name": "How to choose your widget size",
  "description": "Sample sizing guide. Exercises required audience, measurement source, product type, and size table metadata.",
  "step": [{
      "@type": "HowToStep",
      "position": 1,
      "text": "Measure the space where the widget will sit."
    },{
      "@type": "HowToStep",
      "position": 2,
      "text": "Choose the smallest widget size that is equal to or larger than that measurement."
    }
  ]
}
```
No `totalTime` key at all.

Sourced — `public-local/sizing-timed/index.html`:
```json
{
  "@context": "https://schema.org",
  "@type": "HowTo",
  "name": "How to choose your widget size",
  "description": "Sample sizing guide with a sourced duration, proving totalTime reproduces the exact supplied value.",
  "totalTime": "PT2M",
  "step": [{
      "@type": "HowToStep",
      "position": 1,
      "text": "Measure the space where the widget will sit."
    },{
      "@type": "HowToStep",
      "position": 2,
      "text": "Choose the smallest widget size that is equal to or larger than that measurement."
    }
  ]
}
```
`totalTime` reproduces the supplied `"PT2M"` exactly, byte-for-byte.

Full gate output, both fixtures, `TYPIKON_CHECK_MODE=dev`:

`examples/sample-shop` (exit 0, 9 routes — up from 8 with the new fixture page):
```
{"stage":"gate-artifacts-ignored","status":"pass",...}
{"stage":"typikon-validate","status":"pass",...}
{"stage":"zola-check","status":"pass",...}
{"stage":"zola-build","status":"pass",...}
{"stage":"zola-build-local","status":"pass",...}
{"stage":"csp-enforce","status":"pass",...}
{"stage":"lychee","status":"pass",...}
{"stage":"pa11y","status":"pass",...}
{"stage":"pa11y-coverage","status":"info","detail":"9 routes"}
{"stage":"playwright-smoke","status":"pass",...}
{"stage":"playwright-coverage","status":"info","detail":"9 checks"}
```

`examples/sample-blog` (exit 0, unaffected — no sizing-guide page in this fixture):
```
{"stage":"gate-artifacts-ignored","status":"pass",...}
{"stage":"typikon-validate","status":"pass",...}
{"stage":"zola-check","status":"pass",...}
{"stage":"zola-build","status":"pass",...}
{"stage":"zola-build-local","status":"pass",...}
{"stage":"csp-enforce","status":"pass",...}
{"stage":"lychee","status":"pass",...}
{"stage":"pa11y","status":"pass",...}
{"stage":"pa11y-coverage","status":"info","detail":"5 routes"}
{"stage":"playwright-smoke","status":"pass",...}
{"stage":"playwright-coverage","status":"info","detail":"5 checks"}
```

## Why this matters

Structured data is a public factual interface. A schema and template that merely *support* provenance-gated duration, with no fixture ever exercising the sourced branch, leaves that branch unverified — a future edit could silently reintroduce a default or break exact reproduction of a supplied value and nothing in CI would catch it. The issue's acceptance criterion is explicit: fixtures for both cases, not just the schema shape.

## Desired correction

Add the sourced-case fixture and keep the unsourced-case fixture, so `typikon-check` exercises both branches of the `totalTime` conditional on every PR via `examples/sample-shop`.

Closes #59
