### PR TITLE
fix(ci): give the templates' playwright a config it can load

### DIFF
--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -224,9 +224,21 @@ jobs:
         # WHY 5: mirrors ci/kanon-ci.toml.tmpl's playwright timeout_secs=300.
         timeout-minutes: 5
         run: |
-          cp themes/typikon/ci/playwright.config.ts ./playwright.config.ts
-          # WARNING: the config resolves its testDirs from these; it fails closed without them.
-          TYPIKON_ROOT=themes/typikon TYPIKON_CONSUMER_ROOT=. TYPIKON_BASE_URL=http://127.0.0.1:8080 npx playwright test
+          # WARNING: never write playwright.config.ts into the consumer tree — a
+          # consumer may keep its own (forkwright/typikon#39). mktemp puts it outside,
+          # which is also why TYPIKON_ROOT/TYPIKON_CONSUMER_ROOT must be ABSOLUTE: the
+          # config resolves testDirs from them, and a relative path would resolve
+          # against the config file's directory rather than the workspace.
+          PW_CONFIG="$(mktemp -t typikon-playwright-config.XXXXXX.ts)"
+          cp themes/typikon/ci/playwright.config.ts "$PW_CONFIG"
+          # WARNING: NODE_PATH is what lets a config outside the tree resolve
+          # @playwright/test, which is installed globally by the install step above.
+          # Without it playwright dies with MODULE_NOT_FOUND before running a thing.
+          NODE_PATH="$(npm root -g)" \
+          TYPIKON_ROOT="$GITHUB_WORKSPACE/themes/typikon" \
+          TYPIKON_CONSUMER_ROOT="$GITHUB_WORKSPACE" \
+          TYPIKON_BASE_URL=http://127.0.0.1:8080 \
+            npx playwright test --config "$PW_CONFIG"
 
       - name: Tear down static server
         if: always()

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -188,9 +188,20 @@ timeout_secs = 300
 # tests/smoke/ (forkwright/typikon#52).
 cmd = """
 set -euo pipefail
-cp themes/typikon/ci/playwright.config.ts ./playwright.config.ts
-# WARNING: the config resolves its testDirs from these; it fails closed without them.
-TYPIKON_ROOT=themes/typikon TYPIKON_CONSUMER_ROOT=. TYPIKON_BASE_URL=http://127.0.0.1:8080 npx playwright test
+# WARNING: never write playwright.config.ts into the consumer tree — a consumer may
+# keep its own (forkwright/typikon#39). mktemp puts it outside, which is also why
+# TYPIKON_ROOT/TYPIKON_CONSUMER_ROOT must be ABSOLUTE: the config resolves testDirs
+# from them, and a relative path would resolve against the config file's directory.
+PW_CONFIG="$(mktemp -t typikon-playwright-config.XXXXXX.ts)"
+cp themes/typikon/ci/playwright.config.ts "$PW_CONFIG"
+# WARNING: NODE_PATH is what lets a config outside the tree resolve @playwright/test,
+# installed globally by the install stage. Without it playwright dies with
+# MODULE_NOT_FOUND before running a thing.
+NODE_PATH="$(npm root -g)" \
+TYPIKON_ROOT="$PWD/themes/typikon" \
+TYPIKON_CONSUMER_ROOT="$PWD" \
+TYPIKON_BASE_URL=http://127.0.0.1:8080 \
+  npx playwright test --config "$PW_CONFIG"
 """
 timeout_secs = 300
 


### PR DESCRIPTION
Refs #52, #39

## Finding

#52 removed the `hashFiles('tests/smoke/**/*.spec.ts')` guard that skipped the playwright step. What that uncovered is that **the step could never have worked**.

Both templates install `@playwright/test` **globally** (`npm install -g pa11y-ci @playwright/test`), then copy the config into the consumer tree and run it. A config in the consumer tree cannot resolve a globally-installed module, so playwright dies before running anything:

```
Error: Cannot find module '@playwright/test'
Require stack:
- /home/runner/work/ardent-site/ardent-site/playwright.config.ts
```

`bin/typikon-check` has always set `NODE_PATH="$(npm root -g)"` for exactly this, and says so at `bin/typikon-check` stage 8. The templates never did.

## Why nobody noticed

The guard. Every consumer that shipped no `tests/smoke/` skipped the step entirely, so the broken invocation was never reached. The skip was not merely hiding *missing* coverage — it was hiding a step that would have failed on its first execution.

## Also fixed: the config clobbered the consumer's own

`cp themes/typikon/ci/playwright.config.ts ./playwright.config.ts` overwrites a consumer's own config if it has one. That is #39, and `ardent-tools-site`'s `AGENTS.md` already documents working around it:

> It preserves tracked consumer configuration, including `playwright.config.ts`; the pinned Typikon runner does not, and its owning defect is tracked upstream as typikon#39.

The config now goes to `mktemp` outside the tree, matching what `typikon-check` does and why.

### Which forces the root vars to be absolute

Once the config lives outside the workspace, `TYPIKON_ROOT=themes/typikon` and `TYPIKON_CONSUMER_ROOT=.` are wrong: the config resolves its `testDir`s from them via `path.join`, and a relative result resolves against **the config file's own directory**, not the workspace. That is the same trap `ci/playwright.config.ts:8-12` already documents for `testDir` defaults. Both are now absolute (`$GITHUB_WORKSPACE` / `$PWD`).

## Verification

`ci/check-workflow-template.sh ci/github-workflow.yml.tmpl` exits 0. `ci/kanon-ci.toml.tmpl` parses as valid TOML; `ci/github-workflow.yml.tmpl` as valid YAML.

The real verification is downstream: forkwright/ardent-site#30 carries the identical change to its rendered workflow, and its CI run is the first execution of this step by any consumer. It failed with the `MODULE_NOT_FOUND` above before this fix — that failure is what this PR is derived from.

## Provenance

Found by removing a skip. The chain was: a gate that examined nothing → a guard that hid why → a step that could not load its config.
