### PR TITLE
docs: drop deprecated terminology from the coverage check's rationale

### DIFF
--- a/ci/check-font-coverage.py
+++ b/ci/check-font-coverage.py
@@ -2,7 +2,7 @@
 """check-font-coverage — CSS unicode-range must be derived from the bytes.
 
 WHY: a declared unicode-range is a claim about the shipped font, not a fact
-about it — an upstream font master can omit codepoints inside a range a
+about it — an upstream font file can omit codepoints inside a range a
 CSS unicode-range asserts as covered (e.g. Greek letters present only as
 math/science symbols), and when that happens matching text silently falls
 back to the visitor's system font while the CSS still asserts self-hosted


### PR DESCRIPTION
## Finding

`kanon lint` reports `STANDARDS/deprecated-term` at `ci/check-font-coverage.py:5`. The word is used in its font-typography sense ("an upstream font master"), which is why it read as unremarkable — but the rule does not carve that out, and the sentence loses nothing without it.

This appeared in the de-narration pass (#131): the rewritten rationale moved the term into the scanned region. Caught on the post-merge lint rather than before it, which is the honest sequence.

## Desired correction

`an upstream font master` → `an upstream font file`. Same meaning, and it is arguably the clearer phrase — the check reads bytes out of a shipped WOFF2, not a design source.

## Verification

```
python3 -c "import ast; ast.parse(...)"        -> parses
python3 ci/check-font-coverage.py              -> exit 0
kanon lint projects/typikon                    -> No open violations. (1 suppressed, with reason)
```

That returns this repository to zero open violations.
