### PR TITLE
fix(css): give form controls a border token that meets 3:1 non-text contrast

### DIFF
--- a/ci/check-control-contrast.py
+++ b/ci/check-control-contrast.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""check-control-contrast — regression test for WCAG 1.4.11 non-text contrast.
+
+WHY: a form control's border is its only perceivable boundary when it has
+no fill difference from its background. forkwright/typikon#136 found two
+such controls (.purchase-box select, .buttondown-form input[type="email"])
+styled with var(--rule) — a token meant for decorative dividers, which
+only reaches 1.35:1 / 1.26:1 against --bg / --bg-accent, far under the
+3:1 WCAG 1.4.11 floor for UI component boundaries. --control-border is
+the dedicated, contrast-checked token for this role; --rule stays
+reserved for decoration and is never contrast-checked against 3:1.
+
+This script parses static/css/style.css directly (no browser, no built
+site) so it stays exact: it resolves every `--token: #hex` declaration in
+:root, then scans every rule block for a form-control selector (input,
+select, textarea, button) with a `border` declaration that resolves
+through a var() to one of those hex values, and fails if that resolved
+color does not clear 3:1 against both --bg and --bg-accent. This is
+generic over the token name and the selector, not a hardcoded pass for
+the two sites the issue named — a future control styled with the wrong
+token fails the same way.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+THEME_ROOT = Path(__file__).resolve().parent.parent
+STYLE_CSS = THEME_ROOT / "static" / "css" / "style.css"
+
+NON_TEXT_CONTRAST_FLOOR = 3.0
+
+TOKEN_DECL_RE = re.compile(r"--([\w-]+)\s*:\s*(#[0-9A-Fa-f]{6})\s*;")
+RULE_RE = re.compile(r"([^{}]+)\{([^{}]*)\}")
+BORDER_VAR_RE = re.compile(r"border(?:-\w+)?\s*:\s*[^;]*var\(--([\w-]+)\)[^;]*;")
+FORM_CONTROL_SELECTOR_RE = re.compile(r"\b(input|select|textarea|button)\b")
+BG_TOKENS = ("bg", "bg-accent")
+
+
+def srgb_to_linear(channel: int) -> float:
+    c = channel / 255
+    return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def relative_luminance(hex_color: str) -> float:
+    hex_color = hex_color.lstrip("#")
+    r, g, b = (int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+    rl, gl, bl = srgb_to_linear(r), srgb_to_linear(g), srgb_to_linear(b)
+    return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl
+
+
+def contrast_ratio(hex_a: str, hex_b: str) -> float:
+    la, lb = relative_luminance(hex_a), relative_luminance(hex_b)
+    lighter, darker = max(la, lb), min(la, lb)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def parse_root_tokens(css_text: str) -> dict[str, str]:
+    root_match = re.search(r":root\s*\{([^{}]*)\}", css_text, re.DOTALL)
+    if not root_match:
+        return {}
+    return dict(TOKEN_DECL_RE.findall(root_match.group(1)))
+
+
+def find_form_control_border_vars(css_text: str) -> list[tuple[str, str]]:
+    """Return (selector, var-name) for every form-control rule with a border var()."""
+    found = []
+    for selector, body in RULE_RE.findall(css_text):
+        selector = selector.strip()
+        if not FORM_CONTROL_SELECTOR_RE.search(selector):
+            continue
+        for var_name in BORDER_VAR_RE.findall(body):
+            found.append((selector, var_name))
+    return found
+
+
+def main() -> int:
+    css_text = STYLE_CSS.read_text(encoding="utf-8")
+    tokens = parse_root_tokens(css_text)
+
+    for required in ("bg", "bg-accent"):
+        if required not in tokens:
+            print(f"FAIL: :root declares no --{required} token in {STYLE_CSS}", file=sys.stderr)
+            return 1
+
+    control_vars = find_form_control_border_vars(css_text)
+    if not control_vars:
+        print(f"FAIL: found no form-control border declarations to check in {STYLE_CSS}", file=sys.stderr)
+        return 1
+
+    failures = []
+    checked = []
+    for selector, var_name in control_vars:
+        if var_name not in tokens:
+            failures.append(f"{selector}: border var(--{var_name}) has no :root declaration to resolve")
+            continue
+        border_hex = tokens[var_name]
+        for bg_name in BG_TOKENS:
+            ratio = contrast_ratio(border_hex, tokens[bg_name])
+            checked.append(f"{selector} border --{var_name} vs --{bg_name} = {ratio:.2f}:1")
+            if ratio < NON_TEXT_CONTRAST_FLOOR:
+                failures.append(
+                    f"{selector}: border var(--{var_name}) ({border_hex}) is {ratio:.2f}:1 against "
+                    f"--{bg_name} ({tokens[bg_name]}), below the {NON_TEXT_CONTRAST_FLOOR}:1 WCAG "
+                    "1.4.11 non-text contrast floor"
+                )
+
+    if failures:
+        for line in failures:
+            print(f"FAIL: {line}", file=sys.stderr)
+        return 1
+
+    for line in checked:
+        print(f"OK: {line}")
+    print(f"OK: {len(control_vars)} form-control border declaration(s) clear {NON_TEXT_CONTRAST_FLOOR}:1")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -9,6 +9,7 @@ python3 "$ROOT/ci/check-triad-schema.py"
 python3 "$ROOT/ci/check-font-coverage.py"
 python3 "$ROOT/ci/check-release-config.py"
 python3 "$ROOT/ci/check-asset-provenance.py"
+python3 "$ROOT/ci/check-control-contrast.py"
 "$ROOT/ci/check-workflow-template.sh" "$ROOT/ci/github-workflow.yml.tmpl"
 
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-blog"

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -39,7 +39,13 @@
   --text-mid: #44403C;
   --text-light: #6B6661;  /* INVARIANT: must satisfy WCAG 2.1 AA contrast (4.5:1) against --bg */
   --rule: #D6D3CD;
-  
+  /* INVARIANT: form-control boundaries need WCAG 1.4.11 non-text contrast
+     (3:1) against both --bg and --bg-accent; --rule alone measures 1.35:1
+     and 1.26:1 against them, and raising --rule itself to clear the floor
+     would over-darken purely decorative dividers. Interactive controls use
+     this darker split token instead. */
+  --control-border: #827E77;  /* 3.64:1 vs --bg, 3.40:1 vs --bg-accent */
+
   /* Default brand accents — ardent's iron-mordanted botanical dye palette.
      Other typikon consumers should redeclare these (or rename them) in
      site-specific CSS. Class hooks like .swatch-aima / .dye-entry-aima are
@@ -629,7 +635,7 @@ th {
   font-family: var(--font-body);
   font-size: var(--step-0);
   padding: var(--space-xs) var(--space-s);
-  border: 1px solid var(--rule);
+  border: 1px solid var(--control-border);
   background: var(--bg);
   width: 100%;
   max-width: 140px;
@@ -1189,7 +1195,7 @@ main hr {
   font-family: var(--font-body);
   font-size: var(--step-0);
   padding: var(--space-xs) var(--space-s);
-  border: 1px solid var(--rule);
+  border: 1px solid var(--control-border);
   background: var(--bg);
   color: var(--text);
 }


### PR DESCRIPTION
Refs #136 — deliberately NOT "Closes".

**Why issue #136 stays open.** It carries a second, distinct defect beyond the form-control contrast this PR fixes: the home page renders with no heading at any level, while every other page type carries an `<h1>`. A closing keyword here would have swept that half away silently on merge.

It is now split out as **#142**, verified against a built page rather than the template. #136 stays open until the contrast fix here merges and #142 is resolved on its own terms.


## What

Form-control borders resolved through `--rule`, which measures **1.35:1** against `--bg` and **1.26:1** against `--bg-accent` — both far under the 3:1 WCAG 1.4.11 floor for non-text contrast. The newsletter input and the size select had no perceivable boundary.

A dedicated `--control-border` token now carries that job, meeting the floor against both backgrounds, with the ratio stated as an `INVARIANT` beside it.

## Why a split token rather than darkening `--rule`

`--rule` is also the decorative rule colour. Darkening it globally to clear a form-control floor would over-darken every hairline on the site to fix two controls. The issue offered both shapes; this is the one that changes only what was broken.

## Verification

Adversarially reviewed by mutation, not by reading. The reviewer reverted `.purchase-box select`'s border to `var(--rule)`, confirmed the regression check goes red, restored, and diffed to confirm a clean restore before the next mutation. Contrast ratios were recomputed independently rather than taken from the commit message.

Three non-blocking findings, recorded rather than dropped:

1. `ci/check-control-contrast.py:41-42` — the regression check only inspects border declarations resolving through `var(--token)`. A form-control border written as a literal hex bypasses it entirely. The check catches the regression it was built for and not the general class.
2. `static/css/style.css:47` — the `INVARIANT` comment states fixed ratios (3.64:1 / 3.40:1) that hold against typikon's own `--bg` / `--bg-accent`. A consumer redefining those tokens inherits the comment but not the guarantee.
3. #136's own comment thread carries a second, distinct defect — `templates/index.html` has zero `<h1>` elements. Out of scope here; it needs its own issue rather than riding along.

