### PR TITLE
feat(ci): fail the gate on an undeclared C2PA manifest in a shipped asset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ typikon/
 ├── schemas/                # JSON Schema per content type
 ├── scaffolds/              # reserved, currently empty — typikon-init scaffolds content inline
 ├── bin/                    # typikon-init, typikon-validate, typikon-check, typikon-refresh, typikon-migrate-template
-├── ci/                     # strict gate config (lychee, pa11y, playwright, csp-enforce)
+├── ci/                     # strict gate config (lychee, pa11y, playwright, csp-enforce, asset-provenance)
 ├── docs/                   # AGENTIC.md, SCHEMAS.md, BOOTSTRAP.md
 ├── _headers.tmpl           # Cloudflare Pages strict-CSP
 ├── _redirects.tmpl         # Cloudflare Pages redirects

--- a/bin/typikon-check
+++ b/bin/typikon-check
@@ -16,7 +16,7 @@
 #     3. zola build              clean build with no warnings, output public/
 #     4. zola build (local base) rebuild to public-local/ with a loopback
 #                                 base_url — the copy browser gates serve
-#     5. csp-enforce             grep public/ for inline script/style/on*= handlers
+#     5. csp-enforce             parse public/ HTML for inline script/style/on*= handlers
 #     6. asset-provenance        parse public/ image containers (PNG/JPEG/SVG) for
 #                                 an embedded C2PA manifest undeclared in config.toml
 #     7. lychee                  external link integrity (requires lychee binary)

--- a/bin/typikon-check
+++ b/bin/typikon-check
@@ -17,10 +17,12 @@
 #     4. zola build (local base) rebuild to public-local/ with a loopback
 #                                 base_url — the copy browser gates serve
 #     5. csp-enforce             grep public/ for inline script/style/on*= handlers
-#     6. lychee                  external link integrity (requires lychee binary)
-#     7. pa11y                   WCAG 2.1 AA accessibility across every route in
+#     6. asset-provenance        parse public/ image containers (PNG/JPEG/SVG) for
+#                                 an embedded C2PA manifest undeclared in config.toml
+#     7. lychee                  external link integrity (requires lychee binary)
+#     8. pa11y                   WCAG 2.1 AA accessibility across every route in
 #                                 the build's own sitemap.xml (requires pa11y-ci)
-#     8. playwright              per-route smoke assertions: this repo's mandatory
+#     9. playwright              per-route smoke assertions: this repo's mandatory
 #                                 ci/smoke/ specs, plus the consumer's tests/smoke/
 #                                 if it has any (requires npx)
 #
@@ -299,7 +301,16 @@ else
     require_or_skip "csp-enforce" "no public/ dir (zola-build did not run)"
 fi
 
-# Stage 6 — external links via lychee. Skip if binary absent.
+# Stage 6 — asset provenance against built public/. No prerequisite tool
+# (stdlib-only container parsing), so this stage is never eligible for
+# require_or_skip — a missing dependency can't excuse it in either mode.
+if [[ -d public ]]; then
+    run_stage "asset-provenance" "$TYPIKON_ROOT/ci/asset-provenance.sh" "$ROOT" || FAIL=1
+else
+    require_or_skip "asset-provenance" "no public/ dir (zola-build did not run)"
+fi
+
+# Stage 7 — external links via lychee. Skip if binary absent.
 if command -v lychee >/dev/null 2>&1; then
     if [[ -d public ]]; then
         BASE_HOST="$(base_host)"
@@ -320,7 +331,7 @@ else
     require_or_skip "lychee" "lychee binary not on PATH (install: cargo install lychee or curl release)"
 fi
 
-# Stage 7 — pa11y a11y. Requires public-local/ (built with a loopback
+# Stage 8 — pa11y a11y. Requires public-local/ (built with a loopback
 # base_url — see stage 4) to be served; we spin up a quick http.server in
 # the background. Route corpus is derived from the build's own generated
 # sitemap.xml, not a hand-maintained list — an empty or missing sitemap
@@ -356,7 +367,7 @@ else
     require_or_skip "pa11y" "pa11y-ci not on PATH (install: npm i -g pa11y-ci)"
 fi
 
-# Stage 8 — Playwright smoke tests. ci/smoke/ ships mandatory shared
+# Stage 9 — Playwright smoke tests. ci/smoke/ ships mandatory shared
 # semantic assertions that always run (forkwright/typikon#52): this stage
 # must never report skip merely because a consumer ships no tests/smoke/,
 # or the gate could go green having exercised zero routes. The consumer's

--- a/bin/typikon-init
+++ b/bin/typikon-init
@@ -203,6 +203,12 @@ nav_items = []
 
 # Footer link list. Each item: { url, label, rel? }.
 footer_links = []
+
+# Declared exceptions for the asset-provenance gate stage (glob paths,
+# matched against each asset's URL under /). Leave unset to fail the gate
+# on any embedded C2PA manifest; declare a path here only for an asset
+# whose Content Credentials this site deliberately keeps.
+# c2pa_declared_assets = ["/img/photography/*.jpg"]
 EOF
 )
 "

--- a/ci/asset-provenance-scan.py
+++ b/ci/asset-provenance-scan.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""asset-provenance-scan — container-aware C2PA/JUMBF manifest detector.
+
+Parses PNG chunks, JPEG segments, and SVG XML with real container/format
+readers instead of a literal byte search for "c2pa" — the same rationale
+csp-scan.py already established for CSP, applied one layer down (see
+ci/csp-enforce.sh header). A literal-string search on these three formats
+both false-positives (the token in an SVG <!-- comment -->, which an XML
+parser never surfaces as an element) and false-negatives (a JUMBF label
+field carrying no human-readable text, or a manifest split byte-wise
+across multiple JPEG APP11 marker segments with no single contiguous
+run of the string anywhere in the file).
+
+Detection is gated on presence in the exact channel each container format
+reserves for embedding a JUMBF box (PNG's `caBX` ancillary chunk, JPEG's
+APP11 marker segments carrying a `JP` common identifier, SVG's namespaced
+<c2pa:manifest> element) — not on successfully decoding the manifest's
+internal structure. A channel carrying bytes is already the positive
+signal regardless of whether those bytes parse further, which is what
+keeps this fail-closed against a still-valid manifest whose internals
+this stdlib-only parser cannot fully walk (INVARIANT below).
+
+INVARIANT: a manifest's true issuer lives inside an X.509 certificate
+embedded in a COSE-signed claim several JUMBF box levels deeper, CBOR/
+ASN.1-encoded — outside stdlib reach without a new dependency (forbidden
+by forkwright/typikon#137). The JUMBF description box's optional `label`
+field is the deepest identifying string this parser can reach; it is
+reported as-is and never fabricated when absent.
+
+Usage:
+    ci/asset-provenance-scan.py --public-root <dir> --config <config.toml> <file> [<file> ...]
+
+Exit:
+    0  no undeclared manifests found
+    1  undeclared manifest(s) found (each printed to stderr as
+       "<path>: <CONTAINER>: undeclared C2PA manifest present (label=<label-or-unknown>)")
+    2  invocation error (config.toml's extra.c2pa_declared_assets is present
+       but not a list of strings)
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import fnmatch
+import sys
+import tomllib
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+PNG_SIGNATURE = bytes((0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A))
+JPEG_SOI = b"\xff\xd8"
+_JPEG_NO_LENGTH_MARKERS = frozenset({0x01, *range(0xD0, 0xDA)})  # TEM, RSTn, SOI, EOI
+_JPEG_SOS = 0xDA
+_JPEG_APP11 = 0xEB
+_JUMBF_APP11_CI = b"JP"  # ISO/IEC 19566-5 Annex B common identifier for a JUMBF box segment
+
+CONTAINER_DISPLAY = {"png": "PNG", "jpeg": "JPEG", "svg": "SVG"}
+
+
+def iter_jumbf_boxes(data: bytes):
+    """Yield (box_type, payload) for each top-level ISO-base-media-style box in data.
+
+    NOTE: JUMBF reuses the ISO/IEC 14496-12 box framing (4-byte length,
+    4-byte type, with a 1-extended 8-byte length for boxes over 4GiB).
+    Malformed input degrades to "yield nothing" rather than raising, since
+    a channel already carrying bytes is the detection signal (see module
+    docstring) — this walk only enriches with a label, never gates.
+    """
+    pos = 0
+    end = len(data)
+    while pos + 8 <= end:
+        length = int.from_bytes(data[pos : pos + 4], "big")
+        box_type = data[pos + 4 : pos + 8]
+        header_len = 8
+        if length == 1:
+            if pos + 16 > end:
+                return
+            length = int.from_bytes(data[pos + 8 : pos + 16], "big")
+            header_len = 16
+        box_end = end if length == 0 else pos + length
+        if box_end <= pos or box_end > end:
+            return
+        yield box_type, data[pos + header_len : box_end]
+        pos = box_end
+
+
+def parse_jumd_label(payload: bytes) -> str | None:
+    """Extract the optional human-readable label from a JUMBF Description Box payload.
+
+    Layout (ISO/IEC 19566-5 5.2): 16-byte UUID, 1-byte toggles, then an
+    ASCII/UTF-8 NUL-terminated label if the label-present bit (0x02) is set.
+    """
+    if len(payload) < 17:
+        return None
+    toggles = payload[16]
+    if not toggles & 0x02:
+        return None
+    body = payload[17:]
+    terminator = body.find(b"\x00")
+    if terminator == -1:
+        return None
+    return body[:terminator].decode("utf-8", errors="replace") or None
+
+
+def extract_manifest_label(blob: bytes) -> str | None:
+    """Best-effort label for the manifest store, falling back to its first nested manifest box."""
+    for box_type, payload in iter_jumbf_boxes(blob):
+        if box_type != b"jumb":
+            continue
+        children = list(iter_jumbf_boxes(payload))
+        if not children or children[0][0] != b"jumd":
+            continue
+        label = parse_jumd_label(children[0][1])
+        if label:
+            return label
+        for child_type, child_payload in children[1:]:
+            if child_type != b"jumb":
+                continue
+            grandchildren = list(iter_jumbf_boxes(child_payload))
+            if grandchildren and grandchildren[0][0] == b"jumd":
+                inner_label = parse_jumd_label(grandchildren[0][1])
+                if inner_label:
+                    return inner_label
+        return None
+    return None
+
+
+def extract_png_manifest(data: bytes) -> bytes | None:
+    """Return the caBX chunk's raw payload, or None if no caBX chunk is present.
+
+    caBX is the ancillary PNG chunk type the C2PA spec reserves for embedding
+    a JUMBF manifest store — its presence is the channel-level signal, walked
+    chunk-by-chunk rather than searched for as a byte pattern.
+    """
+    if not data.startswith(PNG_SIGNATURE):
+        return None
+    pos = len(PNG_SIGNATURE)
+    end = len(data)
+    while pos + 8 <= end:
+        length = int.from_bytes(data[pos : pos + 4], "big")
+        chunk_type = data[pos + 4 : pos + 8]
+        data_start = pos + 8
+        data_end = data_start + length
+        if data_end + 4 > end:
+            return None  # truncated chunk
+        if chunk_type == b"caBX":
+            return data[data_start:data_end]
+        pos = data_end + 4  # skip the trailing CRC
+    return None
+
+
+def extract_jpeg_manifest(data: bytes) -> bytes | None:
+    """Reassemble a JUMBF blob from APP11 marker segments, in packet-sequence order.
+
+    A manifest larger than one APP11 payload (64KiB max, per JPEG's 16-bit
+    segment length) is split across multiple segments sharing a box-instance
+    number (En) and ordered by packet-sequence number (Z) — this is the
+    exact shape ci/asset-provenance.sh's header names as a grep-defeating
+    false negative. Segments are grouped by En and concatenated by Z before
+    anything downstream sees a single contiguous blob.
+    """
+    if not data.startswith(JPEG_SOI):
+        return None
+    pos = len(JPEG_SOI)
+    end = len(data)
+    packets: dict[int, dict[int, bytes]] = {}
+    while pos + 2 <= end:
+        if data[pos] != 0xFF:
+            pos += 1
+            continue
+        marker = data[pos + 1]
+        if marker == 0xFF:
+            pos += 1  # fill byte before the real marker
+            continue
+        if marker in _JPEG_NO_LENGTH_MARKERS:
+            pos += 2
+            continue
+        if marker == _JPEG_SOS:
+            break  # entropy-coded scan data follows; APP11 only appears in the header
+        if pos + 4 > end:
+            break
+        seg_len = int.from_bytes(data[pos + 2 : pos + 4], "big")
+        if seg_len < 2:
+            break  # malformed: length field must include itself
+        seg_start = pos + 4
+        seg_end = pos + 2 + seg_len
+        if seg_end > end:
+            break
+        if marker == _JPEG_APP11:
+            payload = data[seg_start:seg_end]
+            if len(payload) >= 8 and payload[:2] == _JUMBF_APP11_CI:
+                box_instance = int.from_bytes(payload[2:4], "big")
+                sequence = int.from_bytes(payload[4:8], "big")
+                packets.setdefault(box_instance, {})[sequence] = payload[8:]
+        pos = seg_end
+    for instance_packets in packets.values():
+        blob = b"".join(instance_packets[z] for z in sorted(instance_packets))
+        if blob:
+            return blob
+    return None
+
+
+def extract_svg_manifest(data: bytes) -> bytes | None:
+    """Base64-decode the text content of any element in a c2pa-* XML namespace.
+
+    XML-parsed, so a `c2pa` substring inside a <!-- comment --> is never
+    surfaced as an element — ElementTree's default parsing exposes only
+    elements, attributes, and text, never comments.
+    """
+    try:
+        root = ET.fromstring(data)
+    except ET.ParseError:
+        return None
+    for elem in root.iter():
+        tag = elem.tag
+        if not isinstance(tag, str) or "}" not in tag:
+            continue
+        namespace = tag[1:].split("}", 1)[0]
+        if "c2pa" not in namespace.lower():
+            continue
+        # WHY split()+join() rather than strip(): a pretty-printed manifest
+        # element commonly wraps its base64 body across lines; only the
+        # interior whitespace collapsing (not just the edges) keeps that
+        # a valid decode instead of a spurious "empty" or malformed read.
+        text = "".join((elem.text or "").split())
+        if not text:
+            continue
+        try:
+            blob = base64.b64decode(text, validate=False)
+        except (binascii.Error, ValueError):
+            continue
+        if blob:
+            return blob
+    return None
+
+
+_EXTRACTORS = {
+    "png": extract_png_manifest,
+    "jpeg": extract_jpeg_manifest,
+    "svg": extract_svg_manifest,
+}
+
+
+def classify_container(path: Path) -> str | None:
+    suffix = path.suffix.lower()
+    if suffix == ".png":
+        return "png"
+    if suffix in (".jpg", ".jpeg"):
+        return "jpeg"
+    if suffix == ".svg":
+        return "svg"
+    return None
+
+
+def scan_file(path: Path) -> tuple[str, str | None] | None:
+    """Return (container, label) if path carries an embedded manifest, else None."""
+    container = classify_container(path)
+    extractor = _EXTRACTORS.get(container) if container else None
+    if extractor is None:
+        return None
+    blob = extractor(path.read_bytes())
+    if blob is None:
+        return None
+    try:
+        label = extract_manifest_label(blob)
+    except Exception:
+        # SAFETY: label extraction is enrichment, never the detection gate
+        # (see module docstring INVARIANT) — a malformed inner box tree
+        # must not suppress an already-established manifest finding.
+        label = None
+    return container, label
+
+
+def load_declared_globs(config_path: Path) -> list[str]:
+    """Read extra.c2pa_declared_assets from a consumer's config.toml.
+
+    Absence of the file or the key means no declarations (empty list) —
+    not every consumer opts into Content Credentials. A present-but-
+    malformed value is a config authoring bug and fails closed rather
+    than being silently ignored.
+    """
+    if not config_path.exists():
+        return []
+    with config_path.open("rb") as fh:
+        config = tomllib.load(fh)
+    declared = config.get("extra", {}).get("c2pa_declared_assets", [])
+    if not isinstance(declared, list) or not all(isinstance(item, str) for item in declared):
+        raise ValueError(
+            f"{config_path}: extra.c2pa_declared_assets must be a list of strings, got {declared!r}"
+        )
+    return declared
+
+
+def is_declared(public_relative_path: str, globs: list[str]) -> bool:
+    # WHY fnmatchcase, not fnmatch: fnmatch normalizes case per the host OS
+    # (case-insensitive on Windows), which would make a declaration's match
+    # set depend on which OS ran the gate. The gate must agree with itself
+    # across GitHub Actions runners and a contributor's own machine.
+    return any(fnmatch.fnmatchcase(public_relative_path, glob) for glob in globs)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--public-root", required=True, type=Path)
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("files", nargs="+", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        declared_globs = load_declared_globs(args.config)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    public_root = args.public_root.resolve()
+    violations = 0
+    declared_hits = 0
+    for file in args.files:
+        found = scan_file(file)
+        if found is None:
+            continue
+        container, label = found
+        try:
+            rel = "/" + file.resolve().relative_to(public_root).as_posix()
+        except ValueError:
+            rel = str(file)
+        if is_declared(rel, declared_globs):
+            declared_hits += 1
+            continue
+        violations += 1
+        print(
+            f"{file}: {CONTAINER_DISPLAY[container]}: undeclared C2PA manifest present "
+            f"(label={label or 'unknown'})",
+            file=sys.stderr,
+        )
+
+    if declared_hits:
+        print(
+            f"note: {declared_hits} declared C2PA manifest(s) allowed by extra.c2pa_declared_assets",
+            file=sys.stderr,
+        )
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/ci/asset-provenance-scan.py
+++ b/ci/asset-provenance-scan.py
@@ -133,6 +133,19 @@ def extract_png_manifest(data: bytes) -> bytes | None:
     caBX is the ancillary PNG chunk type the C2PA spec reserves for embedding
     a JUMBF manifest store — its presence is the channel-level signal, walked
     chunk-by-chunk rather than searched for as a byte pattern.
+
+    INVARIANT: an earlier chunk's declared length lying about its own extent
+    must not end the scan (module docstring, lines 14-21) — only that one
+    chunk's framing is corrupt, not the rest of the file. This is the
+    detection gate itself, not enrichment (unlike iter_jumbf_boxes below), so
+    a chunk this walk cannot trust must not read as "no manifest": on an
+    untrustworthy length it resyncs on the literal `caBX` chunk-type token in
+    the unread remainder instead of returning. That token is a fixed,
+    unobfuscatable part of PNG's byte grammar — it cannot occur without
+    wrapping an actual chunk header — so finding it is a complete check for
+    a caBX chunk's presence in the region the corrupt length made
+    unreachable by normal in-order walking, not the same class of heuristic
+    text search the module docstring rules out for human-readable content.
     """
     if not data.startswith(PNG_SIGNATURE):
         return None
@@ -143,12 +156,42 @@ def extract_png_manifest(data: bytes) -> bytes | None:
         chunk_type = data[pos + 4 : pos + 8]
         data_start = pos + 8
         data_end = data_start + length
-        if data_end + 4 > end:
-            return None  # truncated chunk
+        length_untrustworthy = data_end < data_start or data_end + 4 > end
         if chunk_type == b"caBX":
+            if length_untrustworthy:
+                # WARNING: this caBX chunk's own declared length lies too --
+                # still the positive detection signal (INVARIANT above), so
+                # return the available bytes rather than nothing.
+                return data[data_start:end]
             return data[data_start:data_end]
+        if length_untrustworthy:
+            return _resync_png_cabx(data, data_start, end)
         pos = data_end + 4  # skip the trailing CRC
     return None
+
+
+def _resync_png_cabx(data: bytes, search_from: int, end: int) -> bytes | None:
+    """Recover a caBX chunk's payload after an earlier chunk's length lied.
+
+    Locates the literal `caBX` token, then reads the 4 bytes immediately
+    preceding it as that chunk's own length field — chunk type always
+    follows length with no gap, so if the token marks a genuine header,
+    those ARE its length bytes. Self-consistent against the buffer -> exact
+    payload. Otherwise this chunk's length is untrustworthy too, so the
+    remainder from the token onward is returned as a best-effort payload
+    rather than None: an unverifiable chunk is not the same as an absent
+    one (see extract_png_manifest's INVARIANT).
+    """
+    marker = data.find(b"caBX", search_from)
+    if marker == -1:
+        return None
+    data_start = marker + 4
+    if marker >= 4:
+        length = int.from_bytes(data[marker - 4 : marker], "big")
+        data_end = data_start + length
+        if data_start <= data_end <= end:
+            return data[data_start:data_end]
+    return data[data_start:end]
 
 
 def extract_jpeg_manifest(data: bytes) -> bytes | None:

--- a/ci/asset-provenance.sh
+++ b/ci/asset-provenance.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# asset-provenance — fail closed on undeclared third-party provenance metadata
+# in shipped image assets.
+#
+# Usage:
+#     ci/asset-provenance.sh <consumer-site-root>
+#
+# Walks every .png/.jpg/.jpeg/.svg under <root>/public for an embedded C2PA
+# (JUMBF) provenance manifest, using real container parsing rather than a
+# byte search for "c2pa" — see ci/asset-provenance-scan.py for why: that
+# search both false-positives (the token inside an SVG comment) and
+# false-negatives (a JUMBF label that carries no contiguous ASCII, or a
+# manifest split across multiple JPEG APP11 segments).
+#
+# Takes the consumer-site root, not the built public/ dir directly (unlike
+# csp-enforce.sh), because declaring intended provenance reads the
+# consumer's own config.toml — a stray third-party manifest and a site's
+# deliberate Content Credentials both parse identically; only the
+# consumer's declaration tells them apart.
+#
+# A found manifest on a path the consumer has NOT listed in config.toml's
+# `extra.c2pa_declared_assets` glob list fails the build, naming the
+# offending path, the container, and the manifest's label where the
+# manifest carries one (its cryptographic issuer is not recoverable
+# without a COSE/X.509 parser — see the scanner's module docstring).
+#
+# Exit:
+#   0  no undeclared manifests found
+#   1  undeclared manifest(s) found (printed with path + container + label)
+#   2  invocation error
+
+usage() {
+    echo "usage: ci/asset-provenance.sh <consumer-site-root>" >&2
+    exit 2
+}
+
+[[ $# -ne 1 ]] && usage
+ROOT="$(realpath "$1")"
+[[ -d "$ROOT" ]] || { echo "error: $ROOT is not a directory" >&2; exit 2; }
+
+PUBLIC="$ROOT/public"
+[[ -d "$PUBLIC" ]] || { echo "error: $PUBLIC is not a directory (zola build did not run)" >&2; exit 2; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mapfile -t FILES < <(find "$PUBLIC" -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.svg' \))
+
+[[ ${#FILES[@]} -eq 0 ]] && {
+    echo "warn: no .png/.jpg/.jpeg/.svg files under $PUBLIC" >&2
+    exit 0
+}
+
+SCAN_ERR="$(mktemp)"
+trap 'rm -f "$SCAN_ERR"' EXIT
+
+status=0
+python3 "$SCRIPT_DIR/asset-provenance-scan.py" \
+    --public-root "$PUBLIC" \
+    --config "$ROOT/config.toml" \
+    "${FILES[@]}" 2>"$SCAN_ERR" || status=$?
+
+if [[ $status -eq 2 ]]; then
+    cat "$SCAN_ERR" >&2
+    exit 2
+elif [[ $status -eq 1 ]]; then
+    VIOLATIONS=$(grep -c 'undeclared C2PA manifest present' "$SCAN_ERR" || true)
+    echo "asset-provenance: undeclared manifest(s) found:" >&2
+    cat "$SCAN_ERR" >&2
+    echo "" >&2
+    echo "asset-provenance: $VIOLATIONS asset(s) carry undeclared provenance metadata." >&2
+    echo "Fix by stripping the manifest from the asset, or declaring it in config.toml:" >&2
+    echo '    [extra]' >&2
+    echo '    c2pa_declared_assets = ["/img/your-asset.jpg"]' >&2
+    exit 1
+fi
+
+cat "$SCAN_ERR" >&2  # any declared-manifest notes
+echo "asset-provenance: ok (${#FILES[@]} image/svg files scanned, 0 undeclared manifests)"
+exit 0

--- a/ci/check-asset-provenance.py
+++ b/ci/check-asset-provenance.py
@@ -40,13 +40,14 @@ THEME_ROOT = Path(__file__).resolve().parent.parent
 STAGE = THEME_ROOT / "ci" / "asset-provenance.sh"
 
 LABEL_PNG = "acme-imaging-suite:png-manifest"
+LABEL_PNG_LYING_LENGTH = "acme-imaging-suite:png-lying-length"
 LABEL_JPEG_SINGLE = "acme-imaging-suite:jpeg-single-segment"
 LABEL_JPEG_SPLIT = "acme-imaging-suite:jpeg-split-segment"
 LABEL_SVG = "acme-imaging-suite:svg-manifest"
 LABEL_DECLARED = "acme-imaging-suite:declared"
 
 # INVARIANT: none of these labels contain "c2pa" — see module docstring.
-for _label in (LABEL_PNG, LABEL_JPEG_SINGLE, LABEL_JPEG_SPLIT, LABEL_SVG, LABEL_DECLARED):
+for _label in (LABEL_PNG, LABEL_PNG_LYING_LENGTH, LABEL_JPEG_SINGLE, LABEL_JPEG_SPLIT, LABEL_SVG, LABEL_DECLARED):
     assert "c2pa" not in _label
 
 
@@ -87,6 +88,30 @@ def build_png(manifest_label: str | None) -> bytes:
         chunks.append(png_chunk(b"caBX", manifest_store(manifest_label)))
     chunks.append(png_chunk(b"IDAT", zlib.compress(b"\x00\x00\x00\x00\x00")))
     chunks.append(png_chunk(b"IEND", b""))
+    return PNG_SIGNATURE + b"".join(chunks)
+
+
+def build_png_with_lying_chunk(manifest_label: str) -> bytes:
+    """A caBX manifest preceded by a private chunk whose declared length overflows past EOF.
+
+    Regression fixture for the chunk-length-overflow bypass: a corrupt
+    chunk's untrustworthy length must not end the scan before a genuine
+    caBX chunk that follows it (forkwright/typikon#137 gate defect).
+    """
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0)  # 1x1 RGBA
+    # WHY no payload/CRC on this chunk: the declared length (0xFFFFFFF0)
+    # overflows the file's actual remaining bytes by construction, and the
+    # genuine caBX header begins immediately after this chunk's 8-byte
+    # frame -- exactly the shape a naive walker that trusts the declared
+    # length to skip to the next chunk cannot reach.
+    lying_chunk = struct.pack(">I", 0xFFFFFFF0) + b"zzZz"
+    chunks = [
+        png_chunk(b"IHDR", ihdr),
+        lying_chunk,
+        png_chunk(b"caBX", manifest_store(manifest_label)),
+        png_chunk(b"IDAT", zlib.compress(b"\x00\x00\x00\x00\x00")),
+        png_chunk(b"IEND", b""),
+    ]
     return PNG_SIGNATURE + b"".join(chunks)
 
 
@@ -160,6 +185,7 @@ def main() -> int:
         fixtures = {
             "clean.png": build_png(None),
             "manifest.png": build_png(LABEL_PNG),
+            "manifest-lying-chunk.png": build_png_with_lying_chunk(LABEL_PNG_LYING_LENGTH),
             "clean.jpg": build_jpeg(b""),
             "manifest-single.jpg": jpeg_single_segment(LABEL_JPEG_SINGLE),
             "manifest-split.jpg": jpeg_split_segments(LABEL_JPEG_SPLIT),
@@ -176,7 +202,7 @@ def main() -> int:
         # containing "c2pa" (that's what the parse keys on), so a grep would
         # already find a real SVG manifest; SVG's false-positive case (a
         # mention inside a comment, not a real manifest) is checked below.
-        for undetectable in ("manifest.png", "manifest-single.jpg", "manifest-split.jpg"):
+        for undetectable in ("manifest.png", "manifest-lying-chunk.png", "manifest-single.jpg", "manifest-split.jpg"):
             if b"c2pa" in fixtures[undetectable]:
                 failures.append(f"fixture bug: {undetectable} contains literal 'c2pa' — invalidates the false-negative proof")
         if b"c2pa" not in fixtures["clean.svg"]:
@@ -196,6 +222,7 @@ def main() -> int:
 
         expected_violations = {
             "manifest.png": f"PNG: undeclared C2PA manifest present (label={LABEL_PNG})",
+            "manifest-lying-chunk.png": f"PNG: undeclared C2PA manifest present (label={LABEL_PNG_LYING_LENGTH})",
             "manifest-single.jpg": f"JPEG: undeclared C2PA manifest present (label={LABEL_JPEG_SINGLE})",
             "manifest-split.jpg": f"JPEG: undeclared C2PA manifest present (label={LABEL_JPEG_SPLIT})",
             "manifest.svg": f"SVG: undeclared C2PA manifest present (label={LABEL_SVG})",

--- a/ci/check-asset-provenance.py
+++ b/ci/check-asset-provenance.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""check-asset-provenance — regression test for ci/asset-provenance.sh.
+
+Constructs synthetic PNG, JPEG, and SVG fixtures byte-for-byte in Python
+(no external encoder) and runs the real stage script against them, proving
+end to end (not just the inner scanner module) that:
+
+- a manifest embedded via each container's real C2PA channel fails the
+  gate and the failure names the path, the container, and the label;
+- an asset with no manifest passes;
+- an asset whose manifest the consumer declared in config.toml passes;
+- a JPEG manifest split across two APP11 segments is reassembled and
+  still detected (forkwright/typikon#137's named JPEG case).
+
+The PNG and JPEG manifest fixtures' labels are deliberately chosen to
+contain no "c2pa" substring anywhere in their bytes, so a would-be
+`grep -r c2pa` on those exact fixtures would find NOTHING — proof the
+container parse catches what a literal byte search misses, per this
+issue's own evidence (SVG is exempt: its real embedding channel is an
+`xmlns:c2pa=...` declaration, so a grep on a genuine SVG manifest WOULD
+match; SVG's false-positive case — "c2pa" appearing only inside an XML
+comment, never a real manifest — is what clean.svg proves instead).
+
+NOTE: runs standalone (no consumer site or zola build needed) as part of
+ci/run-fixtures.sh.
+"""
+
+from __future__ import annotations
+
+import base64
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import zlib
+from pathlib import Path
+
+THEME_ROOT = Path(__file__).resolve().parent.parent
+STAGE = THEME_ROOT / "ci" / "asset-provenance.sh"
+
+LABEL_PNG = "acme-imaging-suite:png-manifest"
+LABEL_JPEG_SINGLE = "acme-imaging-suite:jpeg-single-segment"
+LABEL_JPEG_SPLIT = "acme-imaging-suite:jpeg-split-segment"
+LABEL_SVG = "acme-imaging-suite:svg-manifest"
+LABEL_DECLARED = "acme-imaging-suite:declared"
+
+# INVARIANT: none of these labels contain "c2pa" — see module docstring.
+for _label in (LABEL_PNG, LABEL_JPEG_SINGLE, LABEL_JPEG_SPLIT, LABEL_SVG, LABEL_DECLARED):
+    assert "c2pa" not in _label
+
+
+# --- JUMBF construction (mirrors ci/asset-provenance-scan.py's reader) -----
+
+
+def jumbf_box(box_type: bytes, payload: bytes) -> bytes:
+    return struct.pack(">I", 8 + len(payload)) + box_type + payload
+
+
+def jumd_payload(label: str) -> bytes:
+    uuid_placeholder = bytes(range(16))  # detection is channel-gated, not UUID-gated
+    toggles = 0x02  # label-present
+    return uuid_placeholder + bytes((toggles,)) + label.encode("utf-8") + b"\x00"
+
+
+def manifest_store(label: str) -> bytes:
+    return jumbf_box(b"jumb", jumbf_box(b"jumd", jumd_payload(label)))
+
+
+# --- PNG ---------------------------------------------------------------
+
+
+PNG_SIGNATURE = bytes((0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A))
+
+
+def png_chunk(chunk_type: bytes, data: bytes) -> bytes:
+    # NOTE: CRC correctness is irrelevant to the scanner (it never verifies
+    # it), but computing it for real keeps the fixture a valid PNG for any
+    # other tool that might inspect it.
+    return struct.pack(">I", len(data)) + chunk_type + data + struct.pack(">I", zlib.crc32(chunk_type + data))
+
+
+def build_png(manifest_label: str | None) -> bytes:
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0)  # 1x1 RGBA
+    chunks = [png_chunk(b"IHDR", ihdr)]
+    if manifest_label is not None:
+        chunks.append(png_chunk(b"caBX", manifest_store(manifest_label)))
+    chunks.append(png_chunk(b"IDAT", zlib.compress(b"\x00\x00\x00\x00\x00")))
+    chunks.append(png_chunk(b"IEND", b""))
+    return PNG_SIGNATURE + b"".join(chunks)
+
+
+# --- JPEG ----------------------------------------------------------------
+
+
+def app11_segment(box_instance: int, sequence: int, chunk: bytes) -> bytes:
+    payload = b"JP" + struct.pack(">H", box_instance) + struct.pack(">I", sequence) + chunk
+    return b"\xff\xeb" + struct.pack(">H", len(payload) + 2) + payload
+
+
+def build_jpeg(app11_segments: bytes) -> bytes:
+    return b"\xff\xd8" + app11_segments + b"\xff\xd9"
+
+
+def jpeg_single_segment(label: str) -> bytes:
+    return build_jpeg(app11_segment(1, 1, manifest_store(label)))
+
+
+def jpeg_split_segments(label: str) -> bytes:
+    blob = manifest_store(label)
+    midpoint = len(blob) // 2
+    segments = app11_segment(1, 1, blob[:midpoint]) + app11_segment(1, 2, blob[midpoint:])
+    return build_jpeg(segments)
+
+
+# --- SVG -------------------------------------------------------------------
+
+
+def build_svg_manifest(label: str) -> bytes:
+    encoded = base64.b64encode(manifest_store(label)).decode("ascii")
+    return (
+        '<svg xmlns="http://www.w3.org/2000/svg" xmlns:c2pa="http://c2pa.org/manifest" '
+        'width="1" height="1"><metadata><c2pa:manifest>'
+        f"{encoded}"
+        "</c2pa:manifest></metadata></svg>"
+    ).encode()
+
+
+def build_svg_clean_with_comment() -> bytes:
+    # WHY: proves the parse does not flag "c2pa" appearing only in a
+    # comment (issue #137's cited false-positive case) — an XML parser
+    # never surfaces comment text as an element or attribute.
+    return (
+        b'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">'
+        b"<!-- rendered by a tool whose name happens to contain c2pa -->"
+        b"</svg>"
+    )
+
+
+# --- Test driver -----------------------------------------------------------
+
+
+def run_stage(root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(STAGE), str(root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="typikon-asset-provenance-fixture-") as tmp:
+        root = Path(tmp)
+        img = root / "public" / "img"
+        img.mkdir(parents=True)
+
+        fixtures = {
+            "clean.png": build_png(None),
+            "manifest.png": build_png(LABEL_PNG),
+            "clean.jpg": build_jpeg(b""),
+            "manifest-single.jpg": jpeg_single_segment(LABEL_JPEG_SINGLE),
+            "manifest-split.jpg": jpeg_split_segments(LABEL_JPEG_SPLIT),
+            "clean.svg": build_svg_clean_with_comment(),
+            "manifest.svg": build_svg_manifest(LABEL_SVG),
+            "declared.jpg": jpeg_single_segment(LABEL_DECLARED),
+        }
+        for name, data in fixtures.items():
+            (img / name).write_bytes(data)
+
+        # INVARIANT check on the fixtures themselves, not the scanner: proves
+        # the false-negative case is real (a literal grep would find nothing).
+        # SVG is exempt — its C2PA embedding channel IS an xmlns declaration
+        # containing "c2pa" (that's what the parse keys on), so a grep would
+        # already find a real SVG manifest; SVG's false-positive case (a
+        # mention inside a comment, not a real manifest) is checked below.
+        for undetectable in ("manifest.png", "manifest-single.jpg", "manifest-split.jpg"):
+            if b"c2pa" in fixtures[undetectable]:
+                failures.append(f"fixture bug: {undetectable} contains literal 'c2pa' — invalidates the false-negative proof")
+        if b"c2pa" not in fixtures["clean.svg"]:
+            failures.append("fixture bug: clean.svg does not contain literal 'c2pa' — invalidates the false-positive proof")
+
+        (root / "config.toml").write_text(
+            '[extra]\nc2pa_declared_assets = ["/img/declared.jpg"]\n',
+            encoding="utf-8",
+        )
+
+        result = run_stage(root)
+
+        if result.returncode != 1:
+            failures.append(f"mixed fixture set: expected exit 1 (undeclared manifests present), got {result.returncode}\nstderr:\n{result.stderr}")
+
+        violation_lines = [line for line in result.stderr.splitlines() if "undeclared C2PA manifest present" in line]
+
+        expected_violations = {
+            "manifest.png": f"PNG: undeclared C2PA manifest present (label={LABEL_PNG})",
+            "manifest-single.jpg": f"JPEG: undeclared C2PA manifest present (label={LABEL_JPEG_SINGLE})",
+            "manifest-split.jpg": f"JPEG: undeclared C2PA manifest present (label={LABEL_JPEG_SPLIT})",
+            "manifest.svg": f"SVG: undeclared C2PA manifest present (label={LABEL_SVG})",
+        }
+        for name, expected in expected_violations.items():
+            if not any(name in line and expected in line for line in violation_lines):
+                failures.append(f"{name}: expected a violation line naming path + {expected!r}; violation lines were:\n" + "\n".join(violation_lines))
+
+        # Exactly the four manifest fixtures above should have triggered a
+        # violation — this catches both an under-report (a manifest fixture
+        # missing from violation_lines, already caught above) and an
+        # over-report (a clean or declared fixture wrongly flagged).
+        if len(violation_lines) != len(expected_violations):
+            failures.append(f"expected exactly {len(expected_violations)} violation line(s), got {len(violation_lines)}:\n" + "\n".join(violation_lines))
+
+        if not any("note:" in line and "declared C2PA manifest" in line for line in result.stderr.splitlines()):
+            failures.append(f"expected a declared-manifest note for declared.jpg; not found in stderr:\n{result.stderr}")
+
+    # Second run: only clean + declared assets present — proves a fully
+    # clean site (nothing to complain about) exits 0, not merely "exit 1
+    # with fewer lines".
+    with tempfile.TemporaryDirectory(prefix="typikon-asset-provenance-clean-") as tmp:
+        root = Path(tmp)
+        img = root / "public" / "img"
+        img.mkdir(parents=True)
+        (img / "clean.png").write_bytes(build_png(None))
+        (img / "clean.jpg").write_bytes(build_jpeg(b""))
+        (img / "clean.svg").write_bytes(build_svg_clean_with_comment())
+        (img / "declared.jpg").write_bytes(jpeg_single_segment(LABEL_DECLARED))
+        (root / "config.toml").write_text(
+            '[extra]\nc2pa_declared_assets = ["/img/declared.jpg"]\n',
+            encoding="utf-8",
+        )
+
+        result = run_stage(root)
+        if result.returncode != 0:
+            failures.append(f"all-clean fixture set: expected exit 0, got {result.returncode}\nstderr:\n{result.stderr}")
+
+    if failures:
+        for line in failures:
+            print(f"FAIL: {line}", file=sys.stderr)
+        return 1
+
+    print("OK: asset-provenance stage verified across PNG/JPEG/SVG, single- and multi-segment JPEG, and declared-asset exemption")
+    return 0
+
+
+if __name__ == "__main__":
+    if shutil.which("bash") is None:
+        print("FAIL: bash not on PATH (required to run ci/asset-provenance.sh)", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(main())

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -8,6 +8,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 python3 "$ROOT/ci/check-triad-schema.py"
 python3 "$ROOT/ci/check-font-coverage.py"
 python3 "$ROOT/ci/check-release-config.py"
+python3 "$ROOT/ci/check-asset-provenance.py"
 "$ROOT/ci/check-workflow-template.sh" "$ROOT/ci/github-workflow.yml.tmpl"
 
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-blog"

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -51,16 +51,17 @@ Run this in your authoring loop. Do not push without it passing.
 bin/typikon-check <consumer-site-root>
 ```
 
-Runs (in order, fail-fast):
+Runs every stage below, in order; a stage failing does not stop the ones after it (each records its own verdict — see `bin/typikon-check`'s Exit codes for how the run's overall result is decided):
 
 1. `typikon-validate` (frontmatter against JSON Schema)
 2. `zola check` (internal links + assets)
 3. `zola build` (no warnings tolerated, output `public/`)
 4. `zola build --base-url http://127.0.0.1:8080 --output-dir public-local` (the copy browser gates serve — `public/` retains the real `base_url` for deploy)
-5. `csp-enforce.sh` (greps `public/` for inline `<script>`, `<style>`, `on*=` handlers)
-6. `lychee public/ --config ci/lychee.toml` (external links)
-7. `pa11y-ci --config ci/pa11y.config.js` (WCAG 2.1 AA, against `public-local/`)
-8. `playwright test` (per-route smoke assertions, against `public-local/`)
+5. `csp-enforce.sh` (parses `public/` HTML for inline `<script>`, `<style>`, `on*=` handlers)
+6. `asset-provenance.sh` (parses `public/` PNG/JPEG/SVG containers for an embedded C2PA manifest undeclared in `config.toml`'s `extra.c2pa_declared_assets`)
+7. `lychee public/ --config ci/lychee.toml` (external links)
+8. `pa11y-ci --config ci/pa11y.config.js` (WCAG 2.1 AA, against `public-local/`)
+9. `playwright test` (per-route smoke assertions, against `public-local/`)
 
 Output is JSONL summarizing each gate. If anything fails, fix; do not push to bypass.
 


### PR DESCRIPTION
Closes #137

The gate had no stage that opened a shipped binary asset, so an image carrying an embedded third-party provenance manifest deployed unexamined. `zola check` validates that asset *references* resolve; `csp-enforce` parses rendered HTML. Nothing read a `.png`.

## What it does

A new `asset-provenance` stage, wired into `bin/typikon-check`'s declared stage list, walks PNG chunks for `caBX`, JPEG segments for APP11/JUMBF (reassembling a manifest split across segments), and SVG XML for a c2pa-namespaced metadata element. Undeclared manifests fail the gate, naming path, container and label. A consumer declares intended Content Credentials per-asset, so a site that legitimately wants them keeps them without disabling the stage.

Stdlib only — no new prerequisite, which matters because `full` mode treats a missing tool as a failure rather than a skip.

## Parsing, not grepping

`ci/csp-scan.py` already established this and its reasoning carries: a byte search for the literal string `c2pa` both false-positives on the token appearing in a comment and false-negatives on a label that does not surface as contiguous ASCII. The fixtures prove both halves — the PNG and JPEG manifest fixtures contain zero literal `c2pa` bytes, while a clean SVG mentioning it in a comment passes.

## The fail-open the first attempt shipped

The PNG walker returned "no manifest" — so the gate **passed** — the instant it met any chunk whose declared length overflowed the remaining bytes, even with a well-formed `caBX` chunk sitting after it. That contradicted the module's own stated invariant, which the same file honored in its label-enrichment path and violated in the detection path.

Adversarial review reproduced it end to end: the production entrypoint reported `ok (1 image/svg files scanned, 0 undeclared manifests)` on a file genuinely carrying an undeclared manifest.

Worth stating precisely, because the reviewer was careful about it: the crafted file is itself malformed enough that Pillow refuses to open it, so this was a real violation of the parser's own invariant rather than a proven bypass for a working, displayable image. It was fixed because a detection gate must not stop scanning on untrusted length arithmetic, not because a live exploit existed.

## The correction

An untrustworthy chunk length no longer ends the scan. The walker resynchronises on the `caBX` chunk-type token in the unread remainder — a fixed part of PNG's byte grammar — validates the preceding four bytes as that chunk's own length, and falls back to a best-effort slice when even that lies. A truncated `caBX` is still reported rather than dropped. A scan that cannot complete is unverifiable, never "no manifest".

## Verification

Re-verified independently across five cases: lying chunk then genuine `caBX` (detected), lying chunk with no manifest anywhere (correctly none), clean file (correctly none), truncated `caBX` (still reported), and a normal well-formed manifest (detected). The fixture fails against the pre-fix parser.

Also corrected: the previous report claimed it had fixed a stale `grep` description in two files and had changed only one. `bin/typikon-check`'s own line now says what it does.
