### PR TITLE
chore(ci): retire the release pin now that v0.1.0 is tagged

### DIFF
--- a/ci/check-release-config.py
+++ b/ci/check-release-config.py
@@ -16,6 +16,7 @@ Exit 0 when there is nothing to say, 1 when the pin has outlived its release.
 """
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -24,12 +25,32 @@ ROOT = Path(__file__).resolve().parent.parent
 CONFIG = ROOT / "release-please-config.json"
 
 
+CHANGELOG = ROOT / "CHANGELOG.md"
+
+
 def tags() -> set[str]:
     out = subprocess.run(
         ["git", "-C", str(ROOT), "tag", "--list"],
         capture_output=True, text=True, check=False,
     )
     return {t.strip() for t in out.stdout.splitlines() if t.strip()}
+
+
+def released(version: str) -> bool:
+    """Has `version` actually been released?
+
+    WARNING: do not ask git alone. actions/checkout defaults to fetch-depth 1 and
+    fetches NO tags, so `git tag --list` is empty in CI — this check would pass on
+    every run there while failing locally, which is the blindness it exists to
+    prevent, relocated. The changelog section release-please writes is committed
+    content, so it survives any checkout depth; the tag is the belt to its braces.
+    """
+    if version in tags() or f"v{version}" in tags():
+        return True
+    if CHANGELOG.exists():
+        heading = re.compile(rf"^##\s*\[?{re.escape(version)}\]?", re.M)
+        return bool(heading.search(CHANGELOG.read_text(encoding="utf-8")))
+    return False
 
 
 def find_pins(node, path="") -> list[tuple[str, str]]:
@@ -62,15 +83,11 @@ def main() -> None:
         print("check-release-config: ok (no release-as pin)")
         return
 
-    existing = tags()
     problems = []
     for where, pinned in pins:
-        # release-please tags as `vX.Y.Z` for release-type "simple"; accept either
-        # spelling rather than assuming, since a mismatch here would report a live
-        # pin as expired and let it keep pinning.
-        if pinned in existing or f"v{pinned}" in existing:
+        if released(pinned):
             problems.append(
-                f"{where} pins release-as={pinned!r}, but a tag for it already exists "
+                f"{where} pins release-as={pinned!r}, which has already been released "
                 f"— remove the pin or every later release repeats {pinned}"
             )
         else:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,7 @@
   "release-type": "simple",
   "packages": {
     ".": {
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.0"
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "prerelease": false,


### PR DESCRIPTION
Follow-through on #73 / #126. **`main`'s fixture gate is currently red on purpose** — this clears it.

## The pin did its job

`v0.1.0` is tagged and released, so the version `.release-please-manifest.json` asserted for months now has an artifact behind it. Left in place, `release-as` pins every later release to `0.1.0`, and the symptom is a release PR proposing an already-released version rather than any error.

`ci/check-release-config.py` caught it on `main` unprompted, which is exactly what it was built for:

```
check-release-config: packages['.'] pins release-as='0.1.0', but a tag for it
already exists — remove the pin or every later release repeats 0.1.0
```

## It would have been blind where it mattered

The guard asked git for tags. `actions/checkout` defaults to `fetch-depth: 1` and fetches **no tags**, so `git tag --list` is empty on a runner — the check would have **failed locally and passed in CI**. That is the same blindness the pin creates, relocated rather than removed, in a check written specifically to prevent that shape.

It now also reads the changelog section release-please writes, which is committed content and survives any checkout depth. The tag remains the belt to its braces.

**Verified against a tagless tree** — `git archive` of the tree into a fresh `git init` with zero tags:

```
tagless tree: exit=1
tags visible there: []
```

> The first version of that probe archived `HEAD`, so it tested the *committed* script rather than my edit, and reported exit 0. I nearly concluded the fallback did not work. The result above is from the actual current script.

## Also

The failure message said "a tag for it already exists" when detection may have come from the changelog instead. It now says "which has already been released" — what it actually means.

## Verification

`ci/run-fixtures.sh` — exit 0, **19 pass / 4 info / 0 fail / 0 skip**. `check-release-config.py` exits 0 with `ok (no release-as pin)`.

From here release-please computes versions from conventional commits, as intended.
