### PR TITLE
fix(ci): stop exempting the gate's own fixture corpus from full-gate-build

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -134,7 +134,20 @@ jobs:
       needs_fleet_repo_token: false
       rust_cache_key: "gate-attestation"
       ai_attribution_check: true
-      docs_only_exemption: true
+      # WHY false, not the reusable's true default: the reusable's
+      # docs-only classifier keys on file extension alone (*.md, docs/*,
+      # llms.txt) and cannot tell examples/*/content/**.md -- the fixture
+      # corpus ci/run-fixtures.sh builds and asserts against -- apart from
+      # real documentation. A diff confined to that corpus matched the
+      # pattern and skipped full-gate-build, the one job that would have
+      # caught a broken fixture (#122; PR #120's run 31339059510 is the
+      # empirical case: three green checks, full-gate-build never ran).
+      # ci/check-fixture-corpus-exemption.sh is the regression guard.
+      # The fleet-wide fix -- parameterizing the shared classifier in
+      # forkwright/.github to exclude gate-input globs -- has wider blast
+      # radius than one repo and stays out of scope here; see #122's
+      # "Desired correction".
+      docs_only_exemption: false
     # WHY no secrets block: the reusable's only declared secret is
     # FLEET_REPO_TOKEN, required solely when needs_fleet_repo_token is
     # true (set false above). check_cmd consumes no repository secret

--- a/ci/check-fixture-corpus-exemption.sh
+++ b/ci/check-fixture-corpus-exemption.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 # repo wants deliberate review, not a drive-by edit from a single-repo fix
 # (#122's own "Desired correction" section says so explicitly).
 #
-# WHAT this proves, as a negative case:
+# NOTE: this script proves two things, as a negative case:
 #   1. [control] the corpus-only diff below DOES match the shared
 #      classifier's bare path pattern -- i.e. this really is the shape #120
 #      hit, not a pattern this script invented.
@@ -47,8 +47,7 @@ set -euo pipefail
 # assertion 1 pass vacuously instead of failing loudly, so re-verify this
 # pattern by hand against forkwright/.github on any SHA bump.
 #
-# Usage:
-#     ci/check-fixture-corpus-exemption.sh
+# NOTE: takes no arguments -- run as ci/check-fixture-corpus-exemption.sh.
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW="$ROOT/.github/workflows/gate-attestation.yml"

--- a/ci/check-fixture-corpus-exemption.sh
+++ b/ci/check-fixture-corpus-exemption.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-fixture-corpus-exemption — regression test for forkwright/typikon#122.
+#
+# WHY: .github/workflows/gate-attestation.yml calls forkwright/.github's
+# hybrid-gate.yml reusable with a docs_only_exemption input. The reusable's
+# classifier (check-trailer job, "Check for docs-only changeset" step) treats
+# every changed path matching *.md/docs/*/llms.txt as documentation and skips
+# full-gate-build. examples/*/content/**.md is NOT documentation -- it is the
+# fixture corpus ci/run-fixtures.sh builds and asserts against (bin/typikon-
+# check zola-builds examples/sample-blog and examples/sample-shop). A diff
+# confined to that corpus matched the pattern and skipped the one job that
+# would have caught a broken fixture -- proven empirically by #120 (run
+# 31339059510: three green checks, full-gate-build never ran, on a PR that
+# touched only the two fixture files reproduced below).
+#
+# WHY this repo cannot use the pattern-level exemption at all: the classifier
+# lives in forkwright/.github (a separate repo, pinned by SHA below) and keys
+# on file extension alone -- it has no notion of "gate input" vs
+# "documentation" to parameterize per-caller. typikon's fix is therefore
+# local: docs_only_exemption is false in gate-attestation.yml, so
+# full-gate-build always runs regardless of what changed. The fleet-wide fix
+# (teach the shared classifier to exclude gate-input globs like examples/**)
+# is out of scope here -- a shared reusable used by every fleet Rust+Zola
+# repo wants deliberate review, not a drive-by edit from a single-repo fix
+# (#122's own "Desired correction" section says so explicitly).
+#
+# WHAT this proves, as a negative case:
+#   1. [control] the corpus-only diff below DOES match the shared
+#      classifier's bare path pattern -- i.e. this really is the shape #120
+#      hit, not a pattern this script invented.
+#   2. [regression guard] applying THIS repo's actual configured
+#      docs_only_exemption value (read from the real workflow file, never
+#      hardcoded here) to that same diff yields NOT exempt. This fails loudly
+#      if gate-attestation.yml is ever edited back to docs_only_exemption:
+#      true without the shared classifier also being parameterized -- the
+#      exact regression #122 reports.
+#
+# NOTE: the case pattern below is a manual mirror of forkwright/.github's
+# hybrid-gate.yml "Check for docs-only changeset" step, at the SHA
+# gate-attestation.yml currently pins (read below, not hardcoded). It cannot
+# import that file -- a workflow_call reusable in another repo, not a local
+# composite action -- so this is structural duplication, the same shape
+# hybrid-gate.yml's own fleet-git-credentials comment names when it
+# duplicates aletheia's guard by hand. A divergence here would make
+# assertion 1 pass vacuously instead of failing loudly, so re-verify this
+# pattern by hand against forkwright/.github on any SHA bump.
+#
+# Usage:
+#     ci/check-fixture-corpus-exemption.sh
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/gate-attestation.yml"
+[[ -f "$WORKFLOW" ]] || { echo "error: $WORKFLOW not found" >&2; exit 2; }
+
+FAIL=0
+fail() {
+    echo "FAIL: $1" >&2
+    FAIL=1
+}
+
+# ── read this repo's actual configured value, not an assumed one ──────
+EXEMPTION_LINE="$(grep -E '^[[:space:]]*docs_only_exemption:[[:space:]]*(true|false)[[:space:]]*$' "$WORKFLOW" || true)"
+if [[ -z "$EXEMPTION_LINE" ]]; then
+    echo "FAIL: no 'docs_only_exemption: true|false' input line found in $WORKFLOW -- cannot verify the exemption predicate" >&2
+    exit 1
+fi
+DOCS_ONLY_EXEMPTION="$(printf '%s' "$EXEMPTION_LINE" | grep -oE 'true|false')"
+
+PIN_SHA="$(grep -oE 'hybrid-gate\.yml@[0-9a-f]{40}' "$WORKFLOW" | cut -d@ -f2 || true)"
+
+# ── the known-bad diff: PR #120's exact fixture-only changeset ────────
+DIFF_PATHS=(
+    "examples/sample-shop/content/sizing.md"
+    "examples/sample-shop/content/sizing-timed.md"
+)
+for p in "${DIFF_PATHS[@]}"; do
+    [[ -f "$ROOT/$p" ]] || fail "fixture path $p no longer exists -- update this script's known-bad diff to a current fixture-corpus change"
+done
+
+# ── mirror of hybrid-gate.yml's check-trailer docs-only pattern ───────
+# case *.md|docs/*|llms.txt -- verbatim from the pinned SHA's
+# "Check for docs-only changeset" step; see the NOTE above.
+pattern_match=true
+for p in "${DIFF_PATHS[@]}"; do
+    case "$p" in
+        *.md | docs/* | llms.txt) ;;
+        *) pattern_match=false ;;
+    esac
+done
+
+# 1. Control: the corpus-only diff really does match the bare pattern, so
+#    this is a faithful reproduction of #122's known-bad case.
+if [[ "$pattern_match" != true ]]; then
+    fail "control failed: ${DIFF_PATHS[*]} do not match the shared classifier's docs-only pattern (*.md|docs/*|llms.txt) -- this script no longer reproduces #122's known-bad case, pick fixture-corpus paths that do"
+fi
+
+# 2. Regression guard: the EFFECTIVE decision the reusable computes is
+#    pattern_match gated by the caller's docs_only_exemption input -- see
+#    hybrid-gate.yml's `if [ "$DOCS_ONLY_EXEMPTION" != "true" ]; then
+#    docs_only=false; fi` short-circuit ahead of the pattern loop.
+if [[ "$DOCS_ONLY_EXEMPTION" == "true" && "$pattern_match" == true ]]; then
+    effective_docs_only=true
+else
+    effective_docs_only=false
+fi
+
+if [[ "$effective_docs_only" == true ]]; then
+    fail "gate-attestation.yml (docs_only_exemption: ${DOCS_ONLY_EXEMPTION}, hybrid-gate.yml@${PIN_SHA:-unknown}) would classify a diff confined to ${DIFF_PATHS[*]} as docs-only and skip full-gate-build -- this is #122: the fixture corpus is not documentation. Set docs_only_exemption: false in ${WORKFLOW}."
+fi
+
+if [[ "$FAIL" -eq 0 ]]; then
+    echo '{"checked":"fixture-corpus-exemption","status":"pass","docs_only_exemption":"'"$DOCS_ONLY_EXEMPTION"'","pinned_sha":"'"${PIN_SHA:-unknown}"'"}'
+fi
+
+exit "$FAIL"

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -12,6 +12,7 @@ python3 "$ROOT/ci/check-asset-provenance.py"
 python3 "$ROOT/ci/check-control-contrast.py"
 "$ROOT/ci/check-workflow-template.sh" "$ROOT/ci/github-workflow.yml.tmpl"
 "$ROOT/ci/check-consumer-check-extension.sh"
+"$ROOT/ci/check-fixture-corpus-exemption.sh"
 
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-blog"
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-shop"


### PR DESCRIPTION
## Finding

`.github/workflows/gate-attestation.yml:137` passed `docs_only_exemption: true` to
`forkwright/.github`'s `hybrid-gate.yml` reusable, pinned at
`84a39d3344660e4010c32755b33a6a88912ad929`. That reusable's `check-trailer` job, in
its "Check for docs-only changeset" step, classifies any diff where every changed
path matches `*.md`/`docs/*`/`llms.txt` as docs-only and skips `full-gate-build`
entirely. The step runs `hybrid-gate.yml:155-219` at the pinned SHA (`:205-276` at
current `forkwright/.github` main); the case-pattern match itself is at `:208` pinned
/ `:266` main — verified both by `git show <ref>:.github/workflows/hybrid-gate.yml`
against the pinned SHA and `origin/main`. The pattern-match arm (`*.md|docs/*|llms.txt`)
is byte-identical between the two; only the diff-range computation feeding it changed
(two-dot `origin/${BASE_REF}..HEAD` at the pinned SHA → three-dot `...HEAD` on main,
an unrelated merge-base-vs-moving-base fix), which does not change what counts as a
match for a fixed diff like this repo's. `examples/*/content/**.md` matches `*.md`,
but it is not documentation: it is the fixture corpus `ci/run-fixtures.sh` builds and
asserts against via `bin/typikon-check` (`ci/run-fixtures.sh:16-17`). A diff confined
to that corpus is therefore classified exempt, when it is exactly the diff most in
need of the gate.

## Evidence

PR #120 touched only two fixture-corpus files:

```
examples/sample-shop/content/sizing.md
examples/sample-shop/content/sizing-timed.md
```

Run [31339059510](https://github.com/forkwright/typikon/actions/runs/31339059510):
`ai-attribution` success, `check-trailer` success, `gate` success, `full-gate-build`
**skipped**. Three green checks and an aggregate `gate` pass with the one job that
builds anything never having run.

## Why this matters

A fixture is how this repo proves a claim. A build failure #120's fixture would have
introduced — a schema violation, a broken link, a pa11y regression — would have
reached `main` with four green checks behind it, discovered only by the next PR that
happens to touch a `.sh`/`.ts` file. The classifier lives in a separate shared repo
(`forkwright/.github`) and keys on file extension alone; it has no notion of "gate
input" vs. "documentation" to parameterize per caller, so no path-level fix is
possible from this repo. Teaching the shared classifier to exclude gate-input globs
fleet-wide is out of scope here by design — issue #122 itself flags that as needing
deliberate review across every consumer, not a drive-by edit riding this fix.

## Desired correction

`.github/workflows/gate-attestation.yml:137` now sets `docs_only_exemption: false`
with an inline comment recording why: no diff can be exempted here without the
shared classifier being able to distinguish `examples/**` from real docs, which it
currently cannot. `full-gate-build` now runs on every PR to this repo regardless of
which paths changed — the repo is public, so this trades no metered CI budget.

`ci/check-fixture-corpus-exemption.sh` is the negative-case fixture, wired into
`ci/run-fixtures.sh:15` (so it runs as part of the gate's own `check_cmd`, not just
locally). It reads this repo's *actual* configured `docs_only_exemption` value out of
`gate-attestation.yml` (never hardcodes it) and, against PR #120's exact two-file
diff:

1. **Control** — asserts the diff still matches the shared classifier's bare pattern
   (`*.md|docs/*|llms.txt`), i.e. it is a faithful reproduction of #122's known-bad
   shape, not a pattern invented for this test.
2. **Regression guard** — computes the same effective decision `hybrid-gate.yml`
   computes (`pattern_match && docs_only_exemption == "true"`) and asserts it is
   `false`.

Ran directly against the un-fixed workflow (`docs_only_exemption: true`), it fails:

```
FAIL: gate-attestation.yml (docs_only_exemption: true,
hybrid-gate.yml@84a39d3344660e4010c32755b33a6a88912ad929) would classify a diff
confined to examples/sample-shop/content/sizing.md
examples/sample-shop/content/sizing-timed.md as docs-only and skip
full-gate-build -- this is #122
```

Against the fixed workflow in this PR, it passes:

```
{"checked":"fixture-corpus-exemption","status":"pass","docs_only_exemption":"false",
"pinned_sha":"84a39d3344660e4010c32755b33a6a88912ad929"}
```

A reviewer can disprove this by: reverting `docs_only_exemption` to `true` and
showing `ci/check-fixture-corpus-exemption.sh` still passes (it will not — that is
the fixture's whole job), or by showing the two cited fixture paths no longer match
the shared classifier's pattern (they do — both end in `.md`), or by showing
`ci/run-fixtures.sh` does not actually invoke the new script (it does, at line 15).

`cargo fmt` is not applicable (no Rust in this repo — `fmt_cmd`/`clippy_cmd`/
`nextest_cmd` are all no-ops per `gate-attestation.yml`'s own header comment).
`shellcheck ci/check-fixture-corpus-exemption.sh` and `shellcheck ci/run-fixtures.sh`
are both clean. `kanon lint . --all` reports zero findings against every file this PR
touches (one pre-existing, unrelated `PY/bare-except` finding in
`ci/asset-provenance-scan.py` predates this branch and is untouched by it).

## On #122's literal Done-when

#122's Done-when reads: "a PR touching only `examples/*/content/**.md` runs
`full-gate-build`, demonstrated by a run link." The evidence above is a local
shell-script simulation of the classifier plus PR #120's *old* run (which shows the
bug, not the fix) — neither is that run link. This is not an oversight; it is a
sequencing constraint worth stating plainly rather than arguing around:

`gate-attestation.yml`'s trigger is `pull_request: branches: [main]` (`:65-69`) —
GitHub filters `pull_request` on the PR's *base* branch, so the workflow only fires
at all when a PR targets `main`. For a `pull_request` run, GitHub executes the
workflow file as it exists in the merge of head into base — which is why this PR's
own head already ran `full-gate-build` under its own `docs_only_exemption: false`
(run [31921071233](https://github.com/forkwright/typikon/actions/runs/31921071233), this
PR's current head 059fc7d — all 4 jobs pass) even though `main` doesn't have that
value yet. But the PR *diff* GitHub
shows is always head vs. base: as long as `main` lacks this fix, any PR built on top
of it that also touches only fixture content would carry this fix's own workflow and
script changes in that diff too — it would not be "a PR touching only
`examples/*/content/**.md`." There is no diff shape that is simultaneously (a)
confined to fixture content and (b) evaluated against the fixed classifier unless the
fix is already merged to `main`. The empirical demonstration #122 asks for is
therefore only producible *after* this PR merges, not before it.

Plan, so this doesn't get silently dropped: merge this PR, then open a follow-up PR
against the now-fixed `main` touching only a fixture-corpus file (e.g. a no-op
content edit to `examples/sample-shop/content/sizing.md`), and post that run's link
as a comment on #122 before closing it. #122 is intentionally NOT auto-closed by this
PR (see below) so that comment is the actual closing action, not this merge.

Addresses #122 — left open; closed separately once the run-link comment above lands,
per the plan in "On #122's literal Done-when."

