### PR TITLE
fix: clear every kanon lint violation in this repo

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -1,3 +1,4 @@
+# kanon:ignore YAML/missing-concurrency -- hybrid-gate.yml declares the group and its own comment forbids callers repeating it; a duplicate self-cancels the shared group
 # WHY(kanon#2522): replaces the standalone trailer-only workflow (waived on
 # `github.actor`, the identity of whoever caused the CURRENT run — flips to a
 # maintainer login on "Re-run failed jobs" and re-arms the trailer check on a

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,15 +15,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-# WHY narrower than kanon's: this repo publishes no binaries and signs no
-# artifacts, so it needs neither `attestations: write` nor `id-token: write`.
+# WHY attestations/id-token are here despite this repo shipping no binaries: the
+# attested subject is the release SOURCE ARCHIVE, not a build output. Consumers pin
+# this theme by submodule SHA, so the source tree IS the artifact they take.
 permissions:
+  attestations: write
   contents: write
+  id-token: write
   pull-requests: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created || steps.release_retry.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name || steps.release_retry.outputs.tag_name }}
     steps:
       # WHY pinned to a SHA: a mutable tag lets the action's behaviour change under
       # an already-reviewed workflow. Same pin as forkwright/kanon.
@@ -47,7 +53,52 @@ jobs:
 
       - name: Retry release-please after transient tag-validation race
         if: steps.release.outcome == 'failure'
+        id: release_retry
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # WHY a second job rather than more steps: it must run only when a release was
+  # actually cut, and the attested archive has to be checked out AT THE TAG — the
+  # first job's tree is whatever main was when it started.
+  attest-release:
+    needs: [release-please]
+    # WARNING: GH-native attestations cannot be persisted for user-owned PRIVATE
+    # repositories; the job 422s there on every cut. typikon is public, so this is
+    # live — the guard keeps it a non-fatal skip if visibility ever flips.
+    if: needs.release-please.outputs.release_created == 'true' && !github.event.repository.private
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Stage source archive
+        id: source
+        run: |
+          archive="typikon-${{ needs.release-please.outputs.tag_name }}.tar.gz"
+          git archive --format=tar.gz --output "$archive" HEAD
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0
+        with:
+          artifact-name: ${{ steps.source.outputs.archive }}.cdx.json
+          format: cyclonedx-json
+          output-file: ${{ steps.source.outputs.archive }}.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest source provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: ${{ steps.source.outputs.archive }}
+
+      - name: Attest CycloneDX SBOM
+        uses: actions/attest-sbom@5026d3663739160db546203eeaffa6aa1c51a4d6 # v1
+        with:
+          subject-path: ${{ steps.source.outputs.archive }}
+          sbom-path: ${{ steps.source.outputs.archive }}.cdx.json

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Optimized for agentic operation. Humans should not need to develop here. The sub
 - **CI** (`ci/`) - strict gate: build, CSP enforcement, internal + external link integrity, a11y, smoke. No pass = no deploy.
 - **Headers** (`_headers.tmpl`, `_redirects.tmpl`) - Cloudflare Pages strict-CSP + redirect templates.
 
-## Sovereignty
+## Visitor runtime
 
 - Self-hosted WOFF2 fonts; zero external CDN dependencies at visitor runtime.
 - Strict CSP with no `unsafe-inline` anywhere. Inline scripts and styles are CI failures.

--- a/ci/check-release-config.py
+++ b/ci/check-release-config.py
@@ -92,7 +92,7 @@ def main() -> None:
             )
         else:
             print(f"check-release-config: {where} pins release-as={pinned!r}, not yet "
-                  f"released — pin is doing its job")
+                  "released — pin is doing its job")
 
     if problems:
         for p in problems:

--- a/ci/local-base-gate-check.sh
+++ b/ci/local-base-gate-check.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+# WARNING: -e matters here. Every failure path in this script exits explicitly and
+# the script ends in `exit 0`, so without it an UNEXPECTED command failure — a
+# missing grep, an unreadable path — falls through to that `exit 0` and the gate
+# reports pass on its own internal error. Sibling scripts (csp-enforce.sh,
+# run-fixtures.sh) already set it; bin/typikon-check deliberately does not, because
+# it accumulates per-stage verdicts instead of exiting at the first failure.
+
 # local-base-gate-check — prove the browser-based gates (pa11y, playwright)
 # are pointed at a loopback build, not the site's production origin.
 #
@@ -31,8 +40,6 @@
 #   1  regression: public-local/ missing/empty, or its HTML leaks the
 #      production origin
 #   2  invocation error
-
-set -uo pipefail
 
 usage() {
     echo "usage: ci/local-base-gate-check.sh <consumer-site-root>" >&2

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -95,8 +95,8 @@ When a schema field is renamed, removed, or changed incompatibly, the typikon PR
 The PR description must list every consumer affected and link the migration runs.
 
 **Adding a required field is the exception, and it is deliberate.** A rename or a
-removal is a transformation of data that already exists, so a script can perform it.
-A new required field asks for information the consumer has never recorded, and no
+removal is a transformation of content that already exists, so a script can perform it.
+A new required field asks for a value the consumer has never recorded, and no
 script can supply it.
 
 That matters most for the provenance fields — `words_source`, `price_source`,
@@ -117,7 +117,7 @@ it blocks.
 
 ### 8. Check the push authority before pushing
 
-`origin` is GitHub (`forkwright/typikon`). No forge remote is configured and there is no mirror step, so a push to `origin` is a push to GitHub. Check with `git remote -v` rather than assuming either shape — this repo previously documented a forge-primary topology it did not have.
+`origin` is GitHub (`forkwright/typikon`). No forge remote is configured and there is no mirror step, so a push to `origin` is a push to GitHub. Check with `git remote -v` instead of assuming either shape.
 
 Whether the fleet returns to a forge-primary split is an open question that forkwright/kanon#3045 owns.
 


### PR DESCRIPTION
A standards sweep with `kanon lint`. **8 open violations → 0**, plus one suppression carrying its reason.

Each hit was read before it was changed. Two were not what the rule first suggested.

## The gate reported pass on its own errors

`ci/local-base-gate-check.sh` set `-uo pipefail`, not `-euo`. Every failure path in it exits explicitly and the script ends in `exit 0` — so an *unexpected* command failure (a missing binary, an unreadable path) fell straight through to that `exit 0`. A gate that green-lights on its own internal error.

Verified both directions rather than assumed:

| case | expected | actual |
|---|---|---|
| valid root | 0 | 0 |
| no args / two args / bad root | 2 | 2 |
| **injected production-origin leak** | **1** | **1** |

The `[[ $# -ne 1 ]] && usage` line is the classic `set -e` trap; bash exempts non-final commands in a `&&` list, and the arg cases above confirm it empirically.

`bin/typikon-check` deliberately keeps `-uo` — it accumulates per-stage verdicts instead of stopping at the first failure. The `WARNING` records which script does which and why.

## My earlier reasoning about attestation was wrong

`.github/workflows/release-please.yml` carried no attestation, and I had written that this repo "publishes no binaries and signs no artifacts, so it needs neither `attestations: write` nor `id-token: write`."

That is the wrong subject. kanon attests a release **source archive** plus a CycloneDX SBOM — not a build output. Consumers pin this theme **by submodule SHA**, so the source tree *is* the artifact they take.

Adds an `attest-release` job on kanon's exact pattern (checkout at the tag, `git archive`, anchore SBOM, `attest-build-provenance` + `attest-sbom`), the `outputs` the job needs, an `id` on the retry step so those outputs resolve on the retry path, and the permissions it genuinely requires.

## One suppression, not a change

`gate-attestation.yml` has no `concurrency` group **on purpose** — `hybrid-gate.yml` declares it and its own comment forbids callers repeating it, or the shared group self-cancels. Suppressed inline with that reason. "Fixing" it would introduce the bug the existing comment warns about.

## The remainder

| file | rule | what it was |
|---|---|---|
| `ci/check-release-config.py:95` | `PYTHON/empty-fstring` | `f"…"` continuation with nothing to interpolate — mine, from earlier today |
| `README.md:19` | `WRITING/identity-fluff` | `## Sovereignty` → `## Visitor runtime`, naming what the section constrains |
| `docs/AGENTIC.md` | `WRITING/elegant-variation` | content → data → information → content cycling in one section |
| `docs/AGENTIC.md:120` | `WRITING/weasel-word` | also dropped "this repo previously documented a forge-primary topology it did not have" — a living surface narrating its own past |

## Verification

```
kanon lint projects/typikon   ->  No open violations.  (1 suppressed, with reason)
ci/run-fixtures.sh            ->  REAL_EXIT=0, 19 pass / 4 info / 0 fail / 0 skip
```
