### PR TITLE
feat(ci): give consumers a gate-check extension point on BOTH pipelines, not just the fallback

### DIFF
--- a/ci/check-consumer-check-extension.sh
+++ b/ci/check-consumer-check-extension.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-consumer-check-extension — regression test for the consumer gate
+# extension point (forkwright/typikon#117).
+#
+# WHY: bin/typikon-refresh re-renders ci/github-workflow.yml.tmpl wholesale
+# on every bump, with no per-consumer opt-in short of the all-or-nothing
+# `# typikon: local` decline marker (#94). Without a declared extension
+# point, a consumer wanting its own gate check (e.g. a price-vs-source-of-
+# truth check) must choose between diverging from every future substrate
+# hardening change or shipping an unchecked claim. This script proves three
+# things hold together, not just that the template text looks right:
+#   1. the rendered template carries a hashFiles-guarded step in the right
+#      place (after the browser-gate/teardown steps, before deploy);
+#   2. bin/typikon-refresh — the real script, not a re-implementation of its
+#      logic — preserves that step when it re-renders a consumer instance;
+#   3. the step's own `run:` command, executed under the same presence
+#      test hashFiles() performs, actually fails the job when the
+#      consumer's script fails. A hook that runs but cannot fail the build
+#      is the defect this fleet keeps finding.
+#
+# Usage:
+#     ci/check-consumer-check-extension.sh
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPL="$ROOT/ci/github-workflow.yml.tmpl"
+
+FAIL=0
+fail() {
+    echo "FAIL: $1" >&2
+    FAIL=1
+}
+
+# ── Part 1 — the template itself: presence, guard, placement ──────────
+
+STEP_LINE="$(grep -n '^\s*- name: Consumer checks$' "$TMPL" | head -1 | cut -d: -f1 || true)"
+TEARDOWN_LINE="$(grep -n '^\s*- name: Tear down static server$' "$TMPL" | head -1 | cut -d: -f1 || true)"
+DEPLOY_LINE="$(grep -n '^\s*- name: Deploy to Cloudflare Pages$' "$TMPL" | head -1 | cut -d: -f1 || true)"
+
+if [[ -z "$STEP_LINE" ]]; then
+    fail "no 'Consumer checks' step in ${TMPL}"
+else
+    grep -qF "if: hashFiles('ci/consumer-check.sh') != ''" "$TMPL" \
+        || fail "'Consumer checks' step is not guarded by hashFiles('ci/consumer-check.sh') != ''"
+    grep -qF 'run: bash ci/consumer-check.sh' "$TMPL" \
+        || fail "'Consumer checks' step does not run 'bash ci/consumer-check.sh'"
+    if [[ -n "$TEARDOWN_LINE" && "$STEP_LINE" -le "$TEARDOWN_LINE" ]]; then
+        fail "'Consumer checks' step (line ${STEP_LINE}) is not after 'Tear down static server' (line ${TEARDOWN_LINE}) — it must run after browser-gate teardown so it can inspect built output"
+    fi
+    if [[ -n "$DEPLOY_LINE" && "$STEP_LINE" -ge "$DEPLOY_LINE" ]]; then
+        fail "'Consumer checks' step (line ${STEP_LINE}) is not before 'Deploy to Cloudflare Pages' (line ${DEPLOY_LINE}) — a failure must block deploy"
+    fi
+fi
+
+# ── Part 2 — round trip through the real typikon-refresh ──────────────
+
+# WARNING: never point TYPIKON_ROOT at this checkout. typikon-refresh's
+# step 1 unconditionally runs `git pull --ff-only origin main` inside
+# TYPIKON_ROOT — against this worktree's own feature branch that would
+# refuse (diverged from origin/main) or, worse, mutate shared git state.
+# Build an isolated fake typikon source tree instead, so the refresh
+# exercises real script logic against a throwaway git remote.
+WORK="$(mktemp -d -t typikon-consumer-check-check.XXXXXX)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+FAKE_TYPIKON="$WORK/fake-typikon"
+CONSUMER="$WORK/consumer"
+
+mkdir -p "$FAKE_TYPIKON/ci" "$FAKE_TYPIKON/bin"
+cp "$TMPL" "$FAKE_TYPIKON/ci/github-workflow.yml.tmpl"
+cp "$ROOT/ci/kanon-ci.toml.tmpl" "$FAKE_TYPIKON/ci/kanon-ci.toml.tmpl"
+cp "$ROOT/bin/typikon-refresh" "$FAKE_TYPIKON/bin/typikon-refresh"
+cp "$ROOT/bin/typikon-defaults.sh" "$FAKE_TYPIKON/bin/typikon-defaults.sh"
+chmod +x "$FAKE_TYPIKON/bin/typikon-refresh"
+echo 'name = "fake-typikon"' > "$FAKE_TYPIKON/theme.toml"
+
+# WARNING: a caller's process tree (a git hook invoking this script) can export
+# GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE. Without unsetting them first, the `git
+# init` calls below would silently no-op against that ambient repo instead of
+# creating the isolated fixtures this script depends on, and every following
+# `git add`/`git commit`/`git clone` would land on the CALLER's live repo.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+git -C "$FAKE_TYPIKON" init -q -b main
+git -C "$FAKE_TYPIKON" -c user.email=fixture@typikon.test -c user.name=fixture add -A
+git -C "$FAKE_TYPIKON" -c user.email=fixture@typikon.test -c user.name=fixture commit -q -m init
+
+mkdir -p "$CONSUMER/themes" "$CONSUMER/ci"
+git -C "$CONSUMER" init -q -b main
+git clone -q "$FAKE_TYPIKON" "$CONSUMER/themes/typikon"
+
+cat > "$CONSUMER/ci/consumer-check.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$CONSUMER/ci/consumer-check.sh"
+
+if ! REFRESH_LOG="$(cd "$CONSUMER" && TYPIKON_PROJECT_NAME=fixture-consumer "$CONSUMER/themes/typikon/bin/typikon-refresh" 2>&1)"; then
+    fail "bin/typikon-refresh exited non-zero against the fixture consumer:"
+    echo "$REFRESH_LOG" >&2
+fi
+
+RENDERED="$CONSUMER/.github/workflows/deploy.yml"
+if [[ ! -f "$RENDERED" ]]; then
+    fail "typikon-refresh did not render ${RENDERED}"
+else
+    grep -qF "if: hashFiles('ci/consumer-check.sh') != ''" "$RENDERED" \
+        || fail "rendered ${RENDERED} lost the hashFiles guard — a refresh would silently drop a consumer's gate check"
+fi
+
+# ── Part 3 — a failing consumer script actually fails the job ─────────
+
+# Simulate hashFiles()'s presence test the same way GitHub Actions
+# evaluates it (a glob match against files in the workspace), then run
+# the step's own extracted `run:` command with the consumer root as
+# cwd — matching ${GITHUB_WORKSPACE} — rather than re-deriving the command
+# by hand, so a corrupted rendered command would be caught here too.
+if [[ -f "$RENDERED" ]]; then
+    # WARNING: the step body carries a comment line between `if:` and
+    # `run:` (see the template), so a fixed-offset `grep -A1` silently
+    # captures the comment instead — evaluating a comment is a no-op that
+    # exits 0 and reads as "the check passed" no matter what the
+    # consumer's script does. Scan forward from the `if:` line for the
+    # first actual `run:` line instead of assuming a fixed offset.
+    RUN_CMD="$(awk '
+        /if: hashFiles\(.ci\/consumer-check\.sh.\) != ./ { found=1; next }
+        found && /^\s*run:\s*/ { sub(/^\s*run:\s*/, ""); print; exit }
+    ' "$RENDERED")"
+    if [[ -z "$RUN_CMD" ]]; then
+        fail "could not extract the 'Consumer checks' step's run: command from ${RENDERED}"
+    else
+        if compgen -G "$CONSUMER/ci/consumer-check.sh" >/dev/null; then
+            if ! (cd "$CONSUMER" && eval "$RUN_CMD"); then
+                fail "a passing ci/consumer-check.sh (exit 0) still failed the step — hashFiles/run wiring is broken"
+            fi
+        else
+            fail "hashFiles presence test found no ci/consumer-check.sh even though the fixture created one"
+        fi
+
+        cat > "$CONSUMER/ci/consumer-check.sh" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+        chmod +x "$CONSUMER/ci/consumer-check.sh"
+        if (cd "$CONSUMER" && eval "$RUN_CMD"); then
+            fail "a failing ci/consumer-check.sh (exit 1) did not fail the step — a hook that cannot fail the build is the defect this fleet keeps finding"
+        fi
+    fi
+fi
+
+if [[ "$FAIL" -eq 0 ]]; then
+    echo '{"checked":"consumer-check-extension-point","status":"pass"}'
+fi
+
+exit "$FAIL"

--- a/ci/check-consumer-check-extension.sh
+++ b/ci/check-consumer-check-extension.sh
@@ -4,27 +4,37 @@ set -euo pipefail
 # check-consumer-check-extension — regression test for the consumer gate
 # extension point (forkwright/typikon#117).
 #
-# WHY: bin/typikon-refresh re-renders ci/github-workflow.yml.tmpl wholesale
-# on every bump, with no per-consumer opt-in short of the all-or-nothing
-# `# typikon: local` decline marker (#94). Without a declared extension
-# point, a consumer wanting its own gate check (e.g. a price-vs-source-of-
-# truth check) must choose between diverging from every future substrate
-# hardening change or shipping an unchecked claim. This script proves three
-# things hold together, not just that the template text looks right:
-#   1. the rendered template carries a hashFiles-guarded step in the right
-#      place (after the browser-gate/teardown steps, before deploy);
+# WHY: bin/typikon-refresh re-renders both ci/github-workflow.yml.tmpl and
+# ci/kanon-ci.toml.tmpl wholesale on every bump, with no per-consumer opt-in
+# short of the all-or-nothing `# typikon: local` decline marker (#94).
+# CLAUDE.md states forge is primary and GitHub is the executable fallback,
+# so the extension point must exist on BOTH rendered pipelines — a consumer
+# running the primary (forge) pipeline must get the same hook a GitHub-only
+# consumer gets, or the "fallback" path is the only one an extension
+# actually reaches. Without a declared extension point on both, a consumer
+# wanting its own gate check (e.g. a price-vs-source-of-truth check) must
+# choose between diverging from every future substrate hardening change or
+# shipping an unchecked claim. This script proves, for EACH of the two
+# rendered pipelines, that:
+#   1. the rendered template carries a guarded stage/step in the right
+#      place (after the browser-gate/teardown stage, before deploy);
 #   2. bin/typikon-refresh — the real script, not a re-implementation of its
-#      logic — preserves that step when it re-renders a consumer instance;
-#   3. the step's own `run:` command, executed under the same presence
-#      test hashFiles() performs, actually fails the job when the
-#      consumer's script fails. A hook that runs but cannot fail the build
-#      is the defect this fleet keeps finding.
+#      logic — preserves that stage/step when it re-renders a consumer
+#      instance;
+#   3. the stage/step's own command, executed under the same presence
+#      test each pipeline performs, actually fails the build when the
+#      consumer's script fails, and is a clean no-op when the consumer
+#      ships no ci/consumer-check.sh at all. A hook that runs but cannot
+#      fail the build is the defect this fleet keeps finding; a hook that
+#      errors out when a consumer simply doesn't use the extension point
+#      is the opposite defect and just as real.
 #
 # Usage:
 #     ci/check-consumer-check-extension.sh
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TMPL="$ROOT/ci/github-workflow.yml.tmpl"
+GH_TMPL="$ROOT/ci/github-workflow.yml.tmpl"
+TOML_TMPL="$ROOT/ci/kanon-ci.toml.tmpl"
 
 FAIL=0
 fail() {
@@ -32,24 +42,59 @@ fail() {
     FAIL=1
 }
 
-# ── Part 1 — the template itself: presence, guard, placement ──────────
+# ── Part 1 — GitHub template: presence, guard, placement ──────────────
 
-STEP_LINE="$(grep -n '^\s*- name: Consumer checks$' "$TMPL" | head -1 | cut -d: -f1 || true)"
-TEARDOWN_LINE="$(grep -n '^\s*- name: Tear down static server$' "$TMPL" | head -1 | cut -d: -f1 || true)"
-DEPLOY_LINE="$(grep -n '^\s*- name: Deploy to Cloudflare Pages$' "$TMPL" | head -1 | cut -d: -f1 || true)"
+STEP_LINE="$(grep -n '^\s*- name: Consumer checks$' "$GH_TMPL" | head -1 | cut -d: -f1 || true)"
+TEARDOWN_LINE="$(grep -n '^\s*- name: Tear down static server$' "$GH_TMPL" | head -1 | cut -d: -f1 || true)"
+DEPLOY_LINE="$(grep -n '^\s*- name: Deploy to Cloudflare Pages$' "$GH_TMPL" | head -1 | cut -d: -f1 || true)"
 
 if [[ -z "$STEP_LINE" ]]; then
-    fail "no 'Consumer checks' step in ${TMPL}"
+    fail "no 'Consumer checks' step in ${GH_TMPL}"
 else
-    grep -qF "if: hashFiles('ci/consumer-check.sh') != ''" "$TMPL" \
+    grep -qF "if: hashFiles('ci/consumer-check.sh') != ''" "$GH_TMPL" \
         || fail "'Consumer checks' step is not guarded by hashFiles('ci/consumer-check.sh') != ''"
-    grep -qF 'run: bash ci/consumer-check.sh' "$TMPL" \
+    grep -qF 'run: bash ci/consumer-check.sh' "$GH_TMPL" \
         || fail "'Consumer checks' step does not run 'bash ci/consumer-check.sh'"
     if [[ -n "$TEARDOWN_LINE" && "$STEP_LINE" -le "$TEARDOWN_LINE" ]]; then
         fail "'Consumer checks' step (line ${STEP_LINE}) is not after 'Tear down static server' (line ${TEARDOWN_LINE}) — it must run after browser-gate teardown so it can inspect built output"
     fi
     if [[ -n "$DEPLOY_LINE" && "$STEP_LINE" -ge "$DEPLOY_LINE" ]]; then
         fail "'Consumer checks' step (line ${STEP_LINE}) is not before 'Deploy to Cloudflare Pages' (line ${DEPLOY_LINE}) — a failure must block deploy"
+    fi
+fi
+
+# ── Part 1b — forge (kanon-ci.toml) template: presence, guard, placement ──
+
+# WARNING: check the STAGES ARRAY entry and the [stages.consumer-checks]
+# block separately. The array line declares the stage runs at all; the
+# block declares what it runs. A template could carry one without the
+# other (a stage listed but never defined, or defined but never scheduled)
+# and either half missing means the extension point doesn't actually fire.
+ARR_STAGE_LINE="$(grep -nF '"consumer-checks",' "$TOML_TMPL" | head -1 | cut -d: -f1 || true)"
+ARR_TEARDOWN_LINE="$(grep -nF '"teardown-static-server",' "$TOML_TMPL" | head -1 | cut -d: -f1 || true)"
+ARR_DEPLOY_LINE="$(grep -nF '"deploy-cloudflare-pages",' "$TOML_TMPL" | head -1 | cut -d: -f1 || true)"
+BLOCK_LINE="$(grep -nF '[stages.consumer-checks]' "$TOML_TMPL" | head -1 | cut -d: -f1 || true)"
+BLOCK_TEARDOWN_LINE="$(grep -nF '[stages.teardown-static-server]' "$TOML_TMPL" | head -1 | cut -d: -f1 || true)"
+BLOCK_DEPLOY_LINE="$(grep -nF '[stages.deploy-cloudflare-pages]' "$TOML_TMPL" | head -1 | cut -d: -f1 || true)"
+
+if [[ -z "$ARR_STAGE_LINE" ]]; then
+    fail "no 'consumer-checks' entry in the [pipeline] stages array of ${TOML_TMPL} — the GitHub fallback path gained the extension point but the forge-primary path (CLAUDE.md: 'Forge is primary; GitHub is the executable fallback') did not"
+elif [[ -z "$ARR_TEARDOWN_LINE" || "$ARR_STAGE_LINE" -le "$ARR_TEARDOWN_LINE" || -z "$ARR_DEPLOY_LINE" || "$ARR_STAGE_LINE" -ge "$ARR_DEPLOY_LINE" ]]; then
+    fail "'consumer-checks' stages-array entry (line ${ARR_STAGE_LINE}) is not between 'teardown-static-server' and 'deploy-cloudflare-pages'"
+fi
+
+if [[ -z "$BLOCK_LINE" ]]; then
+    fail "no [stages.consumer-checks] block in ${TOML_TMPL}"
+else
+    grep -qF 'if [ -f ci/consumer-check.sh ]; then' "$TOML_TMPL" \
+        || fail "[stages.consumer-checks] does not guard on ci/consumer-check.sh presence"
+    grep -qF 'bash ci/consumer-check.sh' "$TOML_TMPL" \
+        || fail "[stages.consumer-checks] does not run 'bash ci/consumer-check.sh'"
+    if [[ -n "$BLOCK_TEARDOWN_LINE" && "$BLOCK_LINE" -le "$BLOCK_TEARDOWN_LINE" ]]; then
+        fail "[stages.consumer-checks] block (line ${BLOCK_LINE}) is not after [stages.teardown-static-server] (line ${BLOCK_TEARDOWN_LINE})"
+    fi
+    if [[ -n "$BLOCK_DEPLOY_LINE" && "$BLOCK_LINE" -ge "$BLOCK_DEPLOY_LINE" ]]; then
+        fail "[stages.consumer-checks] block (line ${BLOCK_LINE}) is not before [stages.deploy-cloudflare-pages] (line ${BLOCK_DEPLOY_LINE})"
     fi
 fi
 
@@ -69,8 +114,8 @@ FAKE_TYPIKON="$WORK/fake-typikon"
 CONSUMER="$WORK/consumer"
 
 mkdir -p "$FAKE_TYPIKON/ci" "$FAKE_TYPIKON/bin"
-cp "$TMPL" "$FAKE_TYPIKON/ci/github-workflow.yml.tmpl"
-cp "$ROOT/ci/kanon-ci.toml.tmpl" "$FAKE_TYPIKON/ci/kanon-ci.toml.tmpl"
+cp "$GH_TMPL" "$FAKE_TYPIKON/ci/github-workflow.yml.tmpl"
+cp "$TOML_TMPL" "$FAKE_TYPIKON/ci/kanon-ci.toml.tmpl"
 cp "$ROOT/bin/typikon-refresh" "$FAKE_TYPIKON/bin/typikon-refresh"
 cp "$ROOT/bin/typikon-defaults.sh" "$FAKE_TYPIKON/bin/typikon-defaults.sh"
 chmod +x "$FAKE_TYPIKON/bin/typikon-refresh"
@@ -110,13 +155,32 @@ else
         || fail "rendered ${RENDERED} lost the hashFiles guard — a refresh would silently drop a consumer's gate check"
 fi
 
-# ── Part 3 — a failing consumer script actually fails the job ─────────
+RENDERED_TOML="$CONSUMER/.kanon-ci.toml"
+if [[ ! -f "$RENDERED_TOML" ]]; then
+    fail "typikon-refresh did not render ${RENDERED_TOML}"
+else
+    grep -qF '"consumer-checks",' "$RENDERED_TOML" \
+        || fail "rendered ${RENDERED_TOML} lost the 'consumer-checks' stages-array entry"
+    grep -qF '[stages.consumer-checks]' "$RENDERED_TOML" \
+        || fail "rendered ${RENDERED_TOML} lost the [stages.consumer-checks] block"
+fi
+
+# ── Part 3 — GitHub: a failing consumer script fails the job, ─────────
+# ──            an absent one is a clean no-op                 ─────────
 
 # Simulate hashFiles()'s presence test the same way GitHub Actions
 # evaluates it (a glob match against files in the workspace), then run
 # the step's own extracted `run:` command with the consumer root as
 # cwd — matching ${GITHUB_WORKSPACE} — rather than re-deriving the command
 # by hand, so a corrupted rendered command would be caught here too.
+gh_hashfiles_nonempty() {
+    # WHY: hashFiles() returns '' when no file matches its glob and a
+    # content hash otherwise — for a single fixed path (no glob magic)
+    # that reduces to plain existence. Used both to decide whether the
+    # step would run and, on removal, to prove it evaluates to skip.
+    [[ -e "$1" ]]
+}
+
 if [[ -f "$RENDERED" ]]; then
     # WARNING: the step body carries a comment line between `if:` and
     # `run:` (see the template), so a fixed-offset `grep -A1` silently
@@ -131,12 +195,12 @@ if [[ -f "$RENDERED" ]]; then
     if [[ -z "$RUN_CMD" ]]; then
         fail "could not extract the 'Consumer checks' step's run: command from ${RENDERED}"
     else
-        if compgen -G "$CONSUMER/ci/consumer-check.sh" >/dev/null; then
+        if gh_hashfiles_nonempty "$CONSUMER/ci/consumer-check.sh"; then
             if ! (cd "$CONSUMER" && eval "$RUN_CMD"); then
-                fail "a passing ci/consumer-check.sh (exit 0) still failed the step — hashFiles/run wiring is broken"
+                fail "GitHub path: a passing ci/consumer-check.sh (exit 0) still failed the step — hashFiles/run wiring is broken"
             fi
         else
-            fail "hashFiles presence test found no ci/consumer-check.sh even though the fixture created one"
+            fail "GitHub path: hashFiles presence test found no ci/consumer-check.sh even though the fixture created one"
         fi
 
         cat > "$CONSUMER/ci/consumer-check.sh" <<'SH'
@@ -145,7 +209,64 @@ exit 1
 SH
         chmod +x "$CONSUMER/ci/consumer-check.sh"
         if (cd "$CONSUMER" && eval "$RUN_CMD"); then
-            fail "a failing ci/consumer-check.sh (exit 1) did not fail the step — a hook that cannot fail the build is the defect this fleet keeps finding"
+            fail "GitHub path: a failing ci/consumer-check.sh (exit 1) did not fail the step — a hook that cannot fail the build is the defect this fleet keeps finding"
+        fi
+
+        # Absent case: remove the script entirely and prove the GUARD
+        # itself — not the run: command, which would legitimately error
+        # if invoked against a missing file — evaluates to skip. This is
+        # what actually makes the absent case a no-op on GitHub: the whole
+        # step never executes.
+        rm -f "$CONSUMER/ci/consumer-check.sh"
+        if gh_hashfiles_nonempty "$CONSUMER/ci/consumer-check.sh"; then
+            fail "GitHub path: hashFiles-equivalent presence test still true after removing ci/consumer-check.sh — the absent case would not be skipped"
+        fi
+    fi
+fi
+
+# ── Part 3b — forge (kanon-ci.toml): a failing consumer script fails ──
+# ──             the stage, an absent one is a clean no-op            ──
+
+if [[ -f "$RENDERED_TOML" ]]; then
+    # Extract the [stages.consumer-checks] cmd = """ ... """ body verbatim
+    # (rather than re-deriving it) so a corrupted rendered command is
+    # caught here too, same rationale as the GitHub RUN_CMD extraction.
+    TOML_CMD="$(awk '
+        /^\[stages\.consumer-checks\]$/ { found=1; next }
+        found && /^cmd = """$/ { incmd=1; next }
+        found && incmd && /^"""$/ { exit }
+        found && incmd { print }
+    ' "$RENDERED_TOML")"
+    if [[ -z "$TOML_CMD" ]]; then
+        fail "could not extract the [stages.consumer-checks] cmd body from ${RENDERED_TOML}"
+    else
+        cat > "$CONSUMER/ci/consumer-check.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+        chmod +x "$CONSUMER/ci/consumer-check.sh"
+        if ! (cd "$CONSUMER" && eval "$TOML_CMD"); then
+            fail "forge path: a passing ci/consumer-check.sh (exit 0) still failed [stages.consumer-checks]"
+        fi
+
+        cat > "$CONSUMER/ci/consumer-check.sh" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+        chmod +x "$CONSUMER/ci/consumer-check.sh"
+        if (cd "$CONSUMER" && eval "$TOML_CMD"); then
+            fail "forge path: a failing ci/consumer-check.sh (exit 1) did not fail [stages.consumer-checks] — the same class of defect the GitHub path was already hardened against"
+        fi
+
+        # Absent case: unlike GitHub, the forge stage has no separate
+        # if:-guard — the presence test is INSIDE the extracted cmd body
+        # itself ([ -f ci/consumer-check.sh ]). Proving the absent case is
+        # a no-op here means actually running the extracted command with
+        # no script present and confirming it exits clean, not merely
+        # confirming a guard exists.
+        rm -f "$CONSUMER/ci/consumer-check.sh"
+        if ! (cd "$CONSUMER" && eval "$TOML_CMD"); then
+            fail "forge path: [stages.consumer-checks] did not exit clean with no ci/consumer-check.sh present — an absent script must be a no-op, not a failure"
         fi
     fi
 fi

--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -247,6 +247,23 @@ jobs:
         run: |
           kill "$(cat /tmp/server.pid 2>/dev/null)" 2>/dev/null || true
 
+      # ── Consumer-owned check (forkwright/typikon#117) ───────────
+      # The declared extension point: a consumer that ships ci/consumer-check.sh
+      # gets it run here, after every build/browser-gate stage (so it can
+      # inspect built output) and before deploy (so a failure blocks it).
+      # typikon-refresh re-renders this template wholesale on every bump
+      # (bin/typikon-refresh), so a consumer's only other way to add a gate
+      # check is diverging from the rendered file and losing every future
+      # substrate hardening change. hashFiles() makes this a no-op for a
+      # consumer with no such script.
+      - name: Consumer checks
+        if: hashFiles('ci/consumer-check.sh') != ''
+        # WHY 2: mirrors ci/kanon-ci.toml.tmpl's typikon-validate timeout_secs=120 —
+        # no substrate-side signal exists for a consumer script's own cost, so this
+        # borrows the budget of the nearest comparable stage rather than guessing.
+        timeout-minutes: 2
+        run: bash ci/consumer-check.sh
+
       # ── Deploy on green pushes to main only ───────────────────
       # Conditioned on ref being main (or master, for legacy consumer
       # repos that haven't migrated their default branch). Decoupled

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -30,6 +30,7 @@ stages = [
   "pa11y",
   "playwright",
   "teardown-static-server",
+  "consumer-checks",
   "deploy-cloudflare-pages",
 ]
 
@@ -211,6 +212,22 @@ set -euo pipefail
 kill "$(cat .kanon-ci/server.pid 2>/dev/null)" 2>/dev/null || true
 """
 timeout_secs = 30
+
+# The declared extension point (forkwright/typikon#117): a consumer that
+# ships ci/consumer-check.sh gets it run here, after every build/browser-gate
+# stage (so it can inspect built output) and before deploy (so a failure
+# blocks it). Mirrors ci/github-workflow.yml.tmpl's hashFiles-guarded
+# "Consumer checks" step stage-for-stage, same as every other stage in this
+# file. kanon-ci has no hashFiles() equivalent, so the no-op-when-absent
+# guard is a plain file test instead of a job-step `if:` condition.
+[stages.consumer-checks]
+cmd = """
+set -euo pipefail
+if [ -f ci/consumer-check.sh ]; then
+  bash ci/consumer-check.sh
+fi
+"""
+timeout_secs = 120
 
 [stages.deploy-cloudflare-pages]
 cmd = """

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -10,6 +10,7 @@ python3 "$ROOT/ci/check-font-coverage.py"
 python3 "$ROOT/ci/check-release-config.py"
 python3 "$ROOT/ci/check-asset-provenance.py"
 "$ROOT/ci/check-workflow-template.sh" "$ROOT/ci/github-workflow.yml.tmpl"
+"$ROOT/ci/check-consumer-check-extension.sh"
 
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-blog"
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-shop"


### PR DESCRIPTION
Closes #117

## What

A consumer can now add `ci/consumer-check.sh` and have it run as a gate stage that survives `typikon-refresh` — on the forge pipeline **and** the GitHub one.

## Why this needed a second pass

The first attempt added the step only to `ci/github-workflow.yml.tmpl`. `CLAUDE.md:47` states the locked decision plainly: *"Forge is primary; GitHub is the executable fallback."* So the extension point existed only on the fallback path, and a consumer running the primary pipeline got nothing — the opposite of the intent.

Adversarial review caught it, and `bin/typikon-refresh`'s own `TMPL_TARGETS` confirms both templates render for every consumer. The gap was real, not theoretical.

`ci/kanon-ci.toml.tmpl` now carries an equivalent `consumer-checks` stage in the same position — after teardown, before deploy. kanon-ci has no `hashFiles()` equivalent, so the no-op-when-absent guard lives in the stage's own command body as a `[ -f ci/consumer-check.sh ]` test rather than a step-level `if:`.

## Verification

Six mutations, each caught and cleanly restored:

1. Full revert of the toml stage — 5 assertions fail across placement, render survival and command extraction.
2. Stage placed before teardown instead of after — caught by the placement assertion.
3. `[ -f ... ]` guard removed so the stage always runs — caught twice, statically and by the live no-op assertion that executes the extracted command with no consumer script present.
4. Consumer script's exit code swallowed with `|| true` — the fail-open class this issue exists to prevent — caught by the forge-path assertion.
5. **The same swallow on the GitHub path is still caught post-refactor**, proving the `TMPL`→`GH_TMPL` rename and the `compgen -G` → `gh_hashfiles_nonempty()` wrapper preserved existing behaviour rather than weakening it.
6. `gh_hashfiles_nonempty()` neutered to always return true — caught by the newly added absent-case assertion, proving that addition is live rather than vacuous.

The absent-case coverage on the GitHub side is new: the earlier commit only ever exercised pass and fail with the script present.

## Two pre-existing findings deliberately left out

Surfaced by the full gate, both verified unrelated to this diff and out of scope:

- `PY/bare-except` at `ci/asset-provenance-scan.py:311` — present verbatim on `origin/main`'s own tip, predates this branch.
- `pa11y-ci` is not installed on this box, so that stage fails locally. CI installs it fresh.
