### PR TITLE
docs: state the push topology this repo actually has

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,8 @@ All CLIs are idempotent; JSONL output for parsing.
 2. Validate: `cd <consumer-site> && themes/typikon/bin/typikon-check .` (every stage passes).
 3. Run the theme gate locally: `cd <typikon> && ci/run-fixtures.sh` (validates typikon's own fixtures).
 4. Commit with conventional commit (type: feat/fix/chore/docs). No inline scripts/styles. No unsafe-inline CSP.
-5. Push to origin (forge is primary). CI gate on forge runs kanon lint + fixtures.
+5. Push to origin (GitHub). The gate is .github/workflows/gate-attestation.yml; no forge
+   remote is configured, so the `.kanon-ci.toml` lint stage does not execute anywhere.
 
 ### Consumer site updates
 
@@ -60,7 +61,8 @@ All decisions are in [CLAUDE.md](CLAUDE.md) under "Locked decisions". Key ones:
 
 ## Boundaries
 
-- **Push to origin (forge), not github.** Git remote verify: `git remote -v`.
+- **Push to origin, which is GitHub.** There is no forge remote and no mirror step.
+  Verify with `git remote -v` rather than assuming either shape.
 - **Never bypass the CI gate.** No `--no-verify`, no `[skip ci]`, no commit on green failure.
 - **Schema changes are migrations.** When a schema changes incompatibly, ship a migration script in `bin/`.
 - **Schemas and primitives change in typikon, not in consumers.** When two consumer sites disagree on a primitive, parameterize the schema here; do not fork the theme.

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -149,7 +149,7 @@ For a routine content edit:
 2. edit the markdown body              # frontmatter is already correct
 3. typikon-validate <site-root>        # exits 0 = good
 4. typikon-check <site-root>           # exits 0 = ready to push
-5. git commit + git push origin main   # forge primary, mirror to GH
+5. git commit + git push origin main
 6. CI re-runs the gate; deploys on green
 ```
 


### PR DESCRIPTION
## Finding

`AGENTS.md` directs an agent to push to a forge remote that does not exist, and asserts that forge CI runs the gate.

```
AGENTS.md:41  5. Push to origin (forge is primary). CI gate on forge runs kanon lint + fixtures.
AGENTS.md:63  - **Push to origin (forge), not github.** Git remote verify: `git remote -v`.
```

```
$ git remote -v
origin  https://github.com/forkwright/typikon.git (fetch)
```

Line 63 instructs verifying with the exact command that disproves line 63.

## Why this one matters more than a stale sentence

The repo already contains the correct answer twice — `CLAUDE.md:52` and `:66`, and `docs/AGENTIC.md:120`. So it holds both answers, and which one an agent acts on depends on which file it opens first. `AGENTS.md` is the file most agent harnesses load by default.

The second claim compounds it: "CI gate on forge runs kanon lint + fixtures" tells a reader that lint is enforced somewhere. It is not. `.kanon-ci.toml` declares a lint stage, no forge remote exists to fire the post-receive hook, and `gate-attestation.yml:44-53` documents that `kanon lint` has no GitHub-hosted path. The stage executes **nowhere** — which is the same gap forkwright/kanon#3151 is about, seen from the consumer side.

## Desired correction

Both lines state the real topology and name the gate that actually runs. `docs/AGENTIC.md:152`'s scaffolding walkthrough carried the same `# forge primary, mirror to GH` trailer thirty lines after its own correction on line 120; dropped.

## Verification

`kanon lint projects/typikon` → **No open violations.**
`ci/run-fixtures.sh` → `REAL_EXIT=0`, 19 pass / 4 info / 0 fail / 0 skip.

## Provenance

This was ranked the top item of an adversarially-verified sweep of the four web repositories and then not acted on in that pass — surfaced again when the operator asked whether any standard had been dropped. It had.
