### PR TITLE
fix(ci): name asset-provenance's label as a label, never a fabricated issuer

### DIFF
--- a/ci/asset-provenance-scan.py
+++ b/ci/asset-provenance-scan.py
@@ -308,16 +308,24 @@ def scan_file(path: Path) -> tuple[str, str | None] | None:
     blob = extractor(path.read_bytes())
     if blob is None:
         return None
-    try:
-        label = extract_manifest_label(blob)
-    except (IndexError, ValueError):
-        # SAFETY: label extraction is enrichment, never the detection gate
-        # (see module docstring INVARIANT) — a malformed inner box tree
-        # must not suppress an already-established manifest finding.
-        # IndexError/ValueError are the class a corrupt/truncated box tree
-        # can raise (out-of-bounds access, bad int conversion); anything
-        # outside that class is a real bug and should propagate.
-        label = None
+    # INVARIANT: extract_manifest_label (and iter_jumbf_boxes / parse_jumd_label
+    # beneath it) cannot raise for any bytes input — every index and slice
+    # in that call graph is preceded by an explicit length check (see their
+    # docstrings above), so a malformed or truncated box tree degrades to
+    # None by returning cleanly, never by being caught. No try/except is
+    # needed here: label extraction is enrichment, never the detection gate
+    # (see module docstring INVARIANT), and this call graph already fails
+    # closed by construction rather than by exception handling. A future
+    # bug that breaks a guard and makes this call raise is exactly the kind
+    # of defect this file's own precedent (ci/csp-scan.py's per-file loop,
+    # which carries no exception guard either) leaves uncaught on purpose —
+    # a loud crash in CI is what surfaces it, not a swallowed exception
+    # that would ship the bug silently. Verified by the
+    # manifest-malformed-label.png fixture in ci/check-asset-provenance.py
+    # (manifest_store_truncated_jumd), which feeds a truncated jumd payload
+    # through the real stage: it stays a clean violation line with
+    # label=unknown, not a traceback.
+    label = extract_manifest_label(blob)
     return container, label
 
 

--- a/ci/asset-provenance-scan.py
+++ b/ci/asset-provenance-scan.py
@@ -23,9 +23,11 @@ this stdlib-only parser cannot fully walk (INVARIANT below).
 INVARIANT: a manifest's true issuer lives inside an X.509 certificate
 embedded in a COSE-signed claim several JUMBF box levels deeper, CBOR/
 ASN.1-encoded — outside stdlib reach without a new dependency (forbidden
-by forkwright/typikon#137). The JUMBF description box's optional `label`
-field is the deepest identifying string this parser can reach; it is
-reported as-is and never fabricated when absent.
+by forkwright/typikon#137; issuer extraction tracked separately at
+forkwright/typikon#148, where accepting that dependency is in scope). The
+JUMBF description box's optional `label` field is the deepest identifying
+string this parser can reach; it is reported AS A LABEL — never renamed
+to "issuer" — and never fabricated when absent.
 
 Usage:
     ci/asset-provenance-scan.py --public-root <dir> --config <config.toml> <file> [<file> ...]
@@ -308,10 +310,13 @@ def scan_file(path: Path) -> tuple[str, str | None] | None:
         return None
     try:
         label = extract_manifest_label(blob)
-    except Exception:
+    except (IndexError, ValueError):
         # SAFETY: label extraction is enrichment, never the detection gate
         # (see module docstring INVARIANT) — a malformed inner box tree
         # must not suppress an already-established manifest finding.
+        # IndexError/ValueError are the class a corrupt/truncated box tree
+        # can raise (out-of-bounds access, bad int conversion); anything
+        # outside that class is a real bug and should propagate.
         label = None
     return container, label
 
@@ -375,7 +380,8 @@ def main(argv: list[str]) -> int:
         violations += 1
         print(
             f"{file}: {CONTAINER_DISPLAY[container]}: undeclared C2PA manifest present "
-            f"(label={label or 'unknown'})",
+            f"(label={label or 'unknown'}; label is a self-declared JUMBF field, not a "
+            "verified issuer — see forkwright/typikon#148)",
             file=sys.stderr,
         )
 

--- a/ci/asset-provenance.sh
+++ b/ci/asset-provenance.sh
@@ -22,8 +22,10 @@ set -euo pipefail
 # A found manifest on a path the consumer has NOT listed in config.toml's
 # `extra.c2pa_declared_assets` glob list fails the build, naming the
 # offending path, the container, and the manifest's label where the
-# manifest carries one (its cryptographic issuer is not recoverable
-# without a COSE/X.509 parser — see the scanner's module docstring).
+# manifest carries one. That label is a self-declared JUMBF field, not a
+# cryptographically verified issuer — the issuer is not recoverable
+# without a COSE/X.509 parser (see the scanner's module docstring and
+# forkwright/typikon#148).
 #
 # Exit:
 #   0  no undeclared manifests found
@@ -68,6 +70,7 @@ elif [[ $status -eq 1 ]]; then
     echo "asset-provenance: undeclared manifest(s) found:" >&2
     cat "$SCAN_ERR" >&2
     echo "" >&2
+    echo "asset-provenance: reported label(s) above are self-declared JUMBF fields, not verified issuers — see forkwright/typikon#148." >&2
     echo "asset-provenance: $VIOLATIONS asset(s) carry undeclared provenance metadata." >&2
     echo "Fix by stripping the manifest from the asset, or declaring it in config.toml:" >&2
     echo '    [extra]' >&2

--- a/ci/check-asset-provenance.py
+++ b/ci/check-asset-provenance.py
@@ -71,6 +71,20 @@ def manifest_store(label: str) -> bytes:
     return jumbf_box(b"jumb", jumbf_box(b"jumd", jumd_payload(label)))
 
 
+def manifest_store_truncated_jumd() -> bytes:
+    """A jumb box wrapping a jumd box whose payload is truncated below the
+    16-byte UUID + 1-byte toggle minimum (ISO/IEC 19566-5 5.2) that
+    parse_jumd_label requires before it will index into the payload.
+
+    Regression fixture for forkwright/typikon#150's must-fix: proves a
+    malformed inner box tree still lets channel-level detection fire (the
+    actual gate) and degrades the label to unknown by returning cleanly out
+    of parse_jumd_label's own length guard, never by throwing and catching —
+    scan_file carries no exception handler around this call at all.
+    """
+    return jumbf_box(b"jumb", jumbf_box(b"jumd", b"short"))
+
+
 # --- PNG ---------------------------------------------------------------
 
 
@@ -91,6 +105,20 @@ def build_png(manifest_label: str | None) -> bytes:
         chunks.append(png_chunk(b"caBX", manifest_store(manifest_label)))
     chunks.append(png_chunk(b"IDAT", zlib.compress(b"\x00\x00\x00\x00\x00")))
     chunks.append(png_chunk(b"IEND", b""))
+    return PNG_SIGNATURE + b"".join(chunks)
+
+
+def build_png_with_raw_manifest(manifest_bytes: bytes) -> bytes:
+    """Embed pre-built (possibly malformed) manifest bytes directly, bypassing
+    manifest_store()'s label encoding — for fixtures that need a corrupt box
+    tree rather than a corrupt label string."""
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0)  # 1x1 RGBA
+    chunks = [
+        png_chunk(b"IHDR", ihdr),
+        png_chunk(b"caBX", manifest_bytes),
+        png_chunk(b"IDAT", zlib.compress(b"\x00\x00\x00\x00\x00")),
+        png_chunk(b"IEND", b""),
+    ]
     return PNG_SIGNATURE + b"".join(chunks)
 
 
@@ -189,6 +217,7 @@ def main() -> int:
             "clean.png": build_png(None),
             "manifest.png": build_png(LABEL_PNG),
             "manifest-lying-chunk.png": build_png_with_lying_chunk(LABEL_PNG_LYING_LENGTH),
+            "manifest-malformed-label.png": build_png_with_raw_manifest(manifest_store_truncated_jumd()),
             "clean.jpg": build_jpeg(b""),
             "manifest-single.jpg": jpeg_single_segment(LABEL_JPEG_SINGLE),
             "manifest-split.jpg": jpeg_split_segments(LABEL_JPEG_SPLIT),
@@ -221,6 +250,13 @@ def main() -> int:
         if result.returncode != 1:
             failures.append(f"mixed fixture set: expected exit 1 (undeclared manifests present), got {result.returncode}\nstderr:\n{result.stderr}")
 
+        # forkwright/typikon#150's must-fix: a malformed inner box tree
+        # (manifest-malformed-label.png) must degrade to label=unknown, not
+        # crash the whole scan. A crash would surface here as an unhandled
+        # Python traceback in stderr instead of a clean violation line.
+        if "Traceback (most recent call last)" in result.stderr:
+            failures.append(f"scan crashed instead of degrading gracefully on a malformed box tree:\n{result.stderr}")
+
         violation_lines = [line for line in result.stderr.splitlines() if "undeclared C2PA manifest present" in line]
 
         expected_violations = {
@@ -229,6 +265,7 @@ def main() -> int:
             "manifest-single.jpg": f"JPEG: undeclared C2PA manifest present (label={LABEL_JPEG_SINGLE}",
             "manifest-split.jpg": f"JPEG: undeclared C2PA manifest present (label={LABEL_JPEG_SPLIT}",
             "manifest.svg": f"SVG: undeclared C2PA manifest present (label={LABEL_SVG}",
+            "manifest-malformed-label.png": "PNG: undeclared C2PA manifest present (label=unknown",
         }
         for name, expected in expected_violations.items():
             if not any(name in line and expected in line for line in violation_lines):

--- a/ci/check-asset-provenance.py
+++ b/ci/check-asset-provenance.py
@@ -6,7 +6,10 @@ Constructs synthetic PNG, JPEG, and SVG fixtures byte-for-byte in Python
 end to end (not just the inner scanner module) that:
 
 - a manifest embedded via each container's real C2PA channel fails the
-  gate and the failure names the path, the container, and the label;
+  gate and the failure names the path, the container, and the label —
+  explicitly disambiguated from a verified issuer inline, not only in a
+  docstring (forkwright/typikon#137's reopening; issuer extraction is
+  forkwright/typikon#148);
 - an asset with no manifest passes;
 - an asset whose manifest the consumer declared in config.toml passes;
 - a JPEG manifest split across two APP11 segments is reassembled and
@@ -221,11 +224,11 @@ def main() -> int:
         violation_lines = [line for line in result.stderr.splitlines() if "undeclared C2PA manifest present" in line]
 
         expected_violations = {
-            "manifest.png": f"PNG: undeclared C2PA manifest present (label={LABEL_PNG})",
-            "manifest-lying-chunk.png": f"PNG: undeclared C2PA manifest present (label={LABEL_PNG_LYING_LENGTH})",
-            "manifest-single.jpg": f"JPEG: undeclared C2PA manifest present (label={LABEL_JPEG_SINGLE})",
-            "manifest-split.jpg": f"JPEG: undeclared C2PA manifest present (label={LABEL_JPEG_SPLIT})",
-            "manifest.svg": f"SVG: undeclared C2PA manifest present (label={LABEL_SVG})",
+            "manifest.png": f"PNG: undeclared C2PA manifest present (label={LABEL_PNG}",
+            "manifest-lying-chunk.png": f"PNG: undeclared C2PA manifest present (label={LABEL_PNG_LYING_LENGTH}",
+            "manifest-single.jpg": f"JPEG: undeclared C2PA manifest present (label={LABEL_JPEG_SINGLE}",
+            "manifest-split.jpg": f"JPEG: undeclared C2PA manifest present (label={LABEL_JPEG_SPLIT}",
+            "manifest.svg": f"SVG: undeclared C2PA manifest present (label={LABEL_SVG}",
         }
         for name, expected in expected_violations.items():
             if not any(name in line and expected in line for line in violation_lines):
@@ -238,8 +241,19 @@ def main() -> int:
         if len(violation_lines) != len(expected_violations):
             failures.append(f"expected exactly {len(expected_violations)} violation line(s), got {len(violation_lines)}:\n" + "\n".join(violation_lines))
 
+        # forkwright/typikon#137's reopening: a `label` must never read as a
+        # verified issuer. Every violation line disambiguates inline (not
+        # merely in a docstring a gate-failure reader would never open), and
+        # points at forkwright/typikon#148 where issuer extraction is scoped.
+        for line in violation_lines:
+            if "not a verified issuer" not in line or "typikon#148" not in line:
+                failures.append(f"violation line does not disambiguate label from issuer: {line!r}")
+
         if not any("note:" in line and "declared C2PA manifest" in line for line in result.stderr.splitlines()):
             failures.append(f"expected a declared-manifest note for declared.jpg; not found in stderr:\n{result.stderr}")
+
+        if not any("self-declared JUMBF fields, not verified issuers" in line for line in result.stderr.splitlines()):
+            failures.append(f"expected the stage-level label/issuer disambiguation line; not found in stderr:\n{result.stderr}")
 
     # Second run: only clean + declared assets present — proves a fully
     # clean site (nothing to complain about) exits 0, not merely "exit 1


### PR DESCRIPTION
## Finding

#137's Done-when bullet 2 asked that a gate failure name "the file path and the issuer." PR #138 shipped detection but could only ever report the JUMBF description box's `label` — a self-declared string, not the manifest's cryptographically verified issuer — because the true issuer lives inside a COSE-signed X.509 certificate, CBOR/ASN.1-encoded several JUMBF box levels deeper than the description box, and #137's own Desired-correction bullets forbid the dependency that would parse it ("which the stdlib covers with no new dependency" / Done-when: "The stage adds no external tool prerequisite"). An op-pause completion audit caught this as a genuine conflict between two requirements within the same issue (reopening comment on #137, 2026-08-14) and recommended: report the label, name it explicitly as a label rather than an issuer, and track issuer verification as separate scoped work.

That recommendation was only half-delivered. The scanner already printed `label=...` (not `issuer=...`) — so it wasn't fabricating a claim — but nothing at the point a reader actually sees a gate failure said a label is *not* an issuer. That disambiguation lived only in the module's docstring, which nobody reads mid-CI-failure.

## Evidence

- `ci/asset-provenance-scan.py:376-382` (pre-change) — the violation line said `(label={label or 'unknown'})` with no note that this is not a verified issuer.
- `ci/asset-provenance-scan.py:23-28` (pre-change) — the disambiguation existed only here, in the module docstring's INVARIANT section.
- `ci/asset-provenance-scan.py:311` (pre-change) — `except Exception:` in `scan_file`'s label-extraction guard is `kanon lint`'s `PY/bare-except` (confirmed via `kanon lint ci/ --all` before this change; clean after).

## Why this matters

A JUMBF label is chosen by whoever produced the manifest and carries no cryptographic guarantee about who signed the content — the issuer is the part of a C2PA claim actually worth trusting. The reopening comment named the exact risk: "a reader mistaking a manifest label for a verified issuer — which is exactly the mistake this gate exists to prevent." A docstring nobody opens during a red CI run does not prevent that mistake; only the failure text itself does.

## Desired correction (delivered)

- `ci/asset-provenance-scan.py`: every violation line now reads `(label=X; label is a self-declared JUMBF field, not a verified issuer — see forkwright/typikon#148)`.
- `ci/asset-provenance.sh`: the stage-level failure summary adds a matching one-line disambiguation before listing violations, and the header comment states the same.
- `ci/check-asset-provenance.py`: asserts every violation line contains `not a verified issuer` and `typikon#148`, and that the stage-level summary line is present. **Verified watched-failing**, not just added: I reverted the disambiguation text locally, re-ran `python3 ci/check-asset-provenance.py`, and got 5 `FAIL: violation line does not disambiguate label from issuer: ...` lines (one per manifest fixture) with exit 1; restoring the change returns to `OK: asset-provenance stage verified across PNG/JPEG/SVG, single- and multi-segment JPEG, and declared-asset exemption` with exit 0. A reviewer can reproduce this by diffing the print statement back to `f"(label={label or 'unknown'})"` and re-running the same command.
- Filed forkwright/typikon#148 to scope full COSE/X.509 issuer extraction as its own unit, since it needs a dependency decision #137 explicitly forbade making implicitly.
- Amended #137's Done-when bullet 2 to state what the stage actually delivers (a named `label`, not a fabricated issuer) and point at #148, per the reopening comment's own recommendation ("Amend this Done-when to say `label`").

## Correction to an earlier commit on this branch (post-review)

An independent adversarial review of this PR (must_fix) found that the first commit's `scan_file`'s bare `except Exception:` -> `except (IndexError, ValueError):` narrowing, and its accompanying SAFETY comment claiming "IndexError/ValueError are the class a corrupt/truncated box tree can raise," were **factually wrong**. Tracing every function reachable from that `try` block (`extract_manifest_label` -> `iter_jumbf_boxes` / `parse_jumd_label`) shows every index and slice is already preceded by an explicit length check (`if len(payload) < 17: return None` before `payload[16]`; `if not children or ...` before `children[0]`; etc.), and `int.from_bytes` / `.decode(errors="replace")` never raise for any bytes input. **No IndexError or ValueError is reachable anywhere in that call graph, for any input** — the narrowed except was dead code, and narrowing it silently dropped the bare except's incidental protection against a *different* exception type (TypeError, KeyError, ...) from a future bug crashing `main()`'s per-file loop, which has no surrounding try/except (`ci/asset-provenance-scan.py:376`, unchanged by this PR). The review also correctly noted no fixture exercised this branch, and — per finding 1 — none could, since it is unreachable.

Fixed in the second commit on this branch:

- Removed the try/except entirely. `scan_file` now calls `extract_manifest_label` unguarded, with an INVARIANT comment explaining why: the call graph fails closed *by construction* (the guards), not by exception handling, so there is nothing to legitimately catch. `kanon lint ci/ --all` stays clean (confirmed) — the fix is honest rather than lint-satisfying-by-accident.
- On the "future bug crashes the whole scan" concern specifically: I chose not to reintroduce broad exception handling to paper over an unknown future bug type, because (a) no specific type can be named for a bug that doesn't exist yet, which is exactly why the narrowing attempt failed, and (b) this file's own cited precedent, `ci/csp-scan.py`'s per-file loop, carries no exception guard around its per-file processing either — a bug there already crashes loud today. A loud CI crash on a genuine future defect is the behavior `PY/bare-except` exists to select for everywhere else in this codebase; swallowing it silently to `label=None` would ship the bug invisibly instead. This is a stated design position, not a dodge — if a reviewer wants a specific broader guard, name the exception type it should catch and the corrupt/adversarial input that would raise it (see next bullet: I looked for one and found none the guards don't already prevent by returning cleanly).
- Added a real negative-case fixture: `manifest-malformed-label.png` (`manifest_store_truncated_jumd()` in `ci/check-asset-provenance.py`) embeds a `jumb` box wrapping a `jumd` box truncated to 5 bytes — below the 17-byte minimum `parse_jumd_label` requires before indexing. The check asserts the stage still reports a violation (`label=unknown`, i.e., channel-level detection is unaffected) and that stderr carries no Python traceback. **Verified watched-failing**: I weakened the guard the fixture targets (`if len(payload) < 17:` -> `if len(payload) < 1:`), reran `python3 ci/check-asset-provenance.py`, and got exactly the predicted crash — an uncaught `IndexError` at `payload[16]`, propagating out of `scan_file` through `main()`'s loop, aborting the scan after only 3 of the expected 6 violation lines printed (the malformed fixture and everything scanned after it in argument order never got reported). Restoring the guard returns the fixture to `OK`, exit 0. A reviewer can reproduce this the same way.

## What a reviewer would have to disprove

- That the new violation-line text and stage-summary line are genuinely present at runtime — reproducible via `python3 ci/check-asset-provenance.py` (exit 0, `OK: ...` on stdout) or by running `ci/asset-provenance.sh` against any consumer site with a planted manifest and reading stderr directly.
- That `extract_manifest_label`'s call graph (`iter_jumbf_boxes`, `parse_jumd_label`) *can* raise something for some byte input despite the guards — name the specific line and the input.
- That `manifest-malformed-label.png` does not actually exercise `parse_jumd_label`'s length guard, or that weakening that guard does not reproduce the crash described above — reproducible by the same edit-and-rerun.
- That #137's amended Done-when no longer matches what's shipped — it can be checked directly against this PR's diff and the running fixture.

Closes #137
