### PR TITLE
fix(ci): stop skipping playwright when a consumer ships no smoke specs

### DIFF
--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -214,7 +214,13 @@ jobs:
         # clean over ZERO routes and exits 0 — a gate that passes by testing nothing.
         run: pa11y-ci --config themes/typikon/ci/pa11y.config.js --sitemap http://127.0.0.1:8080/sitemap.xml
       - name: playwright (per-route smoke)
-        if: ${{ hashFiles('tests/smoke/**/*.spec.ts') != '' }}
+        # WARNING: do not gate this step on the consumer having tests/smoke/. It ran
+        # behind `if: hashFiles('tests/smoke/**/*.spec.ts') != ''`, which skipped the
+        # WHOLE step — including typikon's own mandatory ci/smoke/ specs, which always
+        # exist — for every consumer that ships none. The step then reported `skipped`,
+        # which reads as fine. The config's consumer-smoke project tolerates a missing
+        # testDir: bin/typikon-check runs playwright unconditionally and passes against
+        # examples/sample-blog, which has no tests/smoke/ (forkwright/typikon#52).
         # WHY 5: mirrors ci/kanon-ci.toml.tmpl's playwright timeout_secs=300.
         timeout-minutes: 5
         run: |

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -179,15 +179,18 @@ pa11y-ci --config themes/typikon/ci/pa11y.config.js --sitemap http://127.0.0.1:8
 timeout_secs = 300
 
 [stages.playwright]
+# WARNING: do not gate this stage on the consumer having tests/smoke/. It ran behind
+# `if find tests/smoke ... | grep -q .`, which skipped the WHOLE stage — including
+# typikon's own mandatory ci/smoke/ specs, which always exist — for every consumer
+# that ships none, while printing a reassuring "skip playwright" line. The config's
+# consumer-smoke project tolerates a missing testDir: bin/typikon-check runs
+# playwright unconditionally and passes against examples/sample-blog, which has no
+# tests/smoke/ (forkwright/typikon#52).
 cmd = """
 set -euo pipefail
-if find tests/smoke -type f -name '*.spec.ts' | grep -q .; then
-  cp themes/typikon/ci/playwright.config.ts ./playwright.config.ts
-  # WARNING: the config resolves its testDirs from these; it fails closed without them.
-  TYPIKON_ROOT=themes/typikon TYPIKON_CONSUMER_ROOT=. TYPIKON_BASE_URL=http://127.0.0.1:8080 npx playwright test
-else
-  echo "skip playwright: no tests/smoke/**/*.spec.ts files"
-fi
+cp themes/typikon/ci/playwright.config.ts ./playwright.config.ts
+# WARNING: the config resolves its testDirs from these; it fails closed without them.
+TYPIKON_ROOT=themes/typikon TYPIKON_CONSUMER_ROOT=. TYPIKON_BASE_URL=http://127.0.0.1:8080 npx playwright test
 """
 timeout_secs = 300
 


### PR DESCRIPTION
Closes #52

## Finding

Both generated CI templates gated the **entire** playwright step on the *consumer* having smoke specs:

- `ci/github-workflow.yml.tmpl:217` — `if: ${{ hashFiles('tests/smoke/**/*.spec.ts') != '' }}`
- `ci/kanon-ci.toml.tmpl:184` — `if find tests/smoke -type f -name '*.spec.ts' | grep -q .` … `else echo "skip playwright: no tests/smoke/**/*.spec.ts files"`

typikon's own `ci/smoke/` specs are **mandatory and always exist**. The playwright config runs them as a separate project (`typikon-shared-smoke`) from the consumer's optional `consumer-smoke`. Gating on the consumer's directory therefore skipped typikon's mandatory assertions too.

For a consumer with no `tests/smoke/`, the step ran nothing and reported `skipped` — or, in the kanon template, printed a reassuring `skip playwright` line and exited 0.

## Evidence

Neither shipped fixture has a consumer smoke directory:

```
$ ls examples/sample-blog/tests/smoke
(none)
```

So both templates would skip playwright entirely for both fixtures — in the path that gates deploys.

`bin/typikon-check` stopped doing this when #52 was first addressed; its stage 8 comment says so explicitly ("a consumer with no tests/smoke/ used to make this whole stage report skip, so the gate could go green having exercised zero routes"). The templates were not changed with it, so the defect stayed alive where it mattered most.

This is the same shape as the `--sitemap` note two steps above it in the same file: an instrument that passes by examining nothing.

## Desired correction

The guard is removed from both templates, and each carries a `WARNING` naming the bad path so it is not reintroduced as a "skip work when there is none" optimisation.

The `consumer-smoke` project tolerates a missing `testDir` — this is not an assumption:

`ci/run-fixtures.sh` (the exact command CI runs) against this branch:

```
REAL_EXIT=0
19 "status":"pass"   4 "status":"info"   0 fail   0 skip
```

That covers `examples/sample-blog`, which ships no `tests/smoke/`, and its `playwright-smoke` stage **passes** rather than skipping.

`ci/check-workflow-template.sh ci/github-workflow.yml.tmpl` exits 0; both templates parse as valid YAML and TOML respectively.

`Done when:` a consumer with no `tests/smoke/` still has typikon's mandatory specs run in CI. Verified above.

## Consumer follow-up

`ardent-site/.github/workflows/deploy.yml:191` carries the rendered copy of this guard and needs the same removal; that lands separately in its own repo.
