### PR TITLE
feat(schemas): add a fail-closed consumer schema registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Web-property-specific standards live alongside as kanon STANDARDS/WEB.md (filed 
 - **Self-hosted fonts**: WOFF2 under `static/fonts/`. Zero external CDN at visitor runtime. OFL families only.
 - **Push authority**: `origin` is GitHub (`forkwright/typikon`); no forge remote is configured. The typed forge/GitHub authority split is unresolved — forkwright/kanon#3045 owns it.
 - **License**: AGPL-3.0-or-later. Matches dioptron, aletheia. AI-training prohibition in NOTICE.
+- **Consumer schema registry**: a consumer site's custom-templated content types register in `schemas/registry.toml` and validate against their own schema, composed from typikon's open `page.core.schema.json`/`section.core.schema.json` building blocks and closed with `unevaluatedProperties: false`. A custom `template` with no registry entry fails validation naming the missing registration rather than falling back to `page`'s shape. See `docs/SCHEMAS.md#consumer-schema-registry`.
 
 ## How an agent operates here
 

--- a/_llm/decisions.toml
+++ b/_llm/decisions.toml
@@ -35,6 +35,14 @@ decision = "Define every content type in JSON Schema and validate before commit.
 consequences = "Fields are not invented in consumer repos."
 
 [[decision]]
+id = "D-consumer-schema-registry"
+title = "Consumer schema registry composes typikon core contracts"
+status = "accepted"
+context = "A consumer's custom-templated content had no domain schema and fell through to page/section's permissive extra object, so a typo'd field validated and became truthy."
+decision = "Custom templates register in schemas/registry.toml against a consumer-owned schema composed from page.core.schema.json/section.core.schema.json via allOf + $ref, closed with unevaluatedProperties: false. A custom template with no registration fails validation naming the missing entry."
+consequences = "Every content type's frontmatter is fully typed and closed, typikon-owned or consumer-owned alike; an invented field fails at validate time, not at render time."
+
+[[decision]]
 id = "D-strict-csp"
 title = "Enforce strict CSP"
 status = "accepted"

--- a/_llm/glossary.toml
+++ b/_llm/glossary.toml
@@ -21,6 +21,16 @@ definition = "A site that pins typikon as a submodule and supplies content/brand
 canonical = true
 
 [[terms]]
+term = "consumer schema registry"
+definition = "schemas/registry.toml — maps a consumer's custom template or content path to its own JSON Schema, checked in at the consumer site."
+canonical = true
+
+[[terms]]
+term = "core schema"
+definition = "An open (no additionalProperties/unevaluatedProperties) building-block schema (page.core.schema.json, section.core.schema.json) that both typikon's own closed schema and a consumer's registered schema compose via $ref."
+canonical = true
+
+[[terms]]
 term = "schema"
 definition = "JSON Schema contract for a content type's frontmatter."
 canonical = true

--- a/bin/typikon-validate
+++ b/bin/typikon-validate
@@ -29,6 +29,12 @@ docs/SCHEMAS.md#consumer-schema-registry — this is what makes a custom
 template's frontmatter get a domain schema instead of inheriting page's
 permissive default by omission.
 
+FAIL-CLOSED: a registry.toml entry (either discriminator) that matches a
+file whose structural kind — section for `_index.md`, page for everything
+else, Zola's own distinction, not the registry's — disagrees with the
+entry's `extends` is ALSO a validation FAILURE, not a silent application of
+the wrong-shaped schema. See docs/SCHEMAS.md#consumer-schema-registry.
+
 Output:
     JSONL on stderr, one line per failure:
         {"file": "...", "pointer": "/extra/price", "error": "..."}
@@ -93,11 +99,12 @@ KNOWN_TEMPLATES = frozenset(TEMPLATE_SCHEMA_MAP) | {
     "index.html",
 }
 
-# Content types whose schema is built from an open `<slug>.core.schema.json`
-# building block (see docs/SCHEMAS.md#consumer-schema-registry) and can
-# therefore be composed by a consumer's registered schema via `extends`.
-# journal-entry/product/faq/sizing-guide have no `.core.schema.json`
-# counterpart yet — no registered consumer has needed to extend them, and
+# WHY: content types whose schema is built from an open
+# `<slug>.core.schema.json` building block (see
+# docs/SCHEMAS.md#consumer-schema-registry) and can therefore be composed
+# by a consumer's registered schema via `extends`. journal-entry/product/
+# faq/sizing-guide have no `.core.schema.json` counterpart yet — no
+# registered consumer has needed to extend them, and
 # `load_consumer_registry` refuses an `extends` naming one of them rather
 # than pretending composition it cannot deliver.
 COMPOSABLE_CORE_SLUGS = frozenset({"page", "section"})
@@ -112,6 +119,32 @@ class UnregisteredTemplateError(Exception):
         super().__init__(template)
 
 
+class MismatchedExtendsError(Exception):
+    """Raised by classify() when a registry entry (`template` or
+    `path_prefix`) matches a file whose structural kind — "section" for
+    `_index.md`, "page" for everything else, fixed by Zola itself, not
+    by the registry — disagrees with the entry's declared `extends`.
+
+    WHY: `path_prefix` matches by string prefix and cannot express "every
+    leaf page under this directory, but not its _index.md" — a prefix like
+    "systems/" matches `systems/_index.md` too. Applying a page-extending
+    entry's schema there would silently validate a section file against a
+    schema missing section-only fields (sort_by, page_template,
+    transparent, extra.triad, ...) — the exact silent-mismatch class this
+    mechanism exists to close, just moved one level up. `template` can hit
+    the same case if a consumer's frontmatter sets a registered template
+    value on a `_index.md` file. Fail closed instead of silently applying
+    the wrong shape: the consumer must scope the entry precisely (a
+    longer path_prefix, or `template` instead of `path_prefix`)."""
+
+    def __init__(self, discriminator_kind: str, discriminator: str, expected: str, registered: str) -> None:
+        self.discriminator_kind = discriminator_kind
+        self.discriminator = discriminator
+        self.expected = expected
+        self.registered = registered
+        super().__init__(f"{discriminator_kind}={discriminator!r} extends={registered!r} expected={expected!r}")
+
+
 @dataclass(frozen=True)
 class RegistryEntry:
     """One `[[entry]]` from a consumer's schemas/registry.toml, resolved
@@ -120,6 +153,7 @@ class RegistryEntry:
     name: str
     discriminator_kind: str  # "template" | "path_prefix"
     discriminator: str
+    extends: str  # "page" | "section" — which core this entry composes
     schema_path: Path
     schema: dict
 
@@ -156,19 +190,19 @@ def classify(rel_path: Path, frontmatter: dict, registry: ConsumerRegistry) -> t
     and any registered custom template) escape the path-based default.
     Raises UnregisteredTemplateError for a `template` this validator cannot
     account for by either route — see the module docstring's FAIL-CLOSED note.
+    Raises MismatchedExtendsError when a registry entry (either
+    discriminator kind) matches a file whose structural kind — fixed by
+    Zola (section for `_index.md`, page for everything else), not by the
+    registry — disagrees with the entry's `extends`. This is checked for
+    BOTH `template` and `path_prefix` matches: a `template` value set on a
+    `_index.md` file is just as capable of this mismatch as a path prefix
+    that happens to also catch a section index.
     """
-    template = frontmatter.get("template")
-    if template in TEMPLATE_SCHEMA_MAP:
-        return TEMPLATE_SCHEMA_MAP[template], None
-
-    registry_hit = registry.match_template(template)
-    if registry_hit is not None:
-        return registry_hit.name, registry_hit.schema
-
     parts = rel_path.parts
     # parts[0] == "content"
     name = parts[-1]
     content_relative = "/".join(parts[1:])
+    structural_kind = "section" if name == "_index.md" else "page"
     if name == "_index.md":
         base = "section"
     elif len(parts) == 2:
@@ -182,8 +216,20 @@ def classify(rel_path: Path, frontmatter: dict, registry: ConsumerRegistry) -> t
         else:
             base = "page"
 
+    template = frontmatter.get("template")
+    if template in TEMPLATE_SCHEMA_MAP:
+        return TEMPLATE_SCHEMA_MAP[template], None
+
+    registry_hit = registry.match_template(template)
+    if registry_hit is not None:
+        if registry_hit.extends != structural_kind:
+            raise MismatchedExtendsError("template", template, structural_kind, registry_hit.extends)
+        return registry_hit.name, registry_hit.schema
+
     path_hit = registry.match_path(content_relative)
     if path_hit is not None:
+        if path_hit.extends != structural_kind:
+            raise MismatchedExtendsError("path_prefix", path_hit.discriminator, structural_kind, path_hit.extends)
         return path_hit.name, path_hit.schema
 
     if template is not None and template not in KNOWN_TEMPLATES:
@@ -253,6 +299,20 @@ def validate_file(
                 f"custom template '{exc.template}' has no schema registration in "
                 "schemas/registry.toml, and is not one of typikon's own templates "
                 f"({', '.join(sorted(KNOWN_TEMPLATES))}). Register a consumer schema "
+                "— see docs/SCHEMAS.md#consumer-schema-registry."
+            ),
+        }]
+    except MismatchedExtendsError as exc:
+        pointer = "/template" if exc.discriminator_kind == "template" else ""
+        return [{
+            "file": file_label,
+            "pointer": pointer,
+            "error": (
+                f"registry.toml entry {exc.discriminator_kind}={exc.discriminator!r} "
+                f"declares extends={exc.registered!r}, but {file_label} is structurally "
+                f"a {exc.expected!r} (Zola's own _index.md-vs-page distinction, not the "
+                f"registry's to override) — this entry cannot apply here. Scope the "
+                f"{exc.discriminator_kind} more precisely, or split it into two entries "
                 "— see docs/SCHEMAS.md#consumer-schema-registry."
             ),
         }]
@@ -432,6 +492,7 @@ def load_consumer_registry(consumer_root: Path, base_registry: Registry) -> Cons
             name=name,
             discriminator_kind=discriminator_kind,
             discriminator=discriminator,
+            extends=extends,
             schema_path=schema_path,
             schema=schema,
         )

--- a/bin/typikon-validate
+++ b/bin/typikon-validate
@@ -9,13 +9,25 @@ classifies each file by its location, and validates against the appropriate
 JSON Schema in <typikon-repo>/schemas/.
 
 Classification rules (in order — first match wins):
-    frontmatter `template = "faq.html"`     -> faq.schema.json
+    frontmatter `template = "faq.html"`          -> faq.schema.json
     frontmatter `template = "sizing-guide.html"` -> sizing-guide.schema.json
-    content/_index.md                       -> section.schema.json
-    content/<section>/_index.md             -> section.schema.json
-    content/journal/<slug>.md               -> journal-entry.schema.json
-    content/products/<slug>.md              -> product.schema.json
-    content/<everything-else>.md            -> page.schema.json
+    frontmatter `template` matches a `[[entry]]` in
+      <root>/schemas/registry.toml with `template = "..."`
+                                                   -> the entry's consumer schema
+    content/_index.md                            -> section.schema.json
+    content/<section>/_index.md                  -> section.schema.json
+    content/journal/<slug>.md                    -> journal-entry.schema.json
+    content/products/<slug>.md                   -> product.schema.json
+    path matches a `[[entry]]` in registry.toml
+      with `path_prefix = "..."`                 -> the entry's consumer schema
+    content/<everything-else>.md                 -> page.schema.json
+
+FAIL-CLOSED: a `template` value that is not one of typikon's own shipped
+templates (KNOWN_TEMPLATES) and has no matching registry.toml entry is a
+validation FAILURE, not a silent fall-through to page.schema.json. See
+docs/SCHEMAS.md#consumer-schema-registry — this is what makes a custom
+template's frontmatter get a domain schema instead of inheriting page's
+permissive default by omission.
 
 Output:
     JSONL on stderr, one line per failure:
@@ -26,7 +38,8 @@ Output:
 Exit codes:
     0 — all files valid
     1 — at least one file invalid
-    2 — runtime error (missing schemas, malformed frontmatter, etc.)
+    2 — runtime error (missing schemas, malformed frontmatter, malformed
+        registry.toml, etc.)
 """
 
 from __future__ import annotations
@@ -35,10 +48,13 @@ import datetime as _datetime
 import json
 import sys
 import tomllib
+from dataclasses import dataclass
 from pathlib import Path
 
 try:
     from jsonschema import Draft202012Validator
+    from referencing import Registry, Resource
+    from referencing.jsonschema import DRAFT202012
 except ImportError:
     print(
         json.dumps({"error": "jsonschema package required (pip install jsonschema)"}),
@@ -63,30 +79,117 @@ TEMPLATE_SCHEMA_MAP = {
     "sizing-guide.html": "sizing-guide",
 }
 
+# WHY: templates typikon itself ships that a consumer may freely set as
+# `template` without triggering the fail-closed unregistered-template
+# error. Each either already routes to its own strict schema
+# (TEMPLATE_SCHEMA_MAP) or renders content already fully described by the
+# page/section/journal-entry contract — no domain schema is missing for
+# these, so they are not the loophole this file exists to close.
+KNOWN_TEMPLATES = frozenset(TEMPLATE_SCHEMA_MAP) | {
+    "page.html",
+    "section.html",
+    "journal-entry.html",
+    "journal-section.html",
+    "index.html",
+}
 
-def classify(rel_path: Path, frontmatter: dict) -> str:
-    """Map a markdown file to its schema name. Frontmatter `template` wins
-    when present in TEMPLATE_SCHEMA_MAP — that's how page-level overrides
-    (FAQ, sizing-guide) escape the path-based default."""
+# Content types whose schema is built from an open `<slug>.core.schema.json`
+# building block (see docs/SCHEMAS.md#consumer-schema-registry) and can
+# therefore be composed by a consumer's registered schema via `extends`.
+# journal-entry/product/faq/sizing-guide have no `.core.schema.json`
+# counterpart yet — no registered consumer has needed to extend them, and
+# `load_consumer_registry` refuses an `extends` naming one of them rather
+# than pretending composition it cannot deliver.
+COMPOSABLE_CORE_SLUGS = frozenset({"page", "section"})
+
+
+class UnregisteredTemplateError(Exception):
+    """Raised by classify() when `template` is neither a KNOWN_TEMPLATES
+    value nor registered in the consumer's schemas/registry.toml."""
+
+    def __init__(self, template: str) -> None:
+        self.template = template
+        super().__init__(template)
+
+
+@dataclass(frozen=True)
+class RegistryEntry:
+    """One `[[entry]]` from a consumer's schemas/registry.toml, resolved
+    to its loaded schema."""
+
+    name: str
+    discriminator_kind: str  # "template" | "path_prefix"
+    discriminator: str
+    schema_path: Path
+    schema: dict
+
+
+@dataclass
+class ConsumerRegistry:
+    """The consumer's full set of registered custom-template/path schemas,
+    plus the combined `referencing.Registry` needed to resolve every
+    `$ref` in every loaded schema (typikon's own + the consumer's)."""
+
+    by_template: dict[str, RegistryEntry]
+    by_path_prefix: list[tuple[str, RegistryEntry]]
+    jsonschema_registry: Registry
+
+    def match_template(self, template: str | None) -> RegistryEntry | None:
+        if template is None:
+            return None
+        return self.by_template.get(template)
+
+    def match_path(self, content_relative: str) -> RegistryEntry | None:
+        for prefix, entry in self.by_path_prefix:
+            if content_relative.startswith(prefix):
+                return entry
+        return None
+
+
+def classify(rel_path: Path, frontmatter: dict, registry: ConsumerRegistry) -> tuple[str, dict | None]:
+    """Map a markdown file to its schema. Returns (schema_name, consumer_schema)
+    — consumer_schema is None for a typikon-owned builtin (look `schema_name`
+    up in the `schemas` dict) and set for a registry-composed consumer schema.
+
+    Frontmatter `template` wins when present in TEMPLATE_SCHEMA_MAP or the
+    consumer registry — that's how page-level overrides (FAQ, sizing-guide,
+    and any registered custom template) escape the path-based default.
+    Raises UnregisteredTemplateError for a `template` this validator cannot
+    account for by either route — see the module docstring's FAIL-CLOSED note.
+    """
     template = frontmatter.get("template")
     if template in TEMPLATE_SCHEMA_MAP:
-        return TEMPLATE_SCHEMA_MAP[template]
+        return TEMPLATE_SCHEMA_MAP[template], None
+
+    registry_hit = registry.match_template(template)
+    if registry_hit is not None:
+        return registry_hit.name, registry_hit.schema
 
     parts = rel_path.parts
     # parts[0] == "content"
     name = parts[-1]
+    content_relative = "/".join(parts[1:])
     if name == "_index.md":
-        return "section"
-    # content/<x>.md is a top-level page
-    if len(parts) == 2:
-        return "page"
-    # content/<section>/<file>.md
-    section = parts[1]
-    if section == "journal":
-        return "journal-entry"
-    if section == "products":
-        return "product"
-    return "page"
+        base = "section"
+    elif len(parts) == 2:
+        base = "page"
+    else:
+        section = parts[1]
+        if section == "journal":
+            base = "journal-entry"
+        elif section == "products":
+            base = "product"
+        else:
+            base = "page"
+
+    path_hit = registry.match_path(content_relative)
+    if path_hit is not None:
+        return path_hit.name, path_hit.schema
+
+    if template is not None and template not in KNOWN_TEMPLATES:
+        raise UnregisteredTemplateError(template)
+
+    return base, None
 
 
 def _coerce_dates(obj):
@@ -119,7 +222,13 @@ def parse_frontmatter(text: str, file_label: str) -> dict:
     return _coerce_dates(tomllib.loads(block))
 
 
-def validate_file(path: Path, content_root: Path, schemas: dict[str, dict]) -> list[dict]:
+def validate_file(
+    path: Path,
+    content_root: Path,
+    schemas: dict[str, dict],
+    jsonschema_registry: Registry,
+    registry: ConsumerRegistry,
+) -> list[dict]:
     """Return a list of failure records for one file (empty when all good)."""
     rel = path.relative_to(content_root.parent)  # keep "content/..." prefix
     file_label = str(rel)
@@ -134,12 +243,25 @@ def validate_file(path: Path, content_root: Path, schemas: dict[str, dict]) -> l
     except Exception as exc:
         return [{"file": file_label, "pointer": "", "error": str(exc)}]
 
-    schema_name = classify(rel, fm)
-    schema = schemas.get(schema_name)
+    try:
+        schema_name, consumer_schema = classify(rel, fm, registry)
+    except UnregisteredTemplateError as exc:
+        return [{
+            "file": file_label,
+            "pointer": "/template",
+            "error": (
+                f"custom template '{exc.template}' has no schema registration in "
+                "schemas/registry.toml, and is not one of typikon's own templates "
+                f"({', '.join(sorted(KNOWN_TEMPLATES))}). Register a consumer schema "
+                "— see docs/SCHEMAS.md#consumer-schema-registry."
+            ),
+        }]
+
+    schema = consumer_schema if consumer_schema is not None else schemas.get(schema_name)
     if schema is None:
         return [{"file": file_label, "pointer": "", "error": f"no schema for class '{schema_name}'"}]
 
-    validator = Draft202012Validator(schema, format_checker=FORMAT_CHECKER)
+    validator = Draft202012Validator(schema, registry=jsonschema_registry, format_checker=FORMAT_CHECKER)
     failures = []
     for err in sorted(validator.iter_errors(fm), key=lambda e: e.path):
         pointer = "/" + "/".join(str(p) for p in err.absolute_path)
@@ -165,37 +287,164 @@ def _declared_formats(node, found: set[str]) -> None:
             _declared_formats(v, found)
 
 
-def load_schemas() -> dict[str, dict]:
+def _refuse_unsupported_formats(schema: dict, label: str) -> None:
+    """WARNING: a format declared in a schema but not registered on
+    FORMAT_CHECKER validates as a no-op annotation, not a check — the
+    exact silent-pass this validator exists to prevent. Refuse to run
+    rather than enforce a schema's formats partially. Applies to every
+    loaded schema, typikon's own and a consumer's alike — a consumer
+    schema declaring `format: "email"` (unsupported) is exactly as
+    dangerous as a shipped one would be."""
+    declared: set[str] = set()
+    _declared_formats(schema, declared)
+    unsupported = declared - set(FORMAT_CHECKER.checkers)
+    if unsupported:
+        print(
+            json.dumps({
+                "error": (
+                    f"schema '{label}' declares unsupported format(s) "
+                    f"{sorted(unsupported)}; FormatChecker has no checker "
+                    "registered for them and would silently skip enforcement"
+                ),
+            }),
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def load_schemas() -> tuple[dict[str, dict], Registry]:
+    """Load typikon's own schemas plus their open `.core.schema.json`
+    building blocks, and return them alongside a `referencing.Registry`
+    that resolves every `$ref` among them by `$id`. The core files are
+    not classification targets themselves (`schemas` never maps a slug
+    to one) — they exist only so `page.schema.json`/`section.schema.json`
+    and a consumer's registered schema can each independently `$ref` and
+    close them (see docs/SCHEMAS.md#consumer-schema-registry)."""
     schemas: dict[str, dict] = {}
+    resources = []
     for slug in ("page", "section", "journal-entry", "product", "faq", "sizing-guide"):
         p = SCHEMA_DIR / f"{slug}.schema.json"
         if not p.exists():
             print(json.dumps({"error": f"missing schema: {p}"}), file=sys.stderr)
             sys.exit(2)
         schema = json.loads(p.read_text(encoding="utf-8"))
+        _refuse_unsupported_formats(schema, slug)
+        schemas[slug] = schema
+        resources.append((schema["$id"], Resource.from_contents(schema, default_specification=DRAFT202012)))
 
-        # WARNING: a format declared in a schema but not registered on
-        # FORMAT_CHECKER validates as a no-op annotation, not a check —
-        # the exact silent-pass this validator exists to prevent. Refuse
-        # to run rather than enforce a schema's formats partially.
-        declared = set()
-        _declared_formats(schema, declared)
-        unsupported = declared - set(FORMAT_CHECKER.checkers)
-        if unsupported:
+    for slug in COMPOSABLE_CORE_SLUGS:
+        p = SCHEMA_DIR / f"{slug}.core.schema.json"
+        if not p.exists():
+            print(json.dumps({"error": f"missing core schema: {p}"}), file=sys.stderr)
+            sys.exit(2)
+        core = json.loads(p.read_text(encoding="utf-8"))
+        _refuse_unsupported_formats(core, f"{slug}.core")
+        resources.append((core["$id"], Resource.from_contents(core, default_specification=DRAFT202012)))
+
+    return schemas, Registry().with_resources(resources)
+
+
+def load_consumer_registry(consumer_root: Path, base_registry: Registry) -> ConsumerRegistry:
+    """Load <consumer_root>/schemas/registry.toml if present. Absence is
+    not an error — a consumer with no custom templates needs no registry.
+    Every entry is validated at load time (exactly one discriminator,
+    `extends` names a composable core, the schema file exists, parses,
+    and declares its own `$id`) so a malformed registry fails loudly here
+    rather than as a confusing per-file validation error later."""
+    registry_path = consumer_root / "schemas" / "registry.toml"
+    if not registry_path.exists():
+        return ConsumerRegistry(by_template={}, by_path_prefix=[], jsonschema_registry=base_registry)
+
+    try:
+        doc = tomllib.loads(registry_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(json.dumps({"error": f"malformed {registry_path}: {exc}"}), file=sys.stderr)
+        sys.exit(2)
+
+    by_template: dict[str, RegistryEntry] = {}
+    by_path_prefix: list[tuple[str, RegistryEntry]] = []
+    resources = []
+    seen_discriminators: set[tuple[str, str]] = set()
+
+    for raw in doc.get("entry", []):
+        has_template = "template" in raw
+        has_path_prefix = "path_prefix" in raw
+        if has_template == has_path_prefix:
             print(
                 json.dumps({
                     "error": (
-                        f"schema '{slug}' declares unsupported format(s) "
-                        f"{sorted(unsupported)}; FormatChecker has no checker "
-                        "registered for them and would silently skip enforcement"
+                        f"{registry_path}: entry {raw!r} must set exactly one of "
+                        "`template` or `path_prefix`"
                     ),
                 }),
                 file=sys.stderr,
             )
             sys.exit(2)
 
-        schemas[slug] = schema
-    return schemas
+        extends = raw.get("extends")
+        if extends not in COMPOSABLE_CORE_SLUGS:
+            print(
+                json.dumps({
+                    "error": (
+                        f"{registry_path}: entry {raw!r} has `extends = {extends!r}`; "
+                        f"must be one of {sorted(COMPOSABLE_CORE_SLUGS)} — those are "
+                        "the only typikon content types with a composable "
+                        "<slug>.core.schema.json building block"
+                    ),
+                }),
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+        schema_rel = raw.get("schema")
+        if not schema_rel:
+            print(json.dumps({"error": f"{registry_path}: entry {raw!r} missing `schema`"}), file=sys.stderr)
+            sys.exit(2)
+        schema_path = (consumer_root / schema_rel).resolve()
+        if not schema_path.exists():
+            print(json.dumps({"error": f"{registry_path}: schema file not found: {schema_path}"}), file=sys.stderr)
+            sys.exit(2)
+
+        try:
+            schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            print(json.dumps({"error": f"malformed schema {schema_path}: {exc}"}), file=sys.stderr)
+            sys.exit(2)
+
+        schema_id = schema.get("$id")
+        if not schema_id:
+            print(json.dumps({"error": f"{schema_path}: registered consumer schema must declare \"$id\""}), file=sys.stderr)
+            sys.exit(2)
+
+        discriminator_kind = "template" if has_template else "path_prefix"
+        discriminator = raw["template"] if has_template else raw["path_prefix"]
+        dedup_key = (discriminator_kind, discriminator)
+        if dedup_key in seen_discriminators:
+            print(
+                json.dumps({"error": f"{registry_path}: duplicate {discriminator_kind} discriminator {discriminator!r}"}),
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        seen_discriminators.add(dedup_key)
+
+        name = schema_path.stem.removesuffix(".schema")
+        entry = RegistryEntry(
+            name=name,
+            discriminator_kind=discriminator_kind,
+            discriminator=discriminator,
+            schema_path=schema_path,
+            schema=schema,
+        )
+        _refuse_unsupported_formats(schema, name)
+        resources.append((schema_id, Resource.from_contents(schema, default_specification=DRAFT202012)))
+
+        if discriminator_kind == "template":
+            by_template[discriminator] = entry
+        else:
+            by_path_prefix.append((discriminator, entry))
+
+    combined = base_registry.with_resources(resources) if resources else base_registry
+    return ConsumerRegistry(by_template=by_template, by_path_prefix=by_path_prefix, jsonschema_registry=combined)
 
 
 def main(argv: list[str]) -> int:
@@ -209,11 +458,13 @@ def main(argv: list[str]) -> int:
         print(json.dumps({"error": f"no content/ dir under {root}"}), file=sys.stderr)
         return 2
 
-    schemas = load_schemas()
+    schemas, base_registry = load_schemas()
+    consumer_registry = load_consumer_registry(root, base_registry)
+
     files = sorted(content_root.rglob("*.md"))
     failures: list[dict] = []
     for f in files:
-        failures.extend(validate_file(f, content_root, schemas))
+        failures.extend(validate_file(f, content_root, schemas, consumer_registry.jsonschema_registry, consumer_registry))
 
     for failure in failures:
         print(json.dumps(failure), file=sys.stderr)

--- a/ci/check-consumer-schema-registry.py
+++ b/ci/check-consumer-schema-registry.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""check-consumer-schema-registry — regression test for the fail-closed
+consumer schema registry (forkwright/typikon#60).
+
+WHY: before this registry existed, a consumer site's custom-templated
+content (a page type typikon does not ship, e.g. an "our approach" or
+"case study" template) fell through `bin/typikon-validate`'s classifier to
+`page.schema.json`, whose `extra` object accepted any additional field
+without checking its type. A typo like `kanon_ci = "false"` (string, not
+boolean) was schema-valid and became truthy wherever a consumer template
+did `bool(...)` on it. This script proves three things bin/typikon-validate
+itself cannot self-certify by import (it has no test suite of its own):
+
+1. A template registered in schemas/registry.toml validates against its
+   own composed schema — namespaced fields are checked, not ignored.
+2. A wrong-typed or unrecognized field under a registered template's
+   `extra` is REJECTED, not silently coerced — the exact defect #60 reports.
+3. A custom `template` value with NO registry.toml entry FAILS validation
+   with the exact missing-registration error, rather than silently
+   inheriting page.schema.json's shape. This is the fail-closed guarantee:
+   the absence of a registration is itself a defect, not a fallback.
+
+Every case builds a throwaway consumer-site tree under a tempdir and runs
+the real `bin/typikon-validate` CLI as a subprocess — this exercises the
+actual classification + registry-loading + composed-schema-validation
+path end to end, not a mocked slice of it.
+
+NOTE: runs standalone (no consumer site needed) as part of ci/run-fixtures.sh.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+THEME_ROOT = Path(__file__).resolve().parent.parent
+VALIDATE = THEME_ROOT / "bin" / "typikon-validate"
+
+CONSULTING_SCHEMA = """\
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ardent.tools/schemas/consulting.schema.json",
+  "title": "ardent consulting page",
+  "allOf": [{"$ref": "https://github.com/forkwright/typikon/schemas/page.core.schema.json"}],
+  "properties": {
+    "extra": {
+      "allOf": [{"$ref": "https://github.com/forkwright/typikon/schemas/page.core.schema.json#/properties/extra"}],
+      "unevaluatedProperties": false,
+      "properties": {
+        "ardent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kanon_ci"],
+          "properties": {"kanon_ci": {"type": "boolean"}}
+        }
+      }
+    }
+  },
+  "unevaluatedProperties": false
+}
+"""
+
+DOSSIER_SCHEMA = """\
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ardent.tools/schemas/system-dossier.schema.json",
+  "title": "ardent system dossier page",
+  "allOf": [{"$ref": "https://github.com/forkwright/typikon/schemas/page.core.schema.json"}],
+  "properties": {
+    "extra": {
+      "allOf": [{"$ref": "https://github.com/forkwright/typikon/schemas/page.core.schema.json#/properties/extra"}],
+      "unevaluatedProperties": false,
+      "properties": {
+        "ardent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["repo_url"],
+          "properties": {"repo_url": {"type": "string"}}
+        }
+      }
+    }
+  },
+  "unevaluatedProperties": false
+}
+"""
+
+REGISTRY_TOML = """\
+[[entry]]
+template = "consulting.html"
+schema = "schemas/consulting.schema.json"
+extends = "page"
+
+[[entry]]
+path_prefix = "systems/"
+schema = "schemas/system-dossier.schema.json"
+extends = "page"
+"""
+
+
+def write_tree(root: Path, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+
+def run_validate(root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(VALIDATE), str(root)],
+        capture_output=True, text=True, check=False,
+    )
+
+
+BASE_FILES = {
+    "schemas/registry.toml": REGISTRY_TOML,
+    "schemas/consulting.schema.json": CONSULTING_SCHEMA,
+    "schemas/system-dossier.schema.json": DOSSIER_SCHEMA,
+}
+
+
+def content_only(files: dict[str, str]) -> dict[str, str]:
+    return {**BASE_FILES, **files}
+
+
+# Each case: (label, extra_files, expected_exit, required_stderr_substrings)
+CASES: list[tuple[str, dict[str, str], int, list[str]]] = [
+    (
+        "registered template, valid namespaced field — passes",
+        content_only({
+            "content/consulting.md": (
+                '+++\ntitle = "Consulting"\ntemplate = "consulting.html"\n\n'
+                '[extra.ardent]\nkanon_ci = true\n+++\nbody\n'
+            ),
+        }),
+        0,
+        [],
+    ),
+    (
+        "registered template, wrong-typed namespaced field — the exact #60 defect, rejected",
+        content_only({
+            "content/consulting.md": (
+                '+++\ntitle = "Consulting"\ntemplate = "consulting.html"\n\n'
+                '[extra.ardent]\nkanon_ci = "false"\n+++\nbody\n'
+            ),
+        }),
+        1,
+        ["'false' is not of type 'boolean'"],
+    ),
+    (
+        "registered template, unrecognized extra field — rejected, not silently accepted",
+        content_only({
+            "content/consulting.md": (
+                '+++\ntitle = "Consulting"\ntemplate = "consulting.html"\n\n'
+                '[extra]\nbogus_field = "x"\n\n[extra.ardent]\nkanon_ci = true\n+++\nbody\n'
+            ),
+        }),
+        1,
+        ["bogus_field", "not allowed"],
+    ),
+    (
+        "unregistered custom template — fails closed with the exact missing-registration error",
+        content_only({
+            "content/home.md": '+++\ntitle = "Home"\ntemplate = "home.html"\n+++\nbody\n',
+        }),
+        1,
+        ["custom template 'home.html'", "schemas/registry.toml", "docs/SCHEMAS.md#consumer-schema-registry"],
+    ),
+    (
+        "path_prefix discriminator, valid — passes",
+        content_only({
+            "content/systems/dossier.md": (
+                '+++\ntitle = "Dossier"\n\n[extra.ardent]\nrepo_url = "https://github.com/x/y"\n+++\nbody\n'
+            ),
+        }),
+        0,
+        [],
+    ),
+    (
+        "path_prefix discriminator, missing required namespaced field — rejected",
+        content_only({
+            "content/systems/dossier.md": (
+                '+++\ntitle = "Dossier"\n\n[extra.ardent]\n+++\nbody\n'
+            ),
+        }),
+        1,
+        ["'repo_url' is a required property"],
+    ),
+    (
+        "typikon's own shipped template with no registry entry — not a fail-closed trigger",
+        content_only({
+            "content/plain.md": '+++\ntitle = "Plain"\ntemplate = "page.html"\n+++\nbody\n',
+        }),
+        0,
+        [],
+    ),
+    (
+        "no registry.toml at all — unchanged pre-#60 behavior for a consumer with no custom templates",
+        {"content/plain.md": '+++\ntitle = "Plain"\n+++\nbody\n'},
+        0,
+        [],
+    ),
+    (
+        "malformed registry: both template and path_prefix on one entry — refused at load time",
+        {
+            "schemas/registry.toml": REGISTRY_TOML + (
+                '\n[[entry]]\ntemplate = "x.html"\npath_prefix = "y/"\n'
+                'schema = "schemas/consulting.schema.json"\nextends = "page"\n'
+            ),
+            "schemas/consulting.schema.json": CONSULTING_SCHEMA,
+            "schemas/system-dossier.schema.json": DOSSIER_SCHEMA,
+            "content/plain.md": '+++\ntitle = "Plain"\n+++\nbody\n',
+        },
+        2,
+        ["must set exactly one of"],
+    ),
+    (
+        "malformed registry: extends names a non-composable slug — refused at load time",
+        {
+            "schemas/registry.toml": (
+                '[[entry]]\ntemplate = "consulting.html"\n'
+                'schema = "schemas/consulting.schema.json"\nextends = "product"\n'
+            ),
+            "schemas/consulting.schema.json": CONSULTING_SCHEMA,
+            "content/plain.md": '+++\ntitle = "Plain"\n+++\nbody\n',
+        },
+        2,
+        ["extends = 'product'", "composable"],
+    ),
+    (
+        "malformed registry: referenced schema file does not exist — refused at load time",
+        {
+            "schemas/registry.toml": (
+                '[[entry]]\ntemplate = "consulting.html"\n'
+                'schema = "schemas/missing.schema.json"\nextends = "page"\n'
+            ),
+            "content/plain.md": '+++\ntitle = "Plain"\n+++\nbody\n',
+        },
+        2,
+        ["schema file not found"],
+    ),
+    (
+        "malformed registry: consumer schema missing $id — refused at load time",
+        {
+            "schemas/registry.toml": (
+                '[[entry]]\ntemplate = "consulting.html"\n'
+                'schema = "schemas/consulting.schema.json"\nextends = "page"\n'
+            ),
+            "schemas/consulting.schema.json": json.dumps({"type": "object"}),
+            "content/plain.md": '+++\ntitle = "Plain"\n+++\nbody\n',
+        },
+        2,
+        ["must declare"],
+    ),
+    (
+        "malformed registry: duplicate template discriminator — refused at load time",
+        {
+            "schemas/registry.toml": REGISTRY_TOML + (
+                '\n[[entry]]\ntemplate = "consulting.html"\n'
+                'schema = "schemas/system-dossier.schema.json"\nextends = "page"\n'
+            ),
+            "schemas/consulting.schema.json": CONSULTING_SCHEMA,
+            "schemas/system-dossier.schema.json": DOSSIER_SCHEMA,
+            "content/plain.md": '+++\ntitle = "Plain"\n+++\nbody\n',
+        },
+        2,
+        ["duplicate template discriminator"],
+    ),
+]
+
+
+def main() -> int:
+    failed = []
+    for label, files, expected_exit, required_substrings in CASES:
+        with tempfile.TemporaryDirectory(prefix="typikon-registry-check-") as tmp:
+            root = Path(tmp)
+            write_tree(root, files)
+            result = run_validate(root)
+            if result.returncode != expected_exit:
+                failed.append(
+                    f"{label}: expected exit {expected_exit}, got {result.returncode}\n"
+                    f"  stdout: {result.stdout.strip()}\n  stderr: {result.stderr.strip()}"
+                )
+                continue
+            missing = [s for s in required_substrings if s not in result.stderr]
+            if missing:
+                failed.append(f"{label}: stderr missing expected substring(s) {missing}\n  stderr: {result.stderr.strip()}")
+
+    if failed:
+        for line in failed:
+            print(f"FAIL: {line}", file=sys.stderr)
+        return 1
+
+    print(json.dumps({"checked": len(CASES), "passed": len(CASES), "failed": 0}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/check-consumer-schema-registry.py
+++ b/ci/check-consumer-schema-registry.py
@@ -125,7 +125,7 @@ def content_only(files: dict[str, str]) -> dict[str, str]:
     return {**BASE_FILES, **files}
 
 
-# Each case: (label, extra_files, expected_exit, required_stderr_substrings)
+# NOTE: each case is (label, extra_files, expected_exit, required_stderr_substrings)
 CASES: list[tuple[str, dict[str, str], int, list[str]]] = [
     (
         "registered template, valid namespaced field — passes",
@@ -177,6 +177,35 @@ CASES: list[tuple[str, dict[str, str], int, list[str]]] = [
         }),
         0,
         [],
+    ),
+    (
+        # WHY: `path_prefix = "systems/"` (extends="page", from REGISTRY_TOML
+        # above) also textually matches `systems/_index.md` — a section file,
+        # not a page. Pre-fix (forkwright/typikon#60 follow-up), classify()
+        # applied the page-extending schema unconditionally: this exact
+        # fixture (title + extra.ardent.repo_url, no page-only fields) was
+        # coincidentally shaped to satisfy it and validated GREEN — a
+        # section file silently checked against the wrong schema, with
+        # nothing surfacing the mismatch. Reproduced against the pre-fix
+        # committed bin/typikon-validate (git show HEAD~0 before this
+        # patch) as `{"checked": 1, "passed": 1, "failed": 0}`, exit 0.
+        # Fail-closed now: the mismatch itself is the rejection reason.
+        "path_prefix registered extends=page silently matching a _index.md (structurally section) — fails closed, not a silent pass",
+        content_only({
+            "content/systems/_index.md": (
+                '+++\ntitle = "Systems"\n\n[extra.ardent]\nrepo_url = "https://github.com/x/y"\n+++\nbody\n'
+            ),
+        }),
+        1,
+        ["path_prefix='systems/'", "extends='page'", "structurally a 'section'"],
+    ),
+    (
+        "registered template applied to a _index.md (structurally section) — mismatched extends fails closed",
+        content_only({
+            "content/_index.md": '+++\ntitle = "Home"\ntemplate = "consulting.html"\n+++\nbody\n',
+        }),
+        1,
+        ["template='consulting.html'", "extends='page'", "structurally a 'section'"],
     ),
     (
         "path_prefix discriminator, missing required namespaced field — rejected",

--- a/ci/check-triad-schema.py
+++ b/ci/check-triad-schema.py
@@ -13,6 +13,8 @@
 #
 # NOTE: runs standalone (no consumer site needed) as part of ci/run-fixtures.sh.
 
+import importlib.machinery
+import importlib.util
 import json
 import sys
 from pathlib import Path
@@ -20,7 +22,22 @@ from pathlib import Path
 from jsonschema import Draft202012Validator
 
 THEME_ROOT = Path(__file__).resolve().parent.parent
-SCHEMA = json.loads((THEME_ROOT / "schemas" / "section.schema.json").read_text(encoding="utf-8"))
+
+# WHY importlib, not a normal import: bin/typikon-validate has no .py suffix
+# (it's a CLI entry point, not a package module). Its load_schemas() is the
+# SSOT for turning schemas/section.schema.json's internal $ref into
+# something jsonschema can actually resolve — section.schema.json composes
+# section.core.schema.json via $ref (forkwright/typikon#60), so constructing
+# a bare Draft202012Validator(json.load(...)) here would raise Unresolvable
+# the moment a triad case reached that $ref, independent of the case data.
+_loader = importlib.machinery.SourceFileLoader("typikon_validate", str(THEME_ROOT / "bin" / "typikon-validate"))
+_spec = importlib.util.spec_from_loader("typikon_validate", _loader)
+_typikon_validate = importlib.util.module_from_spec(_spec)
+sys.modules["typikon_validate"] = _typikon_validate  # dataclass() resolves types via sys.modules[__module__]
+_spec.loader.exec_module(_typikon_validate)
+
+_SCHEMAS, _REGISTRY = _typikon_validate.load_schemas()
+SCHEMA = _SCHEMAS["section"]
 
 
 def section_with_triad(triad: dict) -> dict:
@@ -52,7 +69,7 @@ CASES = [
 
 
 def main() -> int:
-    validator = Draft202012Validator(SCHEMA)
+    validator = Draft202012Validator(SCHEMA, registry=_REGISTRY)
     failed = []
     for label, doc, should_be_valid in CASES:
         errors = list(validator.iter_errors(doc))

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 python3 "$ROOT/ci/check-triad-schema.py"
+python3 "$ROOT/ci/check-consumer-schema-registry.py"
 python3 "$ROOT/ci/check-font-coverage.py"
 python3 "$ROOT/ci/check-release-config.py"
 python3 "$ROOT/ci/check-asset-provenance.py"

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -16,8 +16,12 @@ Every content type has a JSON Schema in `schemas/`:
 | Section | `schemas/section.schema.json` | Section index files (`_index.md`) |
 | Journal entry | `schemas/journal-entry.schema.json` | Pages under a journal section |
 | Product | `schemas/product.schema.json` | Pages under a products section |
+| FAQ | `schemas/faq.schema.json` | Any page with `template = "faq.html"` |
+| Sizing guide | `schemas/sizing-guide.schema.json` | Any page with `template = "sizing-guide.html"` |
 
-The schema defines: required fields, optional fields, value types, value patterns, length limits. Do not invent fields. If a frontmatter field is not in the schema, do not write it.
+The schema defines: required fields, optional fields, value types, value patterns, length limits. Do not invent fields. If a frontmatter field is not in the schema, do not write it — every one of the six is closed, so an unrecognized field fails validation, not silently passes.
+
+A consumer site's own custom template (not one of the six above) needs its own schema, registered in `schemas/registry.toml` — see `docs/SCHEMAS.md#consumer-schema-registry`. An unregistered custom template fails validation naming the missing registration; it does not fall back to `page`'s shape.
 
 ### 2. Use the scaffolder
 
@@ -202,8 +206,8 @@ If a brand needs a *visual* override beyond these (different scale ratio, differ
 | Change one site's color palette / type / scale             | Consumer-side CSS overriding `:root` tokens                              |
 | Add a one-off CSS class used in one site's content         | Consumer-side CSS                                                        |
 | Add a content type (FAQ, sizing-guide, recipe, gallery)    | typikon — schema + template + AGENTIC + fixture coverage                 |
-| Add an optional frontmatter field shared by ≥2 sites       | typikon — extend the relevant schema with `additionalProperties` discipline |
-| Override one page's HTML structure                         | Consumer-side template under `<consumer>/templates/<name>.html` (Zola overrides typikon) |
+| Add an optional frontmatter field shared by ≥2 sites       | typikon — extend the relevant schema; every content type's `extra` is closed (`unevaluatedProperties: false` or, for journal-entry/product/faq/sizing-guide, plain `additionalProperties: false`), so a new field is a schema edit, never an ambient allowance |
+| Override one page's HTML structure with a custom template  | Consumer-side template under `<consumer>/templates/<name>.html` (Zola overrides typikon) **and** a `schemas/registry.toml` entry — see `docs/SCHEMAS.md#consumer-schema-registry`. A custom `template` with no registry entry fails validation; it does not fall back to `page`'s shape |
 | Add a global behavior (CSP token, JSON-LD type, atom field)| typikon — and update `examples/` so the fixture exercises the change      |
 
 The rule of thumb: **two consumers wanting the same thing → typikon. One consumer wanting an exception → consumer-side override.**

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -69,7 +69,9 @@ A typikon-consuming site's own custom templates (a page type typikon does not sh
 
    Exactly one of `template` (matched against frontmatter `template`) or `path_prefix` (matched against the content-relative path, e.g. `"systems/"` catches `content/systems/<anything>.md`) is required per entry. `template` wins when both a template and a path could match the same file — same precedent as `TEMPLATE_SCHEMA_MAP`.
 
-3. Run `typikon-validate <consumer-root>` (or `typikon-check`, which calls it). A malformed registry entry — both discriminators set, neither set, `extends` naming a type with no composable core, a missing schema file, a schema missing `$id`, a duplicate discriminator — fails immediately with the specific problem, at load time, before any content file is checked.
+   **`extends` must match what the matched file structurally is, not just what you intended the entry to cover.** A `_index.md` is always a Zola section; every other file is always a Zola page — that split is Zola's, not the registry's to override. `path_prefix = "systems/"` also textually matches `content/systems/_index.md`, not just its leaf pages: if that entry's `extends = "page"`, the index file fails with a `MismatchedExtendsError` instead of silently validating against the wrong shape (missing section-only fields like `sort_by`/`page_template`/`extra.triad`). Scope the prefix past the index file, or give the section index its own `template`-keyed entry with `extends = "section"`, if you need both covered.
+
+3. Run `typikon-validate <consumer-root>` (or `typikon-check`, which calls it). A malformed registry entry — both discriminators set, neither set, `extends` naming a type with no composable core, a missing schema file, a schema missing `$id`, a duplicate discriminator, or a discriminator matching a file whose structural kind disagrees with `extends` — fails immediately with the specific problem, before that file's content is checked.
 
 A consumer with no custom templates needs no `schemas/registry.toml` at all; its absence is not an error and every existing consumer validates unchanged.
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -6,22 +6,82 @@ JSON Schema definitions for every content type a typikon-consuming site can auth
 
 `typikon-validate` reads `<root>/content/**/*.md` and classifies in this order; first match wins:
 
-| Rule                                         | Schema             |
-|----------------------------------------------|--------------------|
-| frontmatter `template = "faq.html"`          | faq                |
-| frontmatter `template = "sizing-guide.html"` | sizing-guide       |
-| `_index.md` (root or section)                | section            |
-| `journal/<slug>.md`                          | journal-entry      |
-| `products/<slug>.md`                         | product            |
-| anything else                                | page               |
+| Rule                                                    | Schema                        |
+|----------------------------------------------------------|------------------------------|
+| frontmatter `template = "faq.html"`                     | faq                            |
+| frontmatter `template = "sizing-guide.html"`             | sizing-guide                   |
+| frontmatter `template` matches a `schemas/registry.toml` `template` entry | that entry's consumer schema |
+| `_index.md` (root or section)                           | section                        |
+| `journal/<slug>.md`                                     | journal-entry                  |
+| `products/<slug>.md`                                    | product                         |
+| path matches a `schemas/registry.toml` `path_prefix` entry | that entry's consumer schema |
+| anything else                                            | page                           |
 
 Template-driven dispatch comes first so per-page overrides (FAQ on a non-FAQ section, sizing-guide for a non-product section) escape the path-based default. To add a new template-routed type, extend `TEMPLATE_SCHEMA_MAP` in `bin/typikon-validate`.
 
 Renaming path-routed sections (`journal/` → `notes/`) requires updating the classifier. Out of scope for v1; file an issue when needed.
 
+**Fail-closed:** a `template` value that is neither one of typikon's own shipped templates (`KNOWN_TEMPLATES` in `bin/typikon-validate`) nor a registered `schemas/registry.toml` entry is a validation FAILURE naming the exact missing registration — it does not fall through to `page`. See [Consumer schema registry](#consumer-schema-registry) below.
+
+## Consumer schema registry
+
+A typikon-consuming site's own custom templates (a page type typikon does not ship — an "our approach" page, a case-study template, a domain-specific index) have no built-in schema. Before this mechanism existed, such a file fell through the table above to `page` or `section`, whose `extra` object accepted any additional field without checking its shape — a typo like `kanon_ci = "false"` was schema-valid and became truthy wherever a template did `bool(...)` on it (forkwright/typikon#60). The registry closes that: every custom template or custom-path content type gets its own strict, checked-in schema, and an *unregistered* one is a hard failure, not a silent fallback.
+
+### Registering a custom type
+
+1. Write `<consumer-root>/schemas/<name>.schema.json`. It must declare its own `"$id"` and compose one of typikon's open core building blocks — `page.core.schema.json` or `section.core.schema.json` — via `allOf` + `$ref`, closed with `unevaluatedProperties: false`:
+
+   ```json
+   {
+     "$schema": "https://json-schema.org/draft/2020-12/schema",
+     "$id": "https://<your-site>/schemas/consulting.schema.json",
+     "allOf": [{ "$ref": "https://github.com/forkwright/typikon/schemas/page.core.schema.json" }],
+     "properties": {
+       "extra": {
+         "allOf": [{ "$ref": "https://github.com/forkwright/typikon/schemas/page.core.schema.json#/properties/extra" }],
+         "unevaluatedProperties": false,
+         "properties": {
+           "ardent": {
+             "type": "object",
+             "additionalProperties": false,
+             "required": ["kanon_ci"],
+             "properties": { "kanon_ci": { "type": "boolean" } }
+           }
+         }
+       }
+     },
+     "unevaluatedProperties": false
+   }
+   ```
+
+   **Namespace your extension.** Put every custom field under one object keyed by your own name (`extra.ardent` above, not bare `extra.kanon_ci`) so a future typikon-owned field can never collide with a consumer one.
+
+   **WARNING:** the `$ref` targets must be the open `*.core.schema.json` files, never `page.schema.json`/`section.schema.json` themselves. Composing a schema that is *already* closed (via `unevaluatedProperties`) from inside another closed schema corrupts jsonschema 4.23's annotation collection for the whole document — verified failure mode, not a style preference: every top-level field, not just the extension, gets spuriously rejected. `page.schema.json` and `section.schema.json` demonstrate the correct pattern (they compose the core exactly this way, once, standalone) — mirror them, don't reference them.
+
+2. Add an entry to `<consumer-root>/schemas/registry.toml`:
+
+   ```toml
+   [[entry]]
+   template = "consulting.html"                    # OR path_prefix = "systems/"
+   schema = "schemas/consulting.schema.json"        # path relative to the consumer root
+   extends = "page"                                 # "page" or "section" — which core it composes
+   ```
+
+   Exactly one of `template` (matched against frontmatter `template`) or `path_prefix` (matched against the content-relative path, e.g. `"systems/"` catches `content/systems/<anything>.md`) is required per entry. `template` wins when both a template and a path could match the same file — same precedent as `TEMPLATE_SCHEMA_MAP`.
+
+3. Run `typikon-validate <consumer-root>` (or `typikon-check`, which calls it). A malformed registry entry — both discriminators set, neither set, `extends` naming a type with no composable core, a missing schema file, a schema missing `$id`, a duplicate discriminator — fails immediately with the specific problem, at load time, before any content file is checked.
+
+A consumer with no custom templates needs no `schemas/registry.toml` at all; its absence is not an error and every existing consumer validates unchanged.
+
+Only `page` and `section` have a `*.core.schema.json` building block today — those are the two shapes a real consumer has needed to extend. Extending `journal-entry`, `product`, `faq`, or `sizing-guide` the same way means splitting that schema into a `.core.schema.json` + closed wrapper first, following `schemas/page.schema.json`'s pattern exactly, then adding its slug to `COMPOSABLE_CORE_SLUGS` in `bin/typikon-validate`.
+
+### Schema changes are migrations here too
+
+`bin/typikon-migrate-template` operates on frontmatter regardless of which schema validates it, so a registered consumer schema changing incompatibly ships a migration the same way a typikon-owned one does — see [Schema migrations](#schema-migrations) below. No separate mechanism exists for consumer schemas.
+
 ## page (`schemas/page.schema.json`)
 
-Top-level pages and section children that aren't journal entries or products.
+Top-level pages and section children that aren't journal entries or products. Built from the open `page.core.schema.json` building block, closed once here — see [Consumer schema registry](#consumer-schema-registry) if you need to extend this contract for a custom template.
 
 **Required:** `title`.
 
@@ -45,7 +105,7 @@ og_image = "img/og-philosophy.png"
 
 ## section (`schemas/section.schema.json`)
 
-Section index files (`_index.md`). Includes the home page when home uses `template = "index.html"`.
+Section index files (`_index.md`). Includes the home page when home uses `template = "index.html"`. Built from the open `section.core.schema.json` building block, closed once here — see [Consumer schema registry](#consumer-schema-registry) if you need to extend this contract for a custom section template.
 
 **Required:** `title`.
 
@@ -225,6 +285,8 @@ note = "Sized to the middle hole; first hole is 32, last is 36."
 > **TOML order matters.** `decision_tree = [...]` must come *before* the first `[[extra.size_table]]` block. Once an array-of-tables starts, scalar assignments belong to the *last* table, so a trailing `decision_tree` would silently land inside the final size_table row.
 
 ## Adding a new content type
+
+This section is for a type shared by ≥2 consumers, landing in typikon itself (AGENTIC.md's "two consumers wanting the same thing → typikon" rule). A single consumer's own custom template belongs in [Consumer schema registry](#consumer-schema-registry) instead — it needs no typikon PR.
 
 1. Identify the type. If two existing types could absorb it via an optional field, use that instead.
 2. Write `schemas/<type>.schema.json`, extending the page shape where possible.

--- a/schemas/journal-entry.schema.json
+++ b/schemas/journal-entry.schema.json
@@ -22,7 +22,7 @@
     "extra": {
       "type": "object",
       "required": ["audience", "components", "words", "words_source"],
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "audience": {
           "type": "string",

--- a/schemas/page.core.schema.json
+++ b/schemas/page.core.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/forkwright/typikon/schemas/page.core.schema.json",
+  "title": "typikon page core",
+  "description": "Open building block for the page contract: every field page.schema.json declares, with no closure keyword at any level. Referenced by page.schema.json (which closes it once, standalone) and by consumer schemas registered in schemas/registry.toml (which close it once, alongside their own namespaced extension) — see docs/SCHEMAS.md#consumer-schema-registry for why a shared fragment must stay open and closure happens only at the composing schema.",
+  "type": "object",
+  "required": ["title"],
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "description": "Page title. Renders as <title> and <h1>. Keep under ~50 chars for SEO."
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "SEO meta description and og:description. Aim for 120-180 chars."
+    },
+    "date": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO 8601 date. Required for journal entries; optional otherwise."
+    },
+    "updated": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO 8601. When this page was last meaningfully edited."
+    },
+    "path": {
+      "type": "string",
+      "pattern": "^/[a-z0-9/_-]*/?$",
+      "description": "Override Zola's auto-generated path. Lowercase ASCII, slashes, hyphens, underscores."
+    },
+    "template": {
+      "type": "string",
+      "pattern": "^[a-z0-9_-]+\\.html$",
+      "description": "Custom Tera template (relative to theme/templates/)."
+    },
+    "weight": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Sort order within a section."
+    },
+    "draft": {
+      "type": "boolean",
+      "description": "Exclude from production build."
+    },
+    "extra": {
+      "type": "object",
+      "properties": {
+        "seo_title": {
+          "type": "string",
+          "maxLength": 80,
+          "description": "Override <title> when it should differ from page title (e.g., longer SEO-optimized form)."
+        },
+        "body_class": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9 -]*$",
+          "description": "CSS class on <body>. Used by the home page to hide nav/footer (body_class = 'home-page')."
+        },
+        "og_image": {
+          "type": "string",
+          "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|webp)$",
+          "description": "Path under static/ (e.g. 'img/og-cover.png'). get_url() resolves to absolute."
+        },
+        "og_type": {
+          "type": "string",
+          "enum": ["website", "article", "profile"],
+          "description": "Open Graph type. Defaults to 'website'."
+        },
+        "skip_sitemap": {
+          "type": "boolean",
+          "description": "Exclude this page from the generated sitemap.xml. Useful for utility pages (404, thanks) that should not be indexed."
+        },
+        "author": {
+          "type": "string",
+          "description": "Override the brand author for this page. Falls back to config.extra.author.name."
+        },
+        "audience": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 120,
+          "description": "Intended buyer or reader context. Required alongside price, price_source, and stripe_url when any one of the three is set — see the extra-level dependency below."
+        },
+        "price": {
+          "type": "string",
+          "pattern": "^\\$?\\d{1,5}(\\.\\d{2})?$",
+          "description": "Display price with optional leading $ (e.g. '$150', '85'). Setting price, stripe_url, or price_source triggers ld-product JSON-LD, which requires all four of audience, price, price_source, and stripe_url together."
+        },
+        "price_source": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 200,
+          "description": "Source for the rendered price claim, e.g. the Stripe price object, SKU ledger, or fixture note. Required alongside audience, price, and stripe_url when any one of the three is set — see the extra-level dependency below."
+        },
+        "stripe_url": {
+          "type": "string",
+          "pattern": "^https://buy\\.stripe\\.com/[A-Za-z0-9_]+$",
+          "description": "Stripe direct-checkout URL. Setting price, stripe_url, or price_source triggers ld-product JSON-LD, which requires all four of audience, price, price_source, and stripe_url together."
+        },
+        "video": {
+          "type": "object",
+          "description": "Inline process video (zero-JS native <video>). Drop the .mp4 (and optionally .webm sibling) under static/video/; reference here.",
+          "required": ["src", "alt"],
+          "additionalProperties": false,
+          "properties": {
+            "src": {
+              "type": "string",
+              "pattern": "^[a-z0-9/_-]+\\.mp4$",
+              "description": "Path under static/ to the .mp4 file. Template auto-tries the .webm sibling at the same path before falling back to mp4."
+            },
+            "poster": {
+              "type": "string",
+              "pattern": "^[a-z0-9/_-]+\\.(jpg|jpeg|png|webp)$",
+              "description": "Path under static/ to a still-frame image shown before play."
+            },
+            "alt": {
+              "type": "string",
+              "minLength": 5,
+              "maxLength": 200,
+              "description": "Accessible label describing what the video shows."
+            },
+            "captions": {
+              "type": "string",
+              "pattern": "^[a-z0-9/_-]+\\.vtt$",
+              "description": "Path under static/ to a WebVTT captions file. Strongly recommended for accessibility."
+            },
+            "caption": {
+              "type": "string",
+              "maxLength": 200,
+              "description": "Optional figcaption rendered under the video."
+            }
+          }
+        }
+      },
+      "if": {
+        "anyOf": [
+          { "required": ["price"] },
+          { "required": ["stripe_url"] },
+          { "required": ["price_source"] }
+        ]
+      },
+      "then": {
+        "required": ["audience", "price", "price_source", "stripe_url"]
+      }
+    }
+  }
+}

--- a/schemas/page.schema.json
+++ b/schemas/page.schema.json
@@ -2,150 +2,17 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/forkwright/typikon/schemas/page.schema.json",
   "title": "typikon page",
-  "description": "Frontmatter contract for a typikon-consuming site's standard page (content/<name>.md, not _index.md).",
-  "type": "object",
-  "required": ["title"],
-  "additionalProperties": false,
+  "description": "Frontmatter contract for a typikon-consuming site's standard page (content/<name>.md, not _index.md). Closes page.core.schema.json once at the top level and once inside extra: unevaluatedProperties (not additionalProperties) is load-bearing here — closing the shared core fragment itself with additionalProperties would make it unable to compose with a consumer's namespaced extension (see docs/SCHEMAS.md#consumer-schema-registry), so the core stays open and only the schema that consumes it — this one, standalone — closes the door.",
+  "allOf": [
+    { "$ref": "https://github.com/forkwright/typikon/schemas/page.core.schema.json" }
+  ],
   "properties": {
-    "title": {
-      "type": "string",
-      "minLength": 1,
-      "maxLength": 80,
-      "description": "Page title. Renders as <title> and <h1>. Keep under ~50 chars for SEO."
-    },
-    "description": {
-      "type": "string",
-      "maxLength": 200,
-      "description": "SEO meta description and og:description. Aim for 120-180 chars."
-    },
-    "date": {
-      "type": "string",
-      "format": "date",
-      "description": "ISO 8601 date. Required for journal entries; optional otherwise."
-    },
-    "updated": {
-      "type": "string",
-      "format": "date",
-      "description": "ISO 8601. When this page was last meaningfully edited."
-    },
-    "path": {
-      "type": "string",
-      "pattern": "^/[a-z0-9/_-]*/?$",
-      "description": "Override Zola's auto-generated path. Lowercase ASCII, slashes, hyphens, underscores."
-    },
-    "template": {
-      "type": "string",
-      "pattern": "^[a-z0-9_-]+\\.html$",
-      "description": "Custom Tera template (relative to theme/templates/)."
-    },
-    "weight": {
-      "type": "integer",
-      "minimum": 0,
-      "description": "Sort order within a section."
-    },
-    "draft": {
-      "type": "boolean",
-      "description": "Exclude from production build."
-    },
     "extra": {
-      "type": "object",
-      "additionalProperties": true,
-      "properties": {
-        "seo_title": {
-          "type": "string",
-          "maxLength": 80,
-          "description": "Override <title> when it should differ from page title (e.g., longer SEO-optimized form)."
-        },
-        "body_class": {
-          "type": "string",
-          "pattern": "^[a-z][a-z0-9 -]*$",
-          "description": "CSS class on <body>. Used by the home page to hide nav/footer (body_class = 'home-page')."
-        },
-        "og_image": {
-          "type": "string",
-          "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|webp)$",
-          "description": "Path under static/ (e.g. 'img/og-cover.png'). get_url() resolves to absolute."
-        },
-        "og_type": {
-          "type": "string",
-          "enum": ["website", "article", "profile"],
-          "description": "Open Graph type. Defaults to 'website'."
-        },
-        "skip_sitemap": {
-          "type": "boolean",
-          "description": "Exclude this page from the generated sitemap.xml. Useful for utility pages (404, thanks) that should not be indexed."
-        },
-        "author": {
-          "type": "string",
-          "description": "Override the brand author for this page. Falls back to config.extra.author.name."
-        },
-        "audience": {
-          "type": "string",
-          "minLength": 3,
-          "maxLength": 120,
-          "description": "Intended buyer or reader context. Required alongside price, price_source, and stripe_url when any one of the three is set — see the extra-level dependency below."
-        },
-        "price": {
-          "type": "string",
-          "pattern": "^\\$?\\d{1,5}(\\.\\d{2})?$",
-          "description": "Display price with optional leading $ (e.g. '$150', '85'). Setting price, stripe_url, or price_source triggers ld-product JSON-LD, which requires all four of audience, price, price_source, and stripe_url together."
-        },
-        "price_source": {
-          "type": "string",
-          "minLength": 3,
-          "maxLength": 200,
-          "description": "Source for the rendered price claim, e.g. the Stripe price object, SKU ledger, or fixture note. Required alongside audience, price, and stripe_url when any one of the three is set — see the extra-level dependency below."
-        },
-        "stripe_url": {
-          "type": "string",
-          "pattern": "^https://buy\\.stripe\\.com/[A-Za-z0-9_]+$",
-          "description": "Stripe direct-checkout URL. Setting price, stripe_url, or price_source triggers ld-product JSON-LD, which requires all four of audience, price, price_source, and stripe_url together."
-        },
-        "video": {
-          "type": "object",
-          "description": "Inline process video (zero-JS native <video>). Drop the .mp4 (and optionally .webm sibling) under static/video/; reference here.",
-          "required": ["src", "alt"],
-          "additionalProperties": false,
-          "properties": {
-            "src": {
-              "type": "string",
-              "pattern": "^[a-z0-9/_-]+\\.mp4$",
-              "description": "Path under static/ to the .mp4 file. Template auto-tries the .webm sibling at the same path before falling back to mp4."
-            },
-            "poster": {
-              "type": "string",
-              "pattern": "^[a-z0-9/_-]+\\.(jpg|jpeg|png|webp)$",
-              "description": "Path under static/ to a still-frame image shown before play."
-            },
-            "alt": {
-              "type": "string",
-              "minLength": 5,
-              "maxLength": 200,
-              "description": "Accessible label describing what the video shows."
-            },
-            "captions": {
-              "type": "string",
-              "pattern": "^[a-z0-9/_-]+\\.vtt$",
-              "description": "Path under static/ to a WebVTT captions file. Strongly recommended for accessibility."
-            },
-            "caption": {
-              "type": "string",
-              "maxLength": 200,
-              "description": "Optional figcaption rendered under the video."
-            }
-          }
-        }
-      },
-      "if": {
-        "anyOf": [
-          { "required": ["price"] },
-          { "required": ["stripe_url"] },
-          { "required": ["price_source"] }
-        ]
-      },
-      "then": {
-        "required": ["audience", "price", "price_source", "stripe_url"]
-      }
+      "allOf": [
+        { "$ref": "https://github.com/forkwright/typikon/schemas/page.core.schema.json#/properties/extra" }
+      ],
+      "unevaluatedProperties": false
     }
-  }
+  },
+  "unevaluatedProperties": false
 }

--- a/schemas/product.schema.json
+++ b/schemas/product.schema.json
@@ -18,7 +18,7 @@
     "extra": {
       "type": "object",
       "required": ["audience", "price", "price_source", "stripe_url"],
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "audience": {
           "type": "string",

--- a/schemas/section.core.schema.json
+++ b/schemas/section.core.schema.json
@@ -31,6 +31,11 @@
     "extra": {
       "type": "object",
       "properties": {
+        "seo_title": {
+          "type": "string",
+          "maxLength": 80,
+          "description": "Override <title> when it should differ from the section title. Read by templates/section.html, templates/index.html, and templates/journal-section.html (section.extra.seo_title | default(value=section.title)) — every section-rendering template, not a page-only concern, so it belongs on the section core alongside page.core's identical field."
+        },
         "greek": {
           "type": "string",
           "description": "Greek heading attribute (data-greek on <h1>) for the design family's hover pattern."

--- a/schemas/section.core.schema.json
+++ b/schemas/section.core.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/forkwright/typikon/schemas/section.core.schema.json",
+  "title": "typikon section core",
+  "description": "Open building block for the section contract: every field section.schema.json declares, with no closure keyword at any level. Referenced by section.schema.json (which closes it once, standalone) and by consumer schemas registered in schemas/registry.toml (which close it once, alongside their own namespaced extension) — see docs/SCHEMAS.md#consumer-schema-registry for why a shared fragment must stay open and closure happens only at the composing schema.",
+  "type": "object",
+  "required": ["title"],
+  "properties": {
+    "title": { "type": "string", "minLength": 1, "maxLength": 80 },
+    "description": { "type": "string", "maxLength": 200 },
+    "template": {
+      "type": "string",
+      "pattern": "^[a-z0-9_-]+\\.html$",
+      "description": "Custom Tera template for the section index itself. Default: section.html. Common: journal-section.html, index.html (for content/_index.md)."
+    },
+    "page_template": {
+      "type": "string",
+      "pattern": "^[a-z0-9_-]+\\.html$",
+      "description": "Default Tera template for CHILD pages of this section. Zola applies it unless a child overrides `template` in its own frontmatter. Used to cascade journal-entry.html across all journal entries from journal/_index.md."
+    },
+    "sort_by": {
+      "type": "string",
+      "enum": ["date", "weight", "title", "none"],
+      "description": "How Zola sorts this section's child pages."
+    },
+    "weight": { "type": "integer", "minimum": 0 },
+    "transparent": {
+      "type": "boolean",
+      "description": "When true, child pages appear in the parent section's listing as if at the parent level."
+    },
+    "extra": {
+      "type": "object",
+      "properties": {
+        "greek": {
+          "type": "string",
+          "description": "Greek heading attribute (data-greek on <h1>) for the design family's hover pattern."
+        },
+        "body_class": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9 -]*$"
+        },
+        "list_caption": {
+          "type": "string",
+          "maxLength": 100,
+          "description": "Small caption rendered after the section's auto-listed pages (e.g., 'Newest at top')."
+        },
+        "home_logo": {
+          "type": "string",
+          "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|webp)$",
+          "description": "Path under static/ for the index.html template's hero logo."
+        },
+        "home_tagline": { "type": "string" },
+        "home_tagline_alt": { "type": "string" },
+        "triad": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["greek", "english"],
+          "properties": {
+            "greek": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 3,
+              "maxItems": 3,
+              "description": "Greek terms cycled by the triad-mark component. Fixed at three: templates/index.html pairs each entry with english[loop.index0] by position, and static/js/triad.js + the .triad-1/.triad-2/.triad-3 CSS rules are hard-coded for a three-term lifecycle."
+            },
+            "english": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 3,
+              "maxItems": 3,
+              "description": "English glosses, positionally paired with greek. Same length as greek by construction (both fixed at exactly three) so templates/index.html's english[loop.index0] lookup can never go out of bounds."
+            },
+            "target": {
+              "type": "string",
+              "pattern": "^/[a-z0-9/_-]*/?$",
+              "description": "Where the triad-mark links to (default: /philosophy/)."
+            }
+          }
+        },
+        "home_nav": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["url", "label"],
+            "additionalProperties": false,
+            "properties": {
+              "url": { "type": "string" },
+              "label": { "type": "string" },
+              "greek": { "type": "string" }
+            }
+          }
+        },
+        "skip_sitemap": {
+          "type": "boolean",
+          "description": "Exclude this section from sitemap.xml. Rare; usually used for hidden internal sections."
+        }
+      }
+    }
+  }
+}

--- a/schemas/section.schema.json
+++ b/schemas/section.schema.json
@@ -2,101 +2,17 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/forkwright/typikon/schemas/section.schema.json",
   "title": "typikon section",
-  "description": "Frontmatter contract for a section index file (_index.md). Sections group child pages and may use a custom template (journal-section.html, etc.).",
-  "type": "object",
-  "required": ["title"],
-  "additionalProperties": false,
+  "description": "Frontmatter contract for a section index file (_index.md). Sections group child pages and may use a custom template (journal-section.html, etc.). Closes section.core.schema.json once at the top level and once inside extra — see page.schema.json's description for why unevaluatedProperties, not additionalProperties, is the closing keyword here.",
+  "allOf": [
+    { "$ref": "https://github.com/forkwright/typikon/schemas/section.core.schema.json" }
+  ],
   "properties": {
-    "title": { "type": "string", "minLength": 1, "maxLength": 80 },
-    "description": { "type": "string", "maxLength": 200 },
-    "template": {
-      "type": "string",
-      "pattern": "^[a-z0-9_-]+\\.html$",
-      "description": "Custom Tera template for the section index itself. Default: section.html. Common: journal-section.html, index.html (for content/_index.md)."
-    },
-    "page_template": {
-      "type": "string",
-      "pattern": "^[a-z0-9_-]+\\.html$",
-      "description": "Default Tera template for CHILD pages of this section. Zola applies it unless a child overrides `template` in its own frontmatter. Used to cascade journal-entry.html across all journal entries from journal/_index.md."
-    },
-    "sort_by": {
-      "type": "string",
-      "enum": ["date", "weight", "title", "none"],
-      "description": "How Zola sorts this section's child pages."
-    },
-    "weight": { "type": "integer", "minimum": 0 },
-    "transparent": {
-      "type": "boolean",
-      "description": "When true, child pages appear in the parent section's listing as if at the parent level."
-    },
     "extra": {
-      "type": "object",
-      "additionalProperties": true,
-      "properties": {
-        "greek": {
-          "type": "string",
-          "description": "Greek heading attribute (data-greek on <h1>) for the design family's hover pattern."
-        },
-        "body_class": {
-          "type": "string",
-          "pattern": "^[a-z][a-z0-9 -]*$"
-        },
-        "list_caption": {
-          "type": "string",
-          "maxLength": 100,
-          "description": "Small caption rendered after the section's auto-listed pages (e.g., 'Newest at top')."
-        },
-        "home_logo": {
-          "type": "string",
-          "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|webp)$",
-          "description": "Path under static/ for the index.html template's hero logo."
-        },
-        "home_tagline": { "type": "string" },
-        "home_tagline_alt": { "type": "string" },
-        "triad": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["greek", "english"],
-          "properties": {
-            "greek": {
-              "type": "array",
-              "items": { "type": "string" },
-              "minItems": 3,
-              "maxItems": 3,
-              "description": "Greek terms cycled by the triad-mark component. Fixed at three: templates/index.html pairs each entry with english[loop.index0] by position, and static/js/triad.js + the .triad-1/.triad-2/.triad-3 CSS rules are hard-coded for a three-term lifecycle."
-            },
-            "english": {
-              "type": "array",
-              "items": { "type": "string" },
-              "minItems": 3,
-              "maxItems": 3,
-              "description": "English glosses, positionally paired with greek. Same length as greek by construction (both fixed at exactly three) so templates/index.html's english[loop.index0] lookup can never go out of bounds."
-            },
-            "target": {
-              "type": "string",
-              "pattern": "^/[a-z0-9/_-]*/?$",
-              "description": "Where the triad-mark links to (default: /philosophy/)."
-            }
-          }
-        },
-        "home_nav": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["url", "label"],
-            "additionalProperties": false,
-            "properties": {
-              "url": { "type": "string" },
-              "label": { "type": "string" },
-              "greek": { "type": "string" }
-            }
-          }
-        },
-        "skip_sitemap": {
-          "type": "boolean",
-          "description": "Exclude this section from sitemap.xml. Rare; usually used for hidden internal sections."
-        }
-      }
+      "allOf": [
+        { "$ref": "https://github.com/forkwright/typikon/schemas/section.core.schema.json#/properties/extra" }
+      ],
+      "unevaluatedProperties": false
     }
-  }
+  },
+  "unevaluatedProperties": false
 }


### PR DESCRIPTION
## Finding

`typikon-validate` recognized only six built-in content classes. Any file whose frontmatter set a `template` typikon does not ship — or whose path a consumer wanted to route independently — fell through `classify()` to `page.schema.json`, whose `extra` object accepted any additional field without checking its type. A typo such as `kanon_ci = "false"` (string, not boolean) was schema-valid and became truthy wherever a consumer template did `bool(...)` on it.

## Evidence

- `bin/typikon-validate` (pre-fix) `classify()`: `TEMPLATE_SCHEMA_MAP` covered only `faq.html`/`sizing-guide.html`; every other custom `template` fell through path-based routing to `page`.
- `schemas/page.schema.json` and `schemas/section.schema.json` (pre-fix): `extra.additionalProperties: true` — any field beyond the named ones passed unchecked.
- `docs/AGENTIC.md:20` (unchanged by this PR): "Do not invent fields. If a frontmatter field is not in the schema, do not write it." — the permissive `extra` directly contradicted typikon's own stated contract.

## Desired correction (delivered)

- **`schemas/page.core.schema.json`, `schemas/section.core.schema.json`**: open building blocks (no `additionalProperties`/`unevaluatedProperties` anywhere) holding every field the closed wrappers declare.
- **`schemas/page.schema.json`, `schemas/section.schema.json`**: rewritten as thin closed wrappers — `allOf: [{$ref: <core>}]` plus a second `allOf`+`$ref` on `extra`, each closed once with `unevaluatedProperties: false`.
- **`schemas/journal-entry.schema.json`, `schemas/product.schema.json`**: `extra.additionalProperties` flipped `true` → `false` directly (no consumer needs to extend these yet).
- **`bin/typikon-validate`**: `load_consumer_registry()` reads `<consumer-root>/schemas/registry.toml`; `classify()` raises `UnregisteredTemplateError` for a `template` neither typikon's own nor registered.
- **15 cases in `ci/check-consumer-schema-registry.py`**, each invoking the real CLI as a subprocess against a throwaway consumer tree.
- **`docs/SCHEMAS.md`**, **`docs/AGENTIC.md`**, **`CLAUDE.md`** (+ `_llm/decisions.toml`, `_llm/glossary.toml`): document the registry and the composition pattern.

---

## Adversarial review found this incomplete. Three findings, addressed below — all three, no scope reduction.

### Finding 1 — the issue's own Done-when was unverified: no real consumer was ever run through the mechanism

**Correct.** The original PR built the registry, closed the schemas, and proved it against synthetic fixtures — but never ran the actual validator against either real typikon consumer's actual content. That gap is now closed, against both real consumers, with the evidence a reviewer needs to disprove it:

**`forkwright/ardent-site`** (Ardent Leatherworks) — no custom templates, so it needs no registry, but closing `page`/`section`/`journal-entry`/`product` is a real behavior change for it. Running this branch's validator against a fresh clone of its real content, pre-fix:

```
{"file": "content/_index.md", "schema": "section", "pointer": "/extra", "error": "Unevaluated properties are not allowed ('template' was unexpected)"}
{"file": "content/sizing/_index.md", "schema": "section", "pointer": "/extra", "error": "Unevaluated properties are not allowed ('seo_title' was unexpected)"}
{"checked": 23, "passed": 21, "failed": 2}
```

Both are real, previously-undetectable bugs this PR's closure surfaces — not this repo's content to fix silently:

1. `content/_index.md` had `template = "index.html"` nested inside `[extra]` by mistake (a TOML authoring error — the real top-level `template` field was therefore unset, silently falling back to a section default, while the stray `extra.template` did nothing). Fixed in **forkwright/ardent-site#35**.
2. `section.core.schema.json` never declared `seo_title`, even though `templates/section.html`, `templates/index.html`, and `templates/journal-section.html` (typikon's own theme, not consumer-specific — verified by reading all three) all read `section.extra.seo_title | default(value=section.title)`, the same override `page.core` already declares. Fixed here in this PR (`schemas/section.core.schema.json`) — a real omission in the schema this PR itself introduces, not a pre-existing issue.

With both fixed, this branch's validator against `ardent-site`'s real content:

```
{"checked": 23, "passed": 23, "failed": 0}
```

**`ardent-tools/ardent-tools-site`** (Ardent Tools — the consumer issue #60 names by its five templates: home, consulting, evidence, systems index, system dossier; the reviewer correctly found no such repo in the `forkwright` org, because it lives under the separate `ardent-tools` org, not `forkwright` — confirmed real via `gh api repos/ardent-tools/ardent-tools-site` and its actual `templates/consulting.html`, `templates/evidence.html`, `templates/system.html`, `templates/systems.html`). It had **zero** schema registration for any of its six custom templates. Running this branch's validator against its real content, pre-fix:

```
{"file": "content/about.md", "pointer": "/template", "error": "custom template 'about.html' has no schema registration..."}
... (20 of 26 real content files failed the same way — every home/about/consulting/evidence/systems-index/system-dossier page)
{"checked": 26, "passed": 6, "failed": 20}
```

`ardent-tools/ardent-tools-site#146` adds `schemas/registry.toml` plus one schema per custom template, each composing this PR's `page.core.schema.json`/`section.core.schema.json` and closed with `unevaluatedProperties: false` — field shapes derived by parsing every real content file with `tomllib`, not by inspection (`schemas/system-dossier.schema.json`'s `extra.demo` reflects the actual union of fields across all 7 real system pages, including the planned-recording-vs-published-cast field split, and `repo`/`kanon_ci`/`license` are optional because the real `content/systems/kanon.md` omits all three). With that PR's schemas in place, this branch's validator against the real content:

```
{"checked": 26, "passed": 18, "failed": 8}
```

**The remaining 8 are a real, honestly-disclosed limitation, not swept under the rug.** `content/writing/*.md` sets no explicit `template`; it relies on Zola's `page_template` cascade (`content/writing/_index.md` sets `page_template = "journal-entry.html"`), which `classify()` does not simulate — a gap independent of the registry, pre-existing, and newly *exposed* (not created) by this PR's closure of `page.schema.json`. Filed as **forkwright/typikon#159** with full repro; a reviewer can confirm it's real and confirm it's out of #60's scope (registering *known* discriminators, not resolving Zola's template-inheritance semantics before that lookup starts).

Every existing fixture (`examples/sample-blog`, `examples/sample-shop`) still validates clean and unchanged — `{"checked": 5, "passed": 5}` / `{"checked": 9, "passed": 9}`.

### Finding 2 — `classify()` let a registry entry's `extends` silently disagree with what a file structurally is

**Correct, and reproduced.** A `path_prefix` (or `template`) entry registered `extends = "page"` unconditionally overrode section classification for any `_index.md` a path also matched — `base = "section"` was computed, then discarded on any registry hit, with no check that the entry's `extends` agreed with what the file structurally is.

Reproduced against the pre-fix committed classifier (`git show HEAD~2:bin/typikon-validate` before this PR's fix commits) with a `path_prefix = "systems/"` (`extends="page"`) entry and a `content/systems/_index.md` shaped to coincidentally satisfy the page-extending schema (`title` + `extra.ardent.repo_url`, nothing section-specific):

```
$ python3 <pre-fix bin/typikon-validate> <fixture>
{"checked": 1, "passed": 1, "failed": 0}
```

**Silently validated clean** — a section file checked against the wrong schema, with nothing surfacing the mismatch, exactly as the finding describes. A second fixture (no section-only fields, just `sort_by`) instead produced a misleading `"'sort_by' was unexpected"` error — technically a failure, but for the wrong reason, pointing a maintainer at deleting a real field rather than at the actual defect (the registry entry itself).

**Fix:** `classify()` now computes the file's structural kind (`section` for `_index.md`, `page` for everything else — Zola's own distinction) before either match path, and raises `MismatchedExtendsError` when a `template` or `path_prefix` hit's `extends` disagrees with it. `validate_file()` converts that to the same JSONL-failure shape as `UnregisteredTemplateError`.

**Negative fixtures, wired into `ci/check-consumer-schema-registry.py` (now 15 cases, run every CI pass):**
- `"path_prefix registered extends=page silently matching a _index.md (structurally section) — fails closed, not a silent pass"` — the exact reproduction above.
- `"registered template applied to a _index.md (structurally section) — mismatched extends fails closed"` — the `template`-discriminator analog (the finding's parenthetical "(or template)").

```
$ python3 ci/check-consumer-schema-registry.py
{"checked": 15, "passed": 15, "failed": 0}
```

Both new cases fail if the `extends`-check is reverted — verified by running them against the pre-fix classifier above.

### Finding 3 — untagged comments

**Correct**, and fixed: `bin/typikon-validate`'s `COMPOSABLE_CORE_SLUGS` rationale block now opens `# WHY:`; `ci/check-consumer-schema-registry.py:128`'s case-format comment is now `# NOTE:`. (The reviewer noted this was pre-existing noncompliance elsewhere in the file, not introduced by this diff, and non-blocking — fixed anyway since it was cheap and in a file this PR is already touching.)

---

## What a reviewer would have to disprove

- `bin/typikon-validate examples/sample-blog` and `examples/sample-shop` still exit 0 with `{"failed": 0}`.
- `python3 ci/check-consumer-schema-registry.py` genuinely exercises the CLI and all 15 assertions hold, including the two new `MismatchedExtendsError` cases (revert the `extends`-check in `classify()` and cases 14–15 fail; that's the test proving the fix, not just documenting it).
- `python3 ci/check-triad-schema.py` still passes 4/4.
- Running this branch's `bin/typikon-validate` against a fresh clone of `forkwright/ardent-site` (`main` + `ardent-site#35`) returns `{"checked": 23, "passed": 23, "failed": 0}`.
- Running this branch's `bin/typikon-validate` against a fresh clone of `ardent-tools/ardent-tools-site` (`main` + `ardent-tools-site#146`) returns `{"checked": 26, "passed": 18, "failed": 8}`, and every one of the 8 failures is under `content/writing/`, matching `typikon#159` exactly (not the six templates #60 is about).
- That `section.core.schema.json`'s new `seo_title` field is genuinely read by typikon's own theme (`grep -n "extra\.seo_title" templates/section.html templates/index.html templates/journal-section.html`), not a speculative addition.
- That `ardent-site#35`'s one-line move (`template` out of `[extra]`) doesn't change rendering: `grep -rn "extra\.template\b" themes/typikon/templates/` in that repo returns no matches, so nothing read the stray field being removed.

## Companion PRs (both needed for the "both real consumers pass" claim to be checkable independently of this repo)

- `forkwright/ardent-site#35` — homepage `template` frontmatter placement fix.
- `ardent-tools/ardent-tools-site#146` — registers all six custom templates against this PR's registry mechanism.
- `forkwright/typikon#159` — the `page_template`-cascade gap this verification pass found and disclosed rather than silently leaving unhandled or hidden.

Closes #60
