### PR TITLE
fix(notice): point at OFL.txt instead of restating which fonts ship

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -24,12 +24,15 @@ from the copyright holder exercising rights not addressed by the AGPL.
 THIRD-PARTY ASSETS
 
 Self-hosted webfonts shipped under static/fonts/ are distributed
-under the SIL Open Font License (OFL) 1.1:
+under the SIL Open Font License (OFL) 1.1.
 
-  - Cormorant Garamond — © Catharsis Fonts. github.com/CatharsisFonts/Cormorant
-  - Spectral — © Production Type. github.com/ProductionType/Spectral
-  - IBM Plex Mono — © IBM Corp. github.com/IBM/plex
+static/fonts/OFL.txt is the authority for which families ship, their
+upstream sources, and the per-family attributions the OFL requires
+derivative binaries (subsets, web conversions) to preserve. It is
+maintained alongside the font files themselves.
 
-The OFL requires that derivative font binaries (subsets, web conversions)
-preserve the original copyright notice. See static/fonts/OFL.txt
-for the full license text and per-family attributions.
+This notice deliberately does not restate that list. It previously did,
+and drifted: it credited a family the theme had stopped shipping while
+omitting the one that replaced it, which is an attribution gap rather
+than a cosmetic staleness. A second copy of a fact only has to be
+forgotten once.


### PR DESCRIPTION
## What

`NOTICE` credited **Cormorant Garamond** and omitted **EB Garamond**. The theme stopped shipping Cormorant when it moved to EB Garamond for Greek coverage (#125); `static/fonts/` today holds `eb-garamond-variable.woff2` and `-italic`, with no Cormorant file anywhere.

## Why it is a license gap, not cosmetic drift

The OFL requires a derivative binary — a subset or web conversion — to preserve its family's copyright notice. NOTICE was failing that in both directions at once: crediting a family the theme does not ship, and shipping a family it does not credit.

## Fixed at the class, not the instance

`static/fonts/OFL.txt` already carries every shipped family with its upstream source and build provenance, and it lives beside the font binaries it describes. So NOTICE now points at it rather than maintaining a second copy of the list.

A duplicated fact only has to be forgotten once, and this one was — the font swap updated the fonts, the CSS, and `OFL.txt`, and missed the copy in NOTICE. Removing the copy is what stops it recurring; correcting the entry would only reset the clock.

## Provenance, including my own error

Reported by the kanon seat while mining an audit report for deletion. My own earlier triage of this repo had recorded the same finding as **FALSE** — a sub-agent asserted the three credited families were the shipped ones, and I carried that forward without checking `static/fonts/` myself. The directory listing settles it in one command, and I did not run it.
