### PR TITLE
fix(templates): stop emitting comment text ahead of the XML declaration

### DIFF
--- a/ci/check-xml-output.sh
+++ b/ci/check-xml-output.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-xml-output — the built XML feeds must be well-formed and start at byte zero.
+#
+# WHY this exists as its own stage: every other gate stage reads HTML. sitemap.xml and
+# atom.xml are rendered by Tera templates whose output nothing parsed, so a template
+# could emit text ahead of the XML declaration and the whole gate stayed green — the
+# feed is served, indexed, and rejected by strict consumers with no local signal.
+#
+# WARNING: byte zero is the load-bearing part, not just well-formedness. A leading
+# blank line or stray character makes the declaration non-first, which several XML
+# parsers reject outright even though the rest of the document is valid.
+#
+# Usage:
+#     ci/check-xml-output.sh <built-output-dir>
+
+usage() {
+    echo "usage: ci/check-xml-output.sh <built-output-dir>" >&2
+    exit 2
+}
+
+[[ $# -ne 1 ]] && usage
+OUT="$(realpath "$1")"
+[[ -d "$OUT" ]] || { echo "error: $OUT is not a directory" >&2; exit 2; }
+
+FAIL=0
+CHECKED=0
+
+for name in sitemap.xml atom.xml; do
+    path="$OUT/$name"
+    [[ -f "$path" ]] || continue
+    CHECKED=$((CHECKED + 1))
+    if ! python3 - "$path" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+path = sys.argv[1]
+raw = open(path, "rb").read()
+declaration = b'<?xml version="1.0" encoding="UTF-8"?>'
+if not raw.startswith(declaration):
+    head = raw[:60].decode("utf-8", "replace").replace("\n", "\\n")
+    print(f"{path}: XML declaration is not at byte zero; file begins {head!r}", file=sys.stderr)
+    sys.exit(1)
+try:
+    ET.parse(path)
+except ET.ParseError as exc:
+    print(f"{path}: strict XML parse failed: {exc}", file=sys.stderr)
+    sys.exit(1)
+PY
+    then
+        FAIL=1
+    fi
+done
+
+if [[ "$CHECKED" -eq 0 ]]; then
+    echo "check-xml-output: no sitemap.xml or atom.xml under $OUT" >&2
+    exit 1
+fi
+
+[[ "$FAIL" -eq 0 ]] || exit 1
+echo "check-xml-output: ok ($CHECKED file(s) well-formed, declaration at byte zero)"

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -18,3 +18,9 @@ python3 "$ROOT/ci/check-release-config.py"
 # this a meaningful check — see ci/local-base-gate-check.sh.
 "$ROOT/ci/local-base-gate-check.sh" "$ROOT/examples/sample-blog"
 "$ROOT/ci/local-base-gate-check.sh" "$ROOT/examples/sample-shop"
+
+# The XML feeds are the only built output no other stage parses. Checked against
+# public/ (the production build) rather than public-local/, since that is what
+# consumers deploy.
+"$ROOT/ci/check-xml-output.sh" "$ROOT/examples/sample-blog/public"
+"$ROOT/ci/check-xml-output.sh" "$ROOT/examples/sample-shop/public"

--- a/templates/sitemap.xml
+++ b/templates/sitemap.xml
@@ -1,12 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
 {# Sitemap override. Filters out pages with extra.skip_sitemap = true so
    /404/ and /thanks/ (or any other transient utility page) don't get
    indexed. Zola's built-in sitemap doesn't support per-page exclusion.
 
-   NOTE: the comment must close with `-#}` (not `#}`) — Tera strips the
-   comment body but not the trailing newline, so a bare `#}` here emits a
-   blank line before the XML declaration and breaks strict XML parsers.
--#}
-<?xml version="1.0" encoding="UTF-8"?>
+   WARNING: the XML declaration stays on line 1, ahead of this comment. A
+   leading comment leaves a newline the trimming close does not reliably
+   remove, and a declaration that is not at byte zero is rejected outright by
+   strict parsers even when the rest of the document is valid.
+
+   WARNING: never write a comment-closing delimiter inside this comment, even
+   as an example in prose. Tera ends the comment at the first one it sees and
+   emits everything after it as literal text. ci/check-xml-output.sh is what
+   catches both mistakes. #}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {%- for sitemap_entry in entries %}
     {%- if not sitemap_entry.extra or not sitemap_entry.extra.skip_sitemap %}


### PR DESCRIPTION
## Finding

`templates/sitemap.xml` shipped a sitemap that **fails strict XML parse** in both fixtures.

The comment at the top explained that the closing delimiter must be the whitespace-trimming form — and wrote the untrimmed form inline as the counter-example. Tera ends a comment at the **first** closing delimiter it sees. So the comment terminated inside its own explanation, and the remaining words were emitted as literal text ahead of the XML declaration.

The comment documenting the rule was the thing violating it.

## Evidence

Built output, before:

```
$ head -c 40 examples/sample-blog/public/sitemap.xml | od -c
0000000   `       (   n   o   t       `   #   }   `   )     342 200 224
0000020       T   e   r   a       s   t   r   i   p   s       t   h   e
```

```
sample-blog/sitemap.xml: byte-zero=False  strict-parse=FAILED: not well-formed (invalid token): line 1, column 0
sample-shop/sitemap.xml: byte-zero=False  strict-parse=FAILED: not well-formed (invalid token): line 1, column 0
```

**`ci/run-fixtures.sh` reported 19 stages passing over this**, because no stage parsed the XML it had just built. Every consumer inherits the template, so every consumer's sitemap was malformed.

## Why moving the declaration, rather than fixing the delimiter

Fixing only the inner delimiter left this:

```
0000000  \n   <   ?   x   m   l       v   e   r   s   i   o   n   =   "
```

A leading newline the trimming close did not remove — still not byte zero, still rejected. So there were **two** independent ways to lose byte zero, and only one was documented.

The declaration now sits on line 1 with the comment beneath it. That shape has no way to grow a prefix.

## The missing instrument

`ci/check-xml-output.sh` parses `sitemap.xml` and `atom.xml` and requires the declaration at byte zero, wired into `ci/run-fixtures.sh` for both fixtures.

**Proved load-bearing against the real defect** before the fix:

```
exit=1
sitemap.xml: XML declaration is not at byte zero; file begins '` (not `#}`) — Tera strips the\n   comment body but not the'
```

and after:

```
check-xml-output: ok (2 file(s) well-formed, declaration at byte zero)
```

## Verification

`ci/run-fixtures.sh` → `REAL_EXIT=0`, **19 pass / 4 info / 0 fail / 0 skip**, with the new stage reporting for both fixtures.

All four built feeds confirmed directly:

| file | byte-zero | strict parse |
|---|---|---|
| `sample-blog/sitemap.xml` | ✅ | ok |
| `sample-blog/atom.xml` | ✅ | ok |
| `sample-shop/sitemap.xml` | ✅ | ok |
| `sample-shop/atom.xml` | ✅ | ok |

## How it surfaced

`ardent-tools-site` shadows `sitemap.xml` specifically to force the declaration to byte zero (typikon#38), and its `bin/validate-site.py` asserts that. Deleting the shadow as redundant during a submodule bump is what exposed the upstream breakage — the consumer's own guard caught what this repo's gate did not.
