### PR TITLE
fix(templates): assert FAQ permalink accessible names on the accessibility tree

### DIFF
--- a/ci/smoke/shared.spec.ts
+++ b/ci/smoke/shared.spec.ts
@@ -58,5 +58,36 @@ for (const route of routes) {
     expect(title.trim(), `${route} should have a non-empty <title>`).not.toBe('');
 
     expect(consoleErrors, `${route} should load with no console errors: ${consoleErrors.join('; ')}`).toEqual([]);
+
+    // WHY read the accessibility tree rather than the DOM (forkwright/typikon#61):
+    // an aria-label override on .faq-anchor passed pa11y's WCAG2AA ruleset
+    // while collapsing every question's computed accessible name to one
+    // repeated string. ariaSnapshot() reads what a screen reader actually
+    // gets, so a future aria-label/aria-labelledby regression fails here
+    // regardless of route content. Runs only on routes that render the FAQ
+    // template; a non-FAQ route has zero .faq-anchor elements and the
+    // block is skipped.
+    const faqAnchors = page.locator('.faq-anchor');
+    const faqAnchorCount = await faqAnchors.count();
+    if (faqAnchorCount > 0) {
+      const visibleTexts = await faqAnchors.evaluateAll((elements) =>
+        elements.map((element) => element.textContent?.trim() ?? ''),
+      );
+      const snapshot = await page.locator('.faq-list').ariaSnapshot();
+      const accessibleNames = [...snapshot.matchAll(/-\s*link\s+"([^"]*)"/g)].map((match) => match[1]);
+
+      expect(
+        accessibleNames.length,
+        `${route} FAQ accessibility tree should expose exactly one link per question: ${snapshot}`,
+      ).toBe(faqAnchorCount);
+      expect(
+        accessibleNames,
+        `${route} each FAQ link's computed accessible name should match its own visible question text, in order`,
+      ).toEqual(visibleTexts);
+      expect(
+        new Set(accessibleNames).size,
+        `${route} FAQ link accessible names should be unique within the page: ${JSON.stringify(accessibleNames)}`,
+      ).toBe(accessibleNames.length);
+    }
   });
 }


### PR DESCRIPTION
## Finding

Every FAQ question permalink exposed the same computed accessible name (`"Link to this question"`), overriding the visible question text. Screen-reader users could not distinguish or invoke a specific question link, and the current automated gate (pa11y, WCAG2AA) does not see this class of defect.

## Evidence

`templates/faq.html:39` on `origin/main` already renders:

```html
<a href="#{{ anchor }}" class="faq-anchor">{{ item.q }}</a>
```

with no `aria-label` — this was dropped in an unrelated commit (`fix(templates): close product-schema gap and drop invented HowTo duration`, #107), so the source-level fix predates this PR. What was missing was verification: nothing proved the fix, and nothing would catch a regression, since pa11y's WCAG2AA ruleset does not flag repeated-but-present accessible names.

Confirmed the rendered output directly. `examples/sample-shop/public-local/faq/index.html:127,135`:

```html
<a href="#fixture" class="faq-anchor">What is this fixture for?</a>
<a href="#how-are-anchors-generated" class="faq-anchor">How are anchors generated?</a>
```

Each anchor's accessible name is now its own question text and differs from the other.

`ci/smoke/shared.spec.ts:61-91` adds an accessibility-tree assertion: for any route rendering the FAQ template, it reads `.faq-list`'s `ariaSnapshot()` (Playwright's ARIA/accessibility-tree capture, not DOM text content) and asserts each `.faq-anchor`'s computed accessible name equals its own visible question text, in order, and that all names are unique on the page.

Verified the assertion is load-bearing, not a tautology: reintroduced `aria-label="Link to this question"` locally and reran the full gate.

- `pa11y` stage: **stayed green** — confirms the issue's original claim that the automated a11y gate does not see this class.
- `playwright-smoke` stage: **failed**, with the exact collapsed-name diff:
  ```
  Error: /faq/ each FAQ link's computed accessible name should match its own visible question text, in order
  - Expected  - 2
  + Received  + 2
    Array [
  -   "What is this fixture for?",
  -   "How are anchors generated?",
  +   "Link to this question",
  +   "Link to this question",
    ]
  ```

Reverted the injected regression; `templates/faq.html` diff against `origin/main` is empty (the only tracked change in this PR is the new assertion in `ci/smoke/shared.spec.ts`).

Full-gate verification (`TYPIKON_CHECK_MODE=dev bin/typikon-check`), clean on both sample sites, exit 0 both runs:

```
sample-shop: pa11y pass (8 routes), playwright-smoke pass (8 checks)
sample-blog: pa11y pass (5 routes), playwright-smoke pass (5 checks)
```

`sample-blog` has no FAQ page — the new assertion block is a no-op there (`.faq-anchor` count 0), confirming it does not affect non-FAQ routes.

## Why this matters

Speech-control and screen-reader users rely on a link's computed accessible name to identify and invoke it. A repeated generic name makes every FAQ entry in a screen-reader link list indistinguishable, and WCAG2AA-level automated tooling does not catch it — the only reliable guard is an accessibility-tree assertion, which this PR adds as a mandatory shared smoke check so any future `aria-label`/`aria-labelledby` regression on `.faq-anchor` fails the gate immediately, on any consumer site, on any FAQ content.

## Desired correction

Done in this PR:

- Confirmed `templates/faq.html` already renders each permalink with the visible question as its sole accessible name (no invented frontmatter field, no schema change — `schemas/faq.schema.json` needed no changes).
- Added the accessibility-tree assertion to `ci/smoke/shared.spec.ts` (runs for every typikon consumer via the mandatory shared smoke stage): each FAQ link's computed accessible name matches its own visible question text and is unique within the page.

Closes #61
