### PR TITLE
feat(ci): run the release machinery the repo already declared

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,53 @@
+name: Release Please
+
+# WHY this exists: release-please-config.json and .release-please-manifest.json
+# have been present since the repo was scaffolded, but nothing ran them — so the
+# manifest asserted 0.1.0 while `git tag` returned nothing and CHANGELOG.md carried
+# only an `## Unreleased` section (forkwright/typikon#73). Config without a runner
+# is a version number with nothing behind it.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+# WHY narrower than kanon's: this repo publishes no binaries and signs no
+# artifacts, so it needs neither `attestations: write` nor `id-token: write`.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      # WHY pinned to a SHA: a mutable tag lets the action's behaviour change under
+      # an already-reviewed workflow. Same pin as forkwright/kanon.
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+        id: release
+        continue-on-error: true
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+
+      # NOTE: GitHub's release-create API creates the tag inline when it does not
+      # yet exist, and can 422 with "Published releases must have a valid tag" while
+      # that tag is still propagating server-side. It is a GitHub-side race, not
+      # manifest drift. One retry clears it; a genuine failure still fails the job.
+      # kanon hit this first (kanon#2436) — this is the second copy of the same
+      # workaround in the fleet, so it belongs in a shared reusable workflow rather
+      # than here. Tracked in the PR that introduced this file.
+      - name: Wait for tag propagation before retry
+        if: steps.release.outcome == 'failure'
+        run: sleep 15
+
+      - name: Retry release-please after transient tag-validation race
+        if: steps.release.outcome == 'failure'
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/ci/check-release-config.py
+++ b/ci/check-release-config.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""check-release-config — a one-shot release pin must not outlive its release.
+
+`release-as` in release-please-config.json forces the next release to a specific
+version. It is the right tool for substantiating a version the manifest already
+claims (forkwright/typikon#73 — the manifest asserted 0.1.0 with no tag behind it),
+and a trap afterwards: left in place it pins EVERY subsequent release to the same
+version, and the symptom is a release-please PR that proposes the version already
+released rather than any error.
+
+JSON carries no comments, so the config cannot warn about itself. This check is the
+warning: once a tag exists for the pinned version, the pin has done its job and must
+be removed.
+
+Exit 0 when there is nothing to say, 1 when the pin has outlived its release.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIG = ROOT / "release-please-config.json"
+
+
+def tags() -> set[str]:
+    out = subprocess.run(
+        ["git", "-C", str(ROOT), "tag", "--list"],
+        capture_output=True, text=True, check=False,
+    )
+    return {t.strip() for t in out.stdout.splitlines() if t.strip()}
+
+
+def find_pins(node, path="") -> list[tuple[str, str]]:
+    """Every truthy `release-as` anywhere in the config, with where it was found.
+
+    WHY a walk and not a fixed lookup: release-please accepts `release-as` at the
+    root, per package, and this repo's config also carries a `github.release-as`
+    slot. A check that knew only one location would report "no pin" for a config
+    that pins — the same shape of blindness the pin itself creates.
+    """
+    found: list[tuple[str, str]] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            here = f"{path}[{key!r}]" if path else key
+            if key == "release-as" and value:
+                found.append((path or "<root>", str(value)))
+            else:
+                found.extend(find_pins(value, here))
+    return found
+
+
+def main() -> None:
+    if not CONFIG.exists():
+        print("check-release-config: no release-please-config.json; nothing to check")
+        return
+
+    config = json.loads(CONFIG.read_text(encoding="utf-8"))
+    pins = find_pins(config)
+    if not pins:
+        print("check-release-config: ok (no release-as pin)")
+        return
+
+    existing = tags()
+    problems = []
+    for where, pinned in pins:
+        # release-please tags as `vX.Y.Z` for release-type "simple"; accept either
+        # spelling rather than assuming, since a mismatch here would report a live
+        # pin as expired and let it keep pinning.
+        if pinned in existing or f"v{pinned}" in existing:
+            problems.append(
+                f"{where} pins release-as={pinned!r}, but a tag for it already exists "
+                f"— remove the pin or every later release repeats {pinned}"
+            )
+        else:
+            print(f"check-release-config: {where} pins release-as={pinned!r}, not yet "
+                  f"released — pin is doing its job")
+
+    if problems:
+        for p in problems:
+            print(f"check-release-config: {p}", file=sys.stderr)
+        sys.exit(1)
+    print("check-release-config: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -7,6 +7,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 python3 "$ROOT/ci/check-triad-schema.py"
 python3 "$ROOT/ci/check-font-coverage.py"
+python3 "$ROOT/ci/check-release-config.py"
 "$ROOT/ci/check-workflow-template.sh" "$ROOT/ci/github-workflow.yml.tmpl"
 
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-blog"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
-      "version-file": ".release-please-manifest.json"
+      "release-as": "0.1.0"
     }
   },
   "prerelease": false,


### PR DESCRIPTION
Closes #73

## Finding

`release-please-config.json` and `.release-please-manifest.json` have been present since scaffolding. **Nothing ever ran them** — the only workflow in this repo is `gate-attestation.yml`.

So the manifest asserted `0.1.0` while `git tag` returned nothing and `CHANGELOG.md` carried a single `## Unreleased` section. Config without a runner is a version number with nothing behind it.

`CHANGELOG.md` says so itself, in its own preamble:

> Once release-please automation is wired (RELEASES.md § Required configuration files), version cuts populate this file with dated, tagged sections below `## Unreleased`.

That sentence has been describing a missing workflow, not a future intention.

## Desired correction

`.github/workflows/release-please.yml`, modelled on `forkwright/kanon`'s, narrowed to what this repo needs — no `attestations: write` or `id-token: write`, since typikon publishes no binaries and signs no artifacts. The action is pinned to the same SHA kanon uses.

`release-as: "0.1.0"` pins the first cut, so the version the manifest already claims is the one that gets a tag. Without it release-please would compute `0.2.0` from the `feat:` commits on main, leaving `0.1.0` a number that never existed.

## The pin is a trap, so it is guarded rather than remembered

Left in place after its release, `release-as` pins **every** later release to the same version. The symptom is not an error — it is a release PR proposing a version that was already released. JSON carries no comments, so the config cannot warn about itself.

`ci/check-release-config.py` is that warning: it fails once a tag exists for a pinned version, and it is wired into `ci/run-fixtures.sh`.

**Verified in both directions:**

| state | expected | actual exit |
|---|---|---|
| pin set, no matching tag | 0 | 0 (`pin is doing its job`) |
| pin set, `v0.1.0` tagged | 1 | **1** (names the pin and the consequence) |
| tag removed again | 0 | 0 |

It walks the whole config rather than one known key, because `release-as` is accepted at the root, per package, and in this repo's `github` block. A check that knew only one location would report "no pin" for a config that pins — the same shape of blindness the pin itself creates.

## Also

Drops `version-file` from the package entry. It pointed at `.release-please-manifest.json`, which release-please already tracks through `manifest-file`; for `release-type: simple`, `version-file` designates a plain version file to rewrite.

## Verification

`ci/run-fixtures.sh` — exit 0, **19 pass / 4 info / 0 fail / 0 skip**. Workflow parses as valid YAML, config as valid JSON.

## What lands next

On merge, the workflow runs on `main` and opens a release PR for `v0.1.0`. Per `basanos/standards/RELEASES.md`, a MINOR/PATCH release-please PR is agent-mergeable on green CI with `allow_release_please`. Once tagged, `check-release-config.py` starts failing until the pin is removed — which is exactly the follow-up it exists to force.

## Note on duplication

The transient tag-propagation retry is now the fleet's second copy of the same workaround (kanon#2436 is the first). Two copies means it belongs in a shared reusable workflow in `forkwright/.github` rather than in each repo. Recording that here rather than silently making a third copy later.
