### PR TITLE
chore(toolchain): pin rust-toolchain.toml to fleet 1.97.1

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -85,9 +85,15 @@ jobs:
     # and review the diff at forkwright/.github before bumping.
     uses: forkwright/.github/.github/workflows/hybrid-gate.yml@84a39d3344660e4010c32755b33a6a88912ad929 # main
     with:
-      # WHY empty: no rust-toolchain.toml exists (there is no Rust code at
-      # all) -- auto-detect applies. The setup-rust-toolchain step runs
-      # unconditionally regardless of this value; it is inert for this repo.
+      # WHY empty, not a literal channel: rust-toolchain.toml at the repo
+      # root (forkwright/kanon#3489) carries the pin even though this repo
+      # has no Rust code of its own -- empty defers to setup-rust-toolchain's
+      # auto-detect, which reads that file rather than resolving whatever
+      # "stable" means at runtime. The setup-rust-toolchain step still runs
+      # unconditionally regardless of this value and its output is still
+      # unused (fmt_cmd/clippy_cmd/nextest_cmd are all "true" above) -- the
+      # file makes that wasted step deterministic, it does not make it
+      # meaningful.
       rust_toolchain: ""
       fmt_cmd: "true"
       check_cmd: |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.97.1"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## What

typikon had no `rust-toolchain.toml`, so its GH Actions gate's `setup-rust-toolchain` step (which
runs unconditionally regardless of `fmt_cmd`/`clippy_cmd`/`nextest_cmd`) resolved whatever `stable`
meant at CI-runtime instead of a pinned version — the class of drift forkwright/kanon#3489 measured
across the fleet (five distinct toolchain values plus four repos with no pin, typikon among them).

Adds `rust-toolchain.toml` pinned to `1.97.1`, matching kanon's shape:

```toml
[toolchain]
channel = "1.97.1"
components = ["rustfmt", "clippy"]
```

Also updates the now-stale `gate-attestation.yml` comment on `rust_toolchain: ""` that documented
"no rust-toolchain.toml exists" — that claim is false as of this PR.

## typikon is not a Cargo workspace — verified, not assumed

`find . -name Cargo.toml` and `find . -name '*.rs'` both return nothing. `bin/` is bash,
`ci/` is Python/bash/TS, `templates/`/`sass`/`schemas` are Zola theme assets. The repo's own
`gate-attestation.yml` header already documents this ("typikon has no Cargo.toml — it is a Zola
theme… not a Rust workspace") and sets `fmt_cmd`/`clippy_cmd`/`nextest_cmd` to `"true"` no-ops.

Consequence: **the pin has no lint or build surface to change here.** There is no Rust source for a
new-in-1.97.1 lint to fire against, so "fix whatever the pin surfaces" surfaced nothing to fix in
typikon's own code. What it *does* change is the previously-wasted, unconditionally-run
`setup-rust-toolchain` step in the shared gate: it now installs a pinned version instead of
resolving `stable` at runtime — determinism for a step whose output stays unused, not a new
correctness guarantee.

## Negative fixture

This change adds no check, validation, or enforcement logic — it is a version pin plus a comment
correction. Per the brief: no negative fixture applies, stated explicitly rather than omitted.

## Acceptance criteria (from the dispatch brief), enumerated

1. **Add `rust-toolchain.toml` pinned to 1.97.1** — `rust-toolchain.toml:2` (`channel = "1.97.1"`).
2. **Match kanon's shape, including `components = ["rustfmt", "clippy"]`** — `rust-toolchain.toml:3`,
   diffed byte-for-byte against `kanon`'s own file (verified via direct read, not recall).
3. **Fix whatever the pin surfaces** — verified there is nothing to fix: no `Cargo.toml`, no `.rs`
   files anywhere in the tree (see above). The stale `gate-attestation.yml:88-96` comment that
   claimed "no rust-toolchain.toml exists" was the one thing the pin *did* surface, and it is fixed
   in this diff.
4. **Check what the gate actually builds before assuming a Cargo workspace** — done; see above.
   Confirmed on the build box: `kanon lint` passes on both `main` and this branch (0 open
   violations either way — the 41 pre-existing `WRITING/*` warnings across `README.md`,
   `CLAUDE.md`, `docs/*.md` are unrelated to this diff, unchanged by it, and out of scope for a
   toolchain-pin PR). The `fixtures-gate` stage of `.kanon-ci.toml` (`ci/run-fixtures.sh`) fails
   identically on `main` and on this branch with `{"error": "jsonschema package required (pip
   install jsonschema)"}` — a verda-build provisioning gap (system `python3` has no `pip` module at
   all), **not** caused by this change. Confirmed by running the same `~/gate-repo.sh typikon`
   control against `main` and observing the identical failure. typikon's actual gate-of-truth is
   this repo's own `gate-attestation.yml` (GH Actions), which installs `jsonschema`/`fonttools`/
   `Brotli` itself in `check_cmd` before running `ci/run-fixtures.sh` — that is the CI this PR's
   checks report against.
5. **Conventional-commit subject with a scope, no AI attribution** — `chore(toolchain): pin
   rust-toolchain.toml to fleet 1.97.1`; no `Co-Authored-By` trailer.
6. **Open PR referencing forkwright/kanon#3489, do not merge** — this PR, below. Not merged by me.

Refs forkwright/kanon#3489
