### PR TITLE
docs: rewrite history-narrating comments as timeless constraints

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -51,8 +51,8 @@
 # epistole's own workflow falls back to a `::warning::` when the token is
 # absent rather than actually running it. `kanon lint` therefore stays
 # forge-only in practice (AGENTS.md: "CI gate on forge runs kanon lint +
-# fixtures") for both the old and the new GH workflow — not a coverage
-# regression from this migration, but a known, pre-existing gap.
+# fixtures"), so the GH gate does not cover it. A known gap, not an
+# oversight.
 #
 # WHY a push trigger and not just pull_request: a squash merge does not
 # carry the source commits' trailers, so no commit on main has a

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,10 +1,9 @@
 name: Release Please
 
 # WHY this exists: release-please-config.json and .release-please-manifest.json
-# have been present since the repo was scaffolded, but nothing ran them — so the
-# manifest asserted 0.1.0 while `git tag` returned nothing and CHANGELOG.md carried
-# only an `## Unreleased` section (forkwright/typikon#73). Config without a runner
-# is a version number with nothing behind it.
+# declare intent only — without a workflow that runs them, the manifest can
+# assert a version that no tag, GitHub release, or CHANGELOG entry backs
+# (forkwright/typikon#73).
 
 on:
   push:
@@ -44,9 +43,8 @@ jobs:
       # yet exist, and can 422 with "Published releases must have a valid tag" while
       # that tag is still propagating server-side. It is a GitHub-side race, not
       # manifest drift. One retry clears it; a genuine failure still fails the job.
-      # kanon hit this first (kanon#2436) — this is the second copy of the same
-      # workaround in the fleet, so it belongs in a shared reusable workflow rather
-      # than here. Tracked in the PR that introduced this file.
+      # This retry belongs in a shared reusable workflow, not duplicated per-repo
+      # (see kanon#2436).
       - name: Wait for tag propagation before retry
         if: steps.release.outcome == 'failure'
         run: sleep 15

--- a/bin/typikon-check
+++ b/bin/typikon-check
@@ -108,12 +108,10 @@ regex_escape() {
 run_stage() {
     local stage="$1"; shift
     local start=$(date +%s%3N)
-    # WHY both streams into one log: stdout used to go to /dev/null, so a
-    # failure pointed the reader at a file that held only stderr. zola, pa11y-ci
-    # and playwright all report their actual diagnostics on STDOUT, so the log
-    # named by the failure was routinely empty for exactly the stages hardest to
-    # diagnose. One combined file also preserves interleaving, which a split
-    # pair cannot.
+    # WHY both streams go to one log: zola, pa11y-ci, and playwright all
+    # report their actual diagnostics on STDOUT, so a failure log must
+    # capture stdout to be useful. One combined file also preserves
+    # interleaving, which separate stdout/stderr files cannot.
     if "$@" >"$LOGDIR/$stage.log" 2>&1; then
         local end=$(date +%s%3N)
         emit "$stage" "pass" "$((end - start))" "ok"
@@ -335,9 +333,7 @@ if command -v pa11y-ci >/dev/null 2>&1; then
             # WARNING: --directory, not `cd X && python3 ...`. A `cd X && cmd &` list
             # runs in a background SUBSHELL, so $! is the subshell and the server is
             # its child — `kill "$!"` then reaps the wrapper and leaves the server
-            # holding the port. Verified: a leaked http.server was found still bound
-            # to 8080, reparented to init, serving a directory that no longer existed.
-            # With --directory there is no list, so $! IS the server.
+            # holding the port. With --directory there is no list, so $! IS the server.
             python3 -m http.server --directory public-local "$LOOPBACK_PORT" >"$LOGDIR/server.log" 2>&1 &
             SRV_PID=$!
             if wait_for_ready "$SRV_PID" "$LOOPBACK_PORT" "/$SENTINEL_FILE" 10; then
@@ -361,11 +357,11 @@ else
 fi
 
 # Stage 8 — Playwright smoke tests. ci/smoke/ ships mandatory shared
-# semantic assertions that always run (forkwright/typikon#52 — a consumer
-# with no tests/smoke/ used to make this whole stage report skip, so the
-# gate could go green having exercised zero routes); the consumer's own
-# tests/smoke/ runs alongside as an addition, never a substitute. Serves
-# public-local/ (see stage 4) for the same reason as pa11y above.
+# semantic assertions that always run (forkwright/typikon#52): this stage
+# must never report skip merely because a consumer ships no tests/smoke/,
+# or the gate could go green having exercised zero routes. The consumer's
+# own tests/smoke/ runs alongside as an addition, never a substitute.
+# Serves public-local/ (see stage 4) for the same reason as pa11y above.
 if command -v npx >/dev/null 2>&1; then
     if [[ -d public-local ]]; then
         # WARNING: never write to $ROOT/playwright.config.ts — a consumer may

--- a/ci/check-font-coverage.py
+++ b/ci/check-font-coverage.py
@@ -1,17 +1,14 @@
 #!/usr/bin/env python3
 """check-font-coverage — CSS unicode-range must be derived from the bytes.
 
-WHY: fonts.css declared full Greek (U+0370-03FF) and Greek Extended
-(U+1F00-1FFF) coverage for Cormorant Garamond and Spectral, but the
-shipped WOFF2 cmaps carry only a handful of Greek letters used as
-math/science symbols (upstream masters, not a subsetting mistake --
-verified by pulling CatharsisFonts/Cormorant and productiontype/Spectral
-directly and finding the same gap in the un-subsetted originals). Real
-Greek text fell back to the visitor's system font glyph-by-glyph while
-the CSS asserted self-hosted coverage. This script treats the shipped
+WHY: a declared unicode-range is a claim about the shipped font, not a fact
+about it — an upstream font master can omit codepoints inside a range a
+CSS unicode-range asserts as covered (e.g. Greek letters present only as
+math/science symbols), and when that happens matching text silently falls
+back to the visitor's system font while the CSS still asserts self-hosted
+coverage (forkwright/typikon#35). This script treats the shipped WOFF2
 cmap as the single source of truth and fails if a declared unicode-range
-codepoint is not actually present in the font it is declared on -- the
-exact class of drift that produced forkwright/typikon#35. Control
+codepoint is not actually present in the font it is declared on. Control
 characters (Unicode category Cc) are excluded: no font maps a glyph to
 them and no browser ever requests one, so their absence from cmap is not
 a coverage gap.

--- a/ci/check-triad-schema.py
+++ b/ci/check-triad-schema.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 """check-triad-schema — regression test for extra.triad cardinality."""
 
-# WHY: schemas/section.schema.json used to validate `greek` and `english`
-# independently at 2-4 items with no equal-cardinality constraint.
-# templates/index.html indexes english[loop.index0] for every greek entry,
-# and static/js/triad.js + the .triad-1/.triad-2/.triad-3 CSS rules are
-# hard-coded for exactly three terms. A schema-valid mismatched-cardinality
-# fixture (e.g. 4 greek / 2 english) passed bin/typikon-validate and then
-# failed Zola's render with an out-of-bounds index. Fixed by pinning both
-# arrays to minItems=maxItems=3. This script proves the fixture that used
-# to slip through validation is now rejected at the schema boundary, and
+# WHY: templates/index.html indexes english[loop.index0] for every greek
+# entry, and static/js/triad.js + the .triad-1/.triad-2/.triad-3 CSS rules
+# are hard-coded for exactly three terms. schemas/section.schema.json must
+# therefore constrain both greek and english to minItems=maxItems=3 — a
+# schema that validated them independently would admit a mismatched-
+# cardinality fixture that passes bin/typikon-validate and then fails
+# Zola's render with an out-of-bounds index. This script proves a
+# mismatched-cardinality fixture is rejected at the schema boundary, and
 # that a valid three-term triad still passes.
 #
 # NOTE: runs standalone (no consumer site needed) as part of ci/run-fixtures.sh.

--- a/ci/check-workflow-template.sh
+++ b/ci/check-workflow-template.sh
@@ -4,13 +4,14 @@ set -euo pipefail
 # hardening in ci/github-workflow.yml.tmpl.
 #
 # WHY: this template is copied verbatim into every typikon-consuming site's
-# .github/workflows/deploy.yml. A prior version shipped without a
-# concurrency group, without a least-privilege permissions block, with
-# actions/checkout and actions/setup-node pinned to a mutable major-version
-# tag instead of a commit SHA, and without persist-credentials: false on
-# checkout — every consumer inherited the gap. typikon's own
-# .github/workflows/gate-attestation.yml already follows this hardening
-# pattern; this script proves the consumer template matches it.
+# .github/workflows/deploy.yml, so any gap here becomes a gap in every
+# consumer. It must always carry: a top-level concurrency group (so
+# overlapping pushes queue rather than race), a least-privilege top-level
+# permissions block, persist-credentials: false on checkout, and every
+# actions/* reference pinned to a commit SHA rather than a mutable
+# major-version tag. typikon's own .github/workflows/gate-attestation.yml
+# follows this same hardening pattern; this script proves the consumer
+# template matches it.
 #
 # Usage:
 #     ci/check-workflow-template.sh <path-to-template>
@@ -38,12 +39,10 @@ grep -qE '^\s*persist-credentials:\s*false' "$TMPL" || fail "no persist-credenti
 # Every `uses: owner/repo@REF` must pin REF to a 40-char commit SHA, not a
 # mutable tag/branch. A trailing `# vX` comment naming the human-readable
 # version is fine and expected.
-# WARNING: this loop must see EVERY `uses:` line, and must FAIL on a form it
-# cannot classify rather than skip it. The previous version selected lines with
-# a pattern requiring exactly `owner/repo@ref`, so any other shape matched
-# nothing and was never pin-checked — silently. `owner/repo/subdir@ref` is a
-# real and common action shape (a composite action in a subdirectory), and it
-# fell straight through the check that exists to catch it.
+# WARNING: this loop must see EVERY `uses:` line and classify it, including
+# `owner/repo/subdir@ref` (a composite action in a subdirectory — a real and
+# common shape). A `uses:` line the classifier cannot match must FAIL rather
+# than be silently skipped, or an unrecognized shape passes unpinned.
 while IFS= read -r line; do
     spec="$(printf '%s' "$line" \
         | sed -E 's/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*//' \

--- a/ci/smoke/shared.spec.ts
+++ b/ci/smoke/shared.spec.ts
@@ -1,11 +1,10 @@
 // Shared semantic smoke assertions for every typikon-consuming site.
 //
-// WHY these run regardless of consumer specs (forkwright/typikon#52): a
-// consumer with no tests/smoke/*.spec.ts previously made the whole
-// playwright-smoke stage report skip, so the browser gate could go green
-// having exercised zero routes. This file always exists, so the stage
-// always has at least this coverage; consumers add to it, they cannot
-// subtract from it (typikon-check does not let a consumer file replace it).
+// WHY these run regardless of consumer specs (forkwright/typikon#52): the
+// browser gate must never report a verdict having exercised zero routes.
+// This file always exists, so the stage always carries at least this
+// coverage; consumers add to it and cannot subtract from it — typikon-check
+// does not let a consumer file replace it.
 //
 // WHY the route list comes from public-local/sitemap.xml rather than a
 // hand-maintained list here: sitemap.xml is Zola's own generated manifest

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -37,7 +37,7 @@
   --bg-accent: #F0EBE0;   /* shadow on rag paper */
   --text: #1C1917;
   --text-mid: #44403C;
-  --text-light: #6B6661;  /* tightened from #78716C to satisfy WCAG 2.1 AA contrast (4.5:1) on the archival-paper bg */
+  --text-light: #6B6661;  /* INVARIANT: must satisfy WCAG 2.1 AA contrast (4.5:1) against --bg */
   --rule: #D6D3CD;
   
   /* Default brand accents — ardent's iron-mordanted botanical dye palette.


### PR DESCRIPTION
## Finding

Ten comments across six files carried history/migration narration ("used to", "a prior version", "the previous version", "Verified: ... was found", "have been present since the repo was scaffolded") alongside the engineering constraint they were protecting, violating kanon STANDARDS.md "## Comments" (no migration notes, no "was previously" narration, only WHY/WARNING/NOTE/PERF/SAFETY/INVARIANT/TODO/FIXME tags; a timeless constraint note is fine, a before/after story is not).

## Evidence

- `static/css/style.css:40` — `--text-light` comment stated the prior hex value it was "tightened from".
- `bin/typikon-check:111` — `run_stage` comment narrated that stdout "used to go to /dev/null".
- `bin/typikon-check:338` — pa11y server comment included a "Verified: a leaked http.server was found still bound to 8080..." anecdote.
- `bin/typikon-check:365` — Stage 8 comment said a consumer with no `tests/smoke/` "used to make this whole stage report skip".
- `ci/check-triad-schema.py:4-13` — WHY block was a full before/after migration note ("used to validate... independently", "the fixture that used to slip through").
- `ci/check-workflow-template.sh:7` — WHY block said "A prior version shipped without a concurrency group...".
- `ci/check-workflow-template.sh:42` — WARNING said "The previous version selected lines with a pattern requiring exactly `owner/repo@ref`...".
- `ci/check-font-coverage.py:4` — WHY narrated the forkwright/typikon#35 investigation (which fonts were pulled, what was verified) at length.
- `.github/workflows/release-please.yml:3` — comment said the config files "have been present since the repo was scaffolded, but nothing ran them".
- `.github/workflows/release-please.yml:48` — NOTE said "kanon hit this first (kanon#2436) — this is the second copy of the same workaround in the fleet... Tracked in the PR that introduced this file."

## Why this matters

A comment that narrates what used to be true stops being useful the moment nobody remembers the "before" state — it reads as trivia rather than a constraint, and a future editor has no way to tell whether the old behavior is still possible to reintroduce. The kanon comment standard requires comments to state what must hold now (and why), not what happened once; git log and issue history already own the "what happened" record.

## Desired correction

Each site is rewritten to state the timeless invariant or mechanism directly, with the real engineering reasoning kept intact (WCAG contrast ratio, why both streams share one log file, why `--directory` prevents a subshell PID mismatch, why `ci/smoke/` must never report skip, why the triad schema pins both arrays to exactly 3 items, what the consumer workflow template must always carry, why the `uses:` classifier must FAIL rather than skip an unrecognized form, why a declared unicode-range must match the shipped cmap, why release-please needs a runner, and why the tag-propagation retry belongs in a shared workflow). Issue references (`#52`, `#35`, `#73`, `kanon#2436`) are kept as pointers; the narration of what those issues' bugs did is removed.

Verified locally: `bash -n` on both shell files, `python3 -c "import ast..."` on both Python files, `python3 -c "import yaml..."` on the workflow, and `ci/run-fixtures.sh` — full gate, exit 0, all stages pass, no fail/skip.