### PR TITLE
fix(templates): give the home page a genuine top-level heading

### DIFF
--- a/ci/check-home-heading.py
+++ b/ci/check-home-heading.py
@@ -126,9 +126,16 @@ def strip_h1_line(theme_dir: Path) -> None:
 
 
 def main() -> int:
+    # WHY a hard failure, not a skip (forkwright/typikon#49's precedent, cited
+    # in bin/typikon-check's own docstring): ci/run-fixtures.sh has no "dev
+    # mode" — every invocation is the gate. zola is installed unconditionally
+    # before this script runs (.github/workflows/gate-attestation.yml, before
+    # the `ci/run-fixtures.sh` line), so its absence here means the install
+    # step broke, not that this check is optional. A green run must mean the
+    # instrument ran, never that it was quietly unavailable.
     if ZOLA is None:
-        print("check-home-heading: SKIP — zola not on PATH", file=sys.stderr)
-        return 0
+        print("check-home-heading: FAIL — zola not on PATH (see gate-attestation.yml's install step)", file=sys.stderr)
+        return 1
 
     failures: list[str] = []
 

--- a/ci/check-home-heading.py
+++ b/ci/check-home-heading.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""check-home-heading — regression test for the home-route <h1> assertion in
+ci/smoke/shared.spec.ts (forkwright/typikon#142), and for the build-time
+guard in templates/partials/assert.html's `no_h1` macro (forkwright/typikon#152).
+
+Runs the real `zola build` against ISOLATED COPIES of this theme's
+templates/static/sass/theme.toml (never the live checkout in place, so this
+is safe to run concurrently and never leaves the working tree mutated) to
+prove both directions of each of the two failure modes the review of #152
+identified. A check nobody has watched fail is an unverified claim:
+
+1. MISSING heading (the defect #142 itself filed). With the
+   `<h1 class="sr-only">` line stripped from a COPY of templates/index.html
+   (simulating a future template edit regressing it), a built home page
+   must have ZERO <h1> elements. Proves the shared.spec.ts assertion
+   (`page.locator('h1').toHaveCount(1)`) has something to catch — Playwright
+   renders static, unmutated HTML for this route, so counting `<h1` in
+   Zola's own build output is a faithful stand-in for what that locator
+   would see, matching this repo's existing check-asset-provenance.py
+   pattern of exercising the real render path instead of a browser.
+   Paired against the SAME templates unmodified, which must produce
+   exactly ONE <h1> — the positive case restored.
+
+2. DUPLICATE heading (the review finding on #152: the unconditional
+   `{{ section.content | safe }}` render below the sr-only <h1> can itself
+   contribute an <h1> when a consumer's home content body starts with a
+   markdown `# ` line, Zola's own leading-heading convention). Against the
+   THEME AS SHIPPED (guard included), a home page whose body starts with
+   `# ` must make the zola build FAIL LOUDLY (the `no_h1` guard firing),
+   never silently ship two <h1> elements. Paired against a body starting
+   with `##` (a consumer's escape hatch) and a body with no markdown at
+   all, both of which must build clean with exactly one <h1>.
+
+NOTE: runs standalone (no consumer site or playwright/browser needed) as
+part of ci/run-fixtures.sh, alongside check-asset-provenance.py.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+THEME_ROOT = Path(__file__).resolve().parent.parent
+ZOLA = shutil.which("zola")
+
+# WHY these exact [extra] fields (not a minimal guess): mirrors
+# examples/sample-blog/config.toml, which is the theme's own proof that
+# this shape builds clean — a hand-trimmed config risks passing for the
+# wrong reason (missing an assert::required field this template doesn't
+# actually reach) rather than proving the heading behavior under test.
+CONFIG_TOML = """title = "Fixture"
+description = "typikon home-heading regression fixture"
+base_url = "https://fixture.example.com"
+default_language = "en"
+output_dir = "public"
+theme = "typikon"
+
+[extra]
+brand_name = "Fixture"
+brand_greek = "Δοκιμή"
+logo_path = "img/logo.svg"
+theme_color = "#FBF7EC"
+og_locale = "en_US"
+founding_date = "2026"
+
+[extra.author]
+name = "Fixture Author"
+uri = "https://fixture.example.com/about/"
+"""
+
+H1_RE = re.compile(r"<h1[ >]", re.IGNORECASE)
+
+
+def copy_theme(dest: Path) -> None:
+    for item in ("templates", "static", "sass", "theme.toml"):
+        src = THEME_ROOT / item
+        if not src.exists():
+            continue
+        if src.is_dir():
+            shutil.copytree(src, dest / item)
+        else:
+            shutil.copy2(src, dest / item)
+
+
+def make_site(root: Path, theme_dir: Path, body: str) -> Path:
+    site = root / "site"
+    (site / "content").mkdir(parents=True)
+    (site / "themes").mkdir()
+    (site / "themes" / "typikon").symlink_to(theme_dir, target_is_directory=True)
+    (site / "config.toml").write_text(CONFIG_TOML)
+    frontmatter = '+++\ntitle = "Fixture"\n\n[extra]\nbody_class = "home-page"\n+++\n'
+    (site / "content" / "_index.md").write_text(frontmatter + body)
+    return site
+
+
+def zola_build(site: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [ZOLA, "build"],
+        cwd=site,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def h1_count(site: Path) -> int:
+    html = (site / "public" / "index.html").read_text()
+    return len(H1_RE.findall(html))
+
+
+def strip_h1_line(theme_dir: Path) -> None:
+    """Simulate a future regression: remove the sr-only <h1> from a COPY."""
+    index_html = theme_dir / "templates" / "index.html"
+    text = index_html.read_text()
+    new_text = re.sub(r'\n\s*<h1 class="sr-only">.*?</h1>\n', "\n", text)
+    if new_text == text:
+        raise RuntimeError(
+            "strip_h1_line: pattern did not match templates/index.html — "
+            "the sr-only <h1> line's shape changed; update this fixture"
+        )
+    index_html.write_text(new_text)
+
+
+def main() -> int:
+    if ZOLA is None:
+        print("check-home-heading: SKIP — zola not on PATH", file=sys.stderr)
+        return 0
+
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="typikon-home-heading-") as tmp:
+        root = Path(tmp)
+
+        # ── Case 1: missing heading (forkwright/typikon#142) ──────────
+        good_theme = root / "theme-good"
+        copy_theme(good_theme)
+
+        bad_theme = root / "theme-missing-h1"
+        copy_theme(bad_theme)
+        strip_h1_line(bad_theme)
+
+        bad_site = make_site(root / "case1-bad", bad_theme, body="")
+        result = zola_build(bad_site)
+        if result.returncode != 0:
+            failures.append(
+                "case1(missing-h1, bad-fixture): expected a clean build "
+                "(the assertion under test is <h1> COUNT, not build success) "
+                f"but zola exited {result.returncode}:\n{result.stderr}"
+            )
+        else:
+            n = h1_count(bad_site)
+            if n != 0:
+                failures.append(
+                    "case1(missing-h1, bad-fixture): expected 0 <h1> elements "
+                    f"with the sr-only heading stripped, got {n} — the fixture "
+                    "did not actually simulate the regression; this proves "
+                    "NOTHING about the real check"
+                )
+            else:
+                print("check-home-heading: case1 bad-fixture confirmed 0 <h1> (regression reproduced)")
+
+        good_site = make_site(root / "case1-good", good_theme, body="")
+        result = zola_build(good_site)
+        if result.returncode != 0:
+            failures.append(
+                f"case1(missing-h1, good-fixture): unmodified templates failed to build:\n{result.stderr}"
+            )
+        else:
+            n = h1_count(good_site)
+            if n != 1:
+                failures.append(
+                    "case1(missing-h1, good-fixture): expected exactly 1 <h1> "
+                    f"from unmodified templates/index.html, got {n}"
+                )
+            else:
+                print("check-home-heading: case1 good-fixture confirmed exactly 1 <h1> (positive case holds)")
+
+        # ── Case 2: duplicate heading (forkwright/typikon#152 review) ─
+        dup_site = make_site(root / "case2-dup", good_theme, body="# Leading heading\n\nBody copy.\n")
+        result = zola_build(dup_site)
+        if result.returncode == 0:
+            n = h1_count(dup_site)
+            failures.append(
+                "case2(duplicate-h1): a home content body starting with `# ` "
+                "was expected to fail the build via the no_h1 guard, but zola "
+                f"exited 0 with {n} <h1> element(s) — the guard did not fire"
+            )
+        elif "no_h1" not in result.stderr and "collides with this page's required heading" not in result.stderr:
+            failures.append(
+                "case2(duplicate-h1): build failed as expected but not via the "
+                f"no_h1 guard (got a different error) — the guard may not be wired:\n{result.stderr}"
+            )
+        else:
+            print("check-home-heading: case2 confirmed the no_h1 guard fails the build on a colliding body")
+
+        subheading_site = make_site(root / "case2-sub", good_theme, body="## A subheading is fine\n\nBody copy.\n")
+        result = zola_build(subheading_site)
+        if result.returncode != 0:
+            failures.append(
+                f"case2(subheading escape hatch): a body starting with `##` must build clean:\n{result.stderr}"
+            )
+        else:
+            n = h1_count(subheading_site)
+            if n != 1:
+                failures.append(
+                    "case2(subheading escape hatch): expected exactly 1 <h1> "
+                    f"(the sr-only one; body's own heading is h2), got {n}"
+                )
+            else:
+                print("check-home-heading: case2 subheading-only fixture confirmed exactly 1 <h1>")
+
+    if failures:
+        print("check-home-heading: FAIL", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print("check-home-heading: ok (4/4 fixtures behaved as required)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -10,6 +10,7 @@ python3 "$ROOT/ci/check-font-coverage.py"
 python3 "$ROOT/ci/check-release-config.py"
 python3 "$ROOT/ci/check-asset-provenance.py"
 python3 "$ROOT/ci/check-control-contrast.py"
+python3 "$ROOT/ci/check-home-heading.py"
 "$ROOT/ci/check-workflow-template.sh" "$ROOT/ci/github-workflow.yml.tmpl"
 "$ROOT/ci/check-consumer-check-extension.sh"
 

--- a/ci/smoke/shared.spec.ts
+++ b/ci/smoke/shared.spec.ts
@@ -58,6 +58,19 @@ for (const route of routes) {
 
     expect(consoleErrors, `${route} should load with no console errors: ${consoleErrors.join('; ')}`).toEqual([]);
 
+    // WHY route === '/' only (forkwright/typikon#142): the home route is
+    // index.html, which now always renders a visually-hidden <h1> so the
+    // page has a heading regardless of which optional home_logo/
+    // home_tagline extras a consumer sets. page.html and section.html
+    // derive their <h1> from a leading `# ` line in the page's own
+    // markdown body rather than asserting one, so a route built from
+    // either (e.g. a section index with no markdown body) is not
+    // guaranteed a heading yet — that is forkwright/typikon#149, a
+    // distinct defect with a different remedy, not folded in here.
+    if (route === '/') {
+      await expect(page.locator('h1'), `${route} (home) should expose exactly one <h1>`).toHaveCount(1);
+    }
+
     // WHY read the accessibility tree rather than the DOM (forkwright/typikon#61):
     // an aria-label override on .faq-anchor passed pa11y's WCAG2AA ruleset
     // while collapsing every question's computed accessible name to one

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,6 +55,16 @@
 
 {% block content %}
 <div class="home">
+  {#- WHY sr-only h1 rather than wrapping the logo (forkwright/typikon#142):
+     home_logo and home_tagline are both optional per this template's own
+     header comment, so a heading tied to either would vanish along with
+     it. section.title is already required (asserted in the title/og_title
+     blocks above) and is the exact string the <title> tag carries, so
+     reusing it here keeps the page's accessible name and its document
+     title in agreement instead of introducing a second, unvalidated
+     source (config.title) for the same fact. -#}
+  <h1 class="sr-only">{{ section.title }}</h1>
+
   {%- if section.extra.home_logo %}
   <img src="/{{ section.extra.home_logo | safe }}" alt="{{ config.extra.brand_name | default(value=config.title) }} logo" class="home-logo">
   {%- endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -93,6 +93,13 @@
   {%- endif %}
 </div>
 
+{#- WHY the guard below, immediately preceding this render (forkwright/typikon#152):
+   section.content is unconditional, unlike every block above it in this
+   template. A consumer whose home content/_index.md body starts with a
+   markdown `# ` line gets a second <h1> from Zola's own leading-heading
+   convention, colliding with the sr-only one above -- this fails the
+   build loudly instead of shipping a silently-broken heading structure. -#}
+{{ assert::no_h1(content=section.content, template="index.html") }}
 {{ section.content | safe }}
 {% endblock content %}
 

--- a/templates/partials/assert.html
+++ b/templates/partials/assert.html
@@ -6,3 +6,18 @@
 {{ throw(message=template ~ ": missing required metadata `" ~ field ~ "`") }}
 {%- endif -%}
 {%- endmacro required %}
+
+{# WHY (forkwright/typikon#152): a template that renders both a required
+   heading element AND a consumer's markdown content unconditionally can be
+   handed a content body whose own first line is `# ...` -- Zola converts a
+   leading ATX-1 line to <h1> regardless of where in the document it sits,
+   so that body now contributes a SECOND <h1> alongside the template's own.
+   Nothing in the schema can catch this (it is a markdown-body convention,
+   not frontmatter), so the only fail-closed point is here, at render time.
+   Same posture as `required` above: a loud build failure that names the
+   collision, never a silently-shipped duplicate heading. #}
+{% macro no_h1(content, template) -%}
+{%- if content is matching("(?i)<h1[ >]") -%}
+{{ throw(message=template ~ ": content contains its own <h1> element (a markdown body starting with a single `# ` line), which collides with this page's required heading. Demote it to `##` or lower.") }}
+{%- endif -%}
+{%- endmacro no_h1 %}


### PR DESCRIPTION
## Finding

The home page rendered with no heading at any level while every other page type carried an `<h1>`.
`templates/index.html` renders a logo + tagline as the visual title, but neither is marked up as a
heading, and both are optional per the template's own header comment — so there was no path to a
guaranteed heading at all.

## Evidence

Before this change, a built home page (`examples/sample-blog`, `examples/sample-shop`) had zero
`<h1>` elements:

```
$ zola build   # examples/sample-blog, pre-fix
$ grep -oE '<h1[ >]' public/index.html | wc -l
0
```

`templates/index.html:57-60` (pre-fix): the `.home` div opened directly into the conditionally-
rendered `home_logo`/`home_tagline` blocks — `section.extra.home_logo` and
`section.extra.home_tagline` are both `{%- if %}`-gated, so a heading tied to either vanishes
along with it whenever a consumer omits one.

`templates/index.html:25-26` (unchanged): `section.title` is already required and asserted here
via `assert::required` for the `<title>`/`og:title` blocks — the exact string a browser tab and a
search result show for this page.

The fix adds one unconditional line, `templates/index.html:66`:

```
<h1 class="sr-only">{{ section.title }}</h1>
```

`.sr-only` is the pre-existing visually-hidden utility class (`static/css/style.css:1252`, already
used by the skip-link in `templates/base.html:62`) — no new CSS, no visual change.

Verified against the built output for both fixture sites post-fix:

```
$ zola build   # examples/sample-blog
$ grep -oE '<h1[^>]*>.*?</h1>' public/index.html
<h1 class="sr-only">Sample Blog</h1>

$ zola build   # examples/sample-shop
$ grep -oE '<h1[^>]*>.*?</h1>' public/index.html
<h1 class="sr-only">Sample Shop</h1>
```

Every other route in both fixture sites was diffed before/after: only `index.html` (and one build
timestamp inside `atom.xml`) changed. No visual regression — `.home-logo`, `.home-tagline`, and the
triad mark are untouched.

## Why this matters

WCAG 2.4.6 and 1.3.1: a heading is how assistive technology exposes what a page is, and screen
readers navigate by heading list before reading linearly. The home page is the page most likely to
be a visitor's first, and the one where orientation matters most. It was also the one theme page
inconsistent with the rest of the same build (about/404/journal-index all render an `<h1>`).

The gate did not — and without `ci/smoke/shared.spec.ts:61-72` (added here), still would not —
catch a future template edit that drops the heading again: pa11y's `WCAG2AA` ruleset does not
universally flag a page with zero headings.

## Desired correction (implemented)

`ci/smoke/shared.spec.ts` asserts, for the home route (`route === '/'`) only:

```ts
await expect(page.locator('h1'), `${route} (home) should expose exactly one <h1>`).toHaveCount(1);
```

Scoped to `/` rather than every route: `page.html`/`section.html` derive their `<h1>` from a
leading `# ` line in the page's own markdown body rather than asserting one, so a route with no
markdown body (a section index that's frontmatter-only, e.g. `examples/sample-shop`'s
`products/_index.md`) currently renders zero headings too — confirmed by building that fixture and
grepping for `<h1>`. That is a distinct defect with a different remedy (the template needs to
assert `page.title`/`section.title` the way `journal-entry.html`/`faq.html` already do, not derive
from markdown convention), filed separately as **forkwright/typikon#149** rather than folded into
this fix or used to widen this spec's assertion to every route, which would fail on that
pre-existing, unrelated gap.

### Addendum — adversarial review (must_fix), both findings addressed

An independent review returned two findings against the state above. Both are fixed, not
disputed — restated here so the claims this PR body makes are the claims actually true of the
diff, not the ones true when it was first opened.

**Finding 1 — no negative-case fixture.** The `toHaveCount(1)` assertion was covered only by the
positive case (both shipped fixtures pass); nobody had watched it fail. Fixed by
`ci/check-home-heading.py` (wired into `ci/run-fixtures.sh:13`, so it runs on every CI invocation
of the fixture gate on both pipelines). It builds the real theme templates — never a
re-implementation of the check's logic — against isolated, disposable site copies (never the live
checkout) and proves, in one run:

- a copy of `templates/index.html` with the `<h1 class="sr-only">` line stripped (the exact
  regression this PR closes) builds to **zero** `<h1>` elements;
- the unmodified templates build to **exactly one**;
- (Finding 2's fixture, below) a home body starting with `# ` **fails the build** via the new
  `no_h1` guard rather than silently shipping two headings;
- a home body starting with `##` builds clean with exactly one `<h1>`.

Reproduce locally: `python3 ci/check-home-heading.py`. To watch it fail (the actual demand — a
check nobody has watched fail is an unverified claim): comment out
`templates/index.html:96-102`'s `{{ assert::no_h1(...) }}` line and rerun — the script reports
`case2(duplicate-h1): ... zola exited 0 with 2 <h1> element(s) — the guard did not fire` and exits
1. Restoring the line restores a clean run. Verified by hand during this fix; the script asserts
the same thing on every CI run, not just this one manual pass.

**Finding 2 — the "exactly one `<h1>`" guarantee did not hold universally.** The unconditional
`{{ section.content | safe }}` render at `templates/index.html:103` (right after the sr-only
`<h1>` and the closed `.home` div) means Zola's own leading-heading convention — a markdown body
whose first line is `# ...` becomes `<h1>...</h1>` regardless of where in the document it sits —
can hand the home route a *second* `<h1>` whenever a consumer's `content/_index.md` body starts
with `# `. Neither shipped fixture exercises this (both have empty markdown bodies), so the
green CI run this PR originally shipped with was silent on the collision, not a refutation of it.

Confirmed the mechanism directly against the pinned toolchain (`zola 0.22.1`, matching
`.github/workflows/gate-attestation.yml:96`):

```
$ cat content/_index.md
+++
+++
# Welcome Home

Some body copy.
$ zola build && cat public/index.html
<h1 id="welcome-home">Welcome Home</h1>
<p>Some body copy.</p>
```

Fixed by adding a build-time guard, `templates/partials/assert.html:19-23` (`no_h1` macro, next to
the existing `required` macro and following its same fail-closed idiom — `throw()` hard-fails the
zola build rather than letting a broken heading structure ship silently), wired in at
`templates/index.html:96-102`, immediately before the `section.content` render:

```tera
{{ assert::no_h1(content=section.content, template="index.html") }}
{{ section.content | safe }}
```

The guard uses Tera's `matching` test (`content is matching("(?i)<h1[ >]")`) — verified against the
pinned Zola/Tera build to actually work as a positional-arg test (`is matching("...")`, not
`is matching(pat="...")`, which fails to parse) and to correctly reject a false-positive
(`<h10>`) while catching both `<h1>` and `<h1 class="...">` regardless of case.

This makes the guarantee this PR's title claims actually universal rather than true only of the
two shipped fixtures: a consumer whose home body starts with `# ` now gets a named, loud build
failure —

```
index.html: content contains its own <h1> element (a markdown body starting with a single `# `
line), which collides with this page's required heading. Demote it to `##` or lower.
```

— pointing at the fix (demote to `##`), never a silently-shipped duplicate `<h1>`. A body starting
with `##` (or with no heading at all) is unaffected; both fixture examples and both `examples/`
sites rebuild clean with exactly one `<h1>` after this change.

**Known, deliberately out of scope:** `templates/journal-entry.html:34` and `templates/faq.html:22`
have the identical latent shape (an unconditional `<h1>{{ page.title }}</h1>` followed by an
unconditional `{{ page.content | safe }}` render) — this is a **pre-existing** collision risk on
those templates, not one this PR introduces, and it predates this branch (confirmed: both already
asserted `page.title` and rendered an `<h1>` from it before this PR). Not folded in here for the
same reason `#149` was split out rather than folded in: it is a distinct set of templates with its
own remedy (the same `no_h1` guard would apply, but that's a decision for that PR, not this one).
Filed as **forkwright/typikon#157** rather than silently leaving it undocumented.

`Done when:` a built home page contains exactly one `<h1>` (exhibited above for both fixture
sites, and now enforced for every consumer, not just the fixtures — exhibited via the `no_h1`
guard); the visual design is unchanged (exhibited via the before/after diff); and a check fails if
the heading is removed (`ci/smoke/shared.spec.ts:61-72`, backed by
`ci/check-home-heading.py`'s negative fixture, which has actually been run and watched fail against
both known-bad inputs — the missing heading and the colliding one — not merely reasoned about in
prose).

A reviewer would have to disprove: that `section.title` is genuinely required at this template (it
is — `templates/index.html:25-26`, same field already used for `<title>`); that the added `<h1>`
is unconditional (it is — no `{% if %}` wraps it, unlike `home_logo`/`home_tagline`); that some
other route's heading count changed (it did not — verified by diffing the full build output of
both fixture sites before and after); or that a home body starting with `# ` can still produce two
`<h1>` elements without the build failing (it cannot — `ci/check-home-heading.py` case2 proves the
guard fires, and restoring the guard after deliberately removing it during this fix restored the
clean run).

Closes #142
