### PR TITLE
fix(typikon-validate): simulate Zola's page_template cascade in classify()

### DIFF
--- a/bin/typikon-validate
+++ b/bin/typikon-validate
@@ -8,7 +8,20 @@ Walks <root>/content/**/*.md, parses TOML frontmatter (between +++ lines),
 classifies each file by its location, and validates against the appropriate
 JSON Schema in <typikon-repo>/schemas/.
 
-Classification rules (in order — first match wins):
+A leaf page (never a section's own _index.md — Zola's page_template governs
+a section's DESCENDANTS, not the section itself) that sets no `template` of
+its own first resolves one from the nearest ancestor section's
+`page_template` — Zola's own cascade ("the given template is applied to ALL
+pages below the section, recursively... if you have several nested
+sections, each with a page_template set, the page will always use the
+closest to itself... a page's own `template` variable will always have
+priority"). The resolved value is then classified by the SAME rules below
+as if the page's own frontmatter had set it — see
+`build_page_template_cascade` / `classify`.
+
+Classification rules (in order — first match wins; `template` here means
+the page's own frontmatter value, or its cascade-resolved effective value
+when it set none):
     frontmatter `template = "faq.html"`          -> faq.schema.json
     frontmatter `template = "sizing-guide.html"` -> sizing-guide.schema.json
     frontmatter `template` matches a `[[entry]]` in
@@ -180,16 +193,95 @@ class ConsumerRegistry:
         return None
 
 
-def classify(rel_path: Path, frontmatter: dict, registry: ConsumerRegistry) -> tuple[str, dict | None]:
+def build_page_template_cascade(content_root: Path) -> dict[Path, str]:
+    """Pre-scan every content/**/_index.md for a declared `page_template`,
+    keyed by the section's own directory (content-parent-relative, matching
+    the `rel_path.parent` classify() sees — e.g. `Path("content")` for the
+    root section, `Path("content/writing")` for a child section). classify()
+    walks this map outward from a leaf page's own directory to resolve
+    Zola's page_template cascade — see the module docstring.
+
+    A separate pre-pass over the whole tree, not built incrementally during
+    main()'s per-file walk: `Path.rglob`'s traversal order is lexicographic
+    per path segment, and "_index.md" (leading `_`, 0x5F) sorts BELOW any
+    letter but ABOVE any digit (0x30-0x39) — a sibling directory named e.g.
+    "2026-review" would sort, and so be visited, before its own section's
+    "_index.md" in the very same walk. Building the cascade incrementally
+    while walking would make resolution depend on directory-naming
+    coincidence instead of the tree's actual ancestry. This pass reads the
+    whole content/**/_index.md set first, independent of any single file's
+    position in main()'s later walk, so resolution is order-independent by
+    construction.
+
+    An _index.md with malformed frontmatter contributes nothing here (same
+    as one with no page_template) rather than raising — that file's own
+    malformed-frontmatter failure is reported exactly once, by
+    validate_file() when the main loop reaches that file in its own right.
+    Silently double-failing it here (or aborting the whole run on one bad
+    section) would not add information the per-file pass doesn't already
+    surface.
+    """
+    cascade: dict[Path, str] = {}
+    for index_path in content_root.rglob("_index.md"):
+        rel_dir = index_path.parent.relative_to(content_root.parent)
+        try:
+            fm = parse_frontmatter(index_path.read_text(encoding="utf-8"), str(index_path))
+        except Exception:
+            continue
+        page_template = fm.get("page_template")
+        if isinstance(page_template, str):
+            cascade[rel_dir] = page_template
+    return cascade
+
+
+def _cascade_lookup(start_dir: Path, cascade: dict[Path, str]) -> str | None:
+    """Walk from a leaf page's own parent directory up through each
+    ancestor section (content/<a>/<b>/, content/<a>/, content/), returning
+    the NEAREST one's `page_template`. Zola: "if you have several nested
+    sections, each with a page_template set, the page will always use the
+    closest to itself" — a section that sets no page_template of its own
+    does not break the chain, it is simply skipped in favor of the next
+    ancestor up. Stops after checking `content` itself (one path segment);
+    `build_page_template_cascade` never keys anything outside content/, so
+    continuing past it can only ever miss.
+    """
+    directory = start_dir
+    while True:
+        hit = cascade.get(directory)
+        if hit is not None:
+            return hit
+        if len(directory.parts) <= 1:
+            return None
+        directory = directory.parent
+
+
+def classify(
+    rel_path: Path,
+    frontmatter: dict,
+    registry: ConsumerRegistry,
+    page_template_cascade: dict[Path, str],
+) -> tuple[str, dict | None]:
     """Map a markdown file to its schema. Returns (schema_name, consumer_schema)
     — consumer_schema is None for a typikon-owned builtin (look `schema_name`
     up in the `schemas` dict) and set for a registry-composed consumer schema.
 
-    Frontmatter `template` wins when present in TEMPLATE_SCHEMA_MAP or the
-    consumer registry — that's how page-level overrides (FAQ, sizing-guide,
-    and any registered custom template) escape the path-based default.
-    Raises UnregisteredTemplateError for a `template` this validator cannot
-    account for by either route — see the module docstring's FAIL-CLOSED note.
+    A page (never a section's own `_index.md` — see `_cascade_lookup`) that
+    sets no `template` of its own first resolves one from
+    `page_template_cascade`: the nearest ancestor section's `page_template`,
+    mirroring Zola's own cascade precedence (nearest-set-ancestor wins; a
+    page's own `template` always wins over any ancestor's page_template —
+    enforced simply by only consulting the cascade when the page's own
+    `template` is absent). From there on, a cascade-resolved value is
+    indistinguishable from an explicitly-set one: it flows through the exact
+    same TEMPLATE_SCHEMA_MAP / registry / KNOWN_TEMPLATES-fail-closed checks
+    below.
+
+    Frontmatter `template` (explicit or cascade-resolved) wins when present
+    in TEMPLATE_SCHEMA_MAP or the consumer registry — that's how page-level
+    overrides (FAQ, sizing-guide, and any registered custom template) escape
+    the path-based default. Raises UnregisteredTemplateError for a
+    `template` this validator cannot account for by either route — see the
+    module docstring's FAIL-CLOSED note.
     Raises MismatchedExtendsError when a registry entry (either
     discriminator kind) matches a file whose structural kind — fixed by
     Zola (section for `_index.md`, page for everything else), not by the
@@ -217,6 +309,9 @@ def classify(rel_path: Path, frontmatter: dict, registry: ConsumerRegistry) -> t
             base = "page"
 
     template = frontmatter.get("template")
+    if template is None and structural_kind == "page":
+        template = _cascade_lookup(rel_path.parent, page_template_cascade)
+
     if template in TEMPLATE_SCHEMA_MAP:
         return TEMPLATE_SCHEMA_MAP[template], None
 
@@ -274,6 +369,7 @@ def validate_file(
     schemas: dict[str, dict],
     jsonschema_registry: Registry,
     registry: ConsumerRegistry,
+    page_template_cascade: dict[Path, str],
 ) -> list[dict]:
     """Return a list of failure records for one file (empty when all good)."""
     rel = path.relative_to(content_root.parent)  # keep "content/..." prefix
@@ -290,7 +386,7 @@ def validate_file(
         return [{"file": file_label, "pointer": "", "error": str(exc)}]
 
     try:
-        schema_name, consumer_schema = classify(rel, fm, registry)
+        schema_name, consumer_schema = classify(rel, fm, registry, page_template_cascade)
     except UnregisteredTemplateError as exc:
         return [{
             "file": file_label,
@@ -521,11 +617,16 @@ def main(argv: list[str]) -> int:
 
     schemas, base_registry = load_schemas()
     consumer_registry = load_consumer_registry(root, base_registry)
+    # WHY: built in its own full-tree pass, BEFORE the per-file walk below —
+    # see build_page_template_cascade for why this must not be incremental.
+    page_template_cascade = build_page_template_cascade(content_root)
 
     files = sorted(content_root.rglob("*.md"))
     failures: list[dict] = []
     for f in files:
-        failures.extend(validate_file(f, content_root, schemas, consumer_registry.jsonschema_registry, consumer_registry))
+        failures.extend(validate_file(
+            f, content_root, schemas, consumer_registry.jsonschema_registry, consumer_registry, page_template_cascade,
+        ))
 
     for failure in failures:
         print(json.dumps(failure), file=sys.stderr)

--- a/ci/check-page-template-cascade.py
+++ b/ci/check-page-template-cascade.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""check-page-template-cascade — regression test for forkwright/typikon#159.
+
+WHY: bin/typikon-validate's classify() read only a file's OWN frontmatter
+`template` field. It had no notion of Zola's page_template cascade: a
+section's `_index.md` can set `page_template = "..."` and Zola applies that
+template to every descendant page that sets no `template` of its own,
+recursively through nested sections, with the closest ancestor winning
+(https://www.getzola.org/documentation/content/section/ — "The given
+template is applied to ALL pages below the section, recursively. If you
+have several nested sections, each with a page_template set, the page will
+always use the closest to itself. However, a page's own `template`
+variable will always have priority."). Pre-fix, such a page fell through
+to path-based classification and validated against the wrong schema —
+reproduced below exactly as forkwright/typikon#159 reports it: a
+non-canonical section directory (not content/journal/, not
+content/products/) cascading one of typikon's own templates to its
+children.
+
+This script proves, against the REAL `bin/typikon-validate` CLI (Section A,
+subprocess — the actual classify()+validate_file()+main() path, not a
+reimplementation) and the real `_cascade_lookup` function (Section B,
+imported via importlib — bin/typikon-validate has no .py suffix, so it
+cannot be `import`ed normally; mirrors ci/check-triad-schema.py's own
+loader for the same reason):
+
+Section A (subprocess, full pipeline):
+  1. [REQUIRED NEGATIVE FIXTURE] a leaf page with no `template` of its own,
+     under a section whose _index.md sets `page_template = "faq.html"`,
+     validates against faq.schema.json — exactly as if it had set
+     `template = "faq.html"` itself. Pre-fix this fell through to
+     page.schema.json and failed on the very extra fields ("questions")
+     the cascaded template's schema exists to check.
+  2. a page's own `template` always wins over an ancestor's page_template.
+  3. `page_template` does NOT apply to a section's own `_index.md` — only
+     to pages below it (Zola's own text: "applied to ALL pages below the
+     section" — a section's _index.md is not below itself).
+  4. of two nested sections that each set page_template, the closer one
+     wins for its own descendants.
+  5. a section that sets NO page_template does not break the chain — its
+     descendants inherit from the next ancestor up that does.
+  6. a malformed ancestor _index.md does not crash the run, and does not
+     silently swallow ITS OWN malformed-frontmatter error (reported once,
+     by the ordinary per-file path) — nor does it poison an unrelated
+     sibling section's cascade.
+  7. cascade resolution is independent of Path.rglob's traversal order: a
+     subsection directory whose name sorts BEFORE "_index.md" ("_" is
+     0x5F, above ASCII digits 0x30-0x39) still correctly inherits its
+     ancestor's page_template. A cascade built incrementally during the
+     main per-file walk (instead of the required full pre-pass) would
+     visit this file before ever recording its own section's ancestor,
+     and this case would silently fall through to path-based
+     classification exactly like the un-fixed classifier does.
+  8. a page_template value that resolves through the CONSUMER REGISTRY
+     (forkwright/typikon#60), not just TEMPLATE_SCHEMA_MAP, is reached the
+     same way — the cascade only resolves an effective `template` value;
+     everything downstream of that (registry match, fail-closed checks)
+     is the existing, unmodified pipeline.
+
+Section B (direct, `_cascade_lookup` in isolation):
+  proves the walk's own arithmetic — nearest-wins, skip-non-setting
+  ancestors, page's-own-template-short-circuits (by never being called),
+  and stopping at content/ without KeyError/IndexError past the root —
+  against constructed Path keys where the full-pipeline noise (schema
+  validation, frontmatter parsing) cannot obscure an off-by-one in the
+  walk itself.
+
+NOTE: runs standalone (no consumer site needed) as part of ci/run-fixtures.sh.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+THEME_ROOT = Path(__file__).resolve().parent.parent
+VALIDATE = THEME_ROOT / "bin" / "typikon-validate"
+
+_loader = importlib.machinery.SourceFileLoader("typikon_validate_cascade", str(VALIDATE))
+_spec = importlib.util.spec_from_loader("typikon_validate_cascade", _loader)
+_tv = importlib.util.module_from_spec(_spec)
+sys.modules["typikon_validate_cascade"] = _tv  # dataclass() resolves types via sys.modules[__module__]
+_spec.loader.exec_module(_tv)
+
+
+def write_tree(root: Path, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+
+def run_validate(root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(VALIDATE), str(root)],
+        capture_output=True, text=True, check=False,
+    )
+
+
+# ── Section A: subprocess, full pipeline ───────────────────────────────
+
+# NOTE: each case is (label, files, expected_exit, required_stderr_substrings)
+CASES: list[tuple[str, dict[str, str], int, list[str]]] = [
+    (
+        # REQUIRED NEGATIVE FIXTURE for #159. Pre-fix command + failure,
+        # captured verbatim (git stash of the pre-fix bin/typikon-validate
+        # run against this exact fixture):
+        #   $ python3 bin/typikon-validate <this fixture>
+        #   {"file": "content/guides/shipping.md", "schema": "page",
+        #    "pointer": "/extra", "error": "Unevaluated properties are not
+        #    allowed ('questions' was unexpected)"}
+        #   {"checked": 2, "passed": 1, "failed": 1}
+        #   exit=1
+        # "questions" is faq.schema.json's own required array field —
+        # page.schema.json's extra has never heard of it. Post-fix, the
+        # cascade resolves content/guides/shipping.md's effective template
+        # to "faq.html" (from content/guides/_index.md's page_template,
+        # since the page itself sets none) and validates it against
+        # faq.schema.json, where `questions` is exactly the right shape.
+        "leaf page with no template, under a section with page_template=faq.html, cascades to faq.schema.json",
+        {
+            "content/guides/_index.md": (
+                '+++\ntitle = "Guides"\ntemplate = "section.html"\n'
+                'page_template = "faq.html"\n+++\nbody\n'
+            ),
+            "content/guides/shipping.md": (
+                '+++\ntitle = "Shipping FAQ"\n\n[extra]\naudience = "customers"\n\n'
+                '[[extra.questions]]\nq = "How long does shipping take?"\n'
+                'a = "Three to five business days."\n+++\nbody\n'
+            ),
+        },
+        0,
+        [],
+    ),
+    (
+        "a page's own template overrides an ancestor's page_template",
+        {
+            "content/guides/_index.md": (
+                '+++\ntitle = "Guides"\npage_template = "faq.html"\n+++\nbody\n'
+            ),
+            "content/guides/plain.md": (
+                '+++\ntitle = "Plain page, not a FAQ"\ntemplate = "page.html"\n+++\nbody\n'
+            ),
+        },
+        0,
+        [],
+    ),
+    (
+        "page_template does not apply to a section's OWN _index.md — a nested section under a page_template ancestor still classifies as section, not the cascaded schema",
+        {
+            "content/guides/_index.md": (
+                '+++\ntitle = "Guides"\npage_template = "faq.html"\n+++\nbody\n'
+            ),
+            # A nested section index: structurally a section (name ==
+            # "_index.md"), so it must classify via section.schema.json
+            # regardless of the ancestor's page_template. If the cascade
+            # wrongly applied here, this would be validated against
+            # faq.schema.json and fail (no `extra.questions`); it must
+            # pass as a section instead.
+            "content/guides/shipping/_index.md": (
+                '+++\ntitle = "Shipping"\n+++\nbody\n'
+            ),
+        },
+        0,
+        [],
+    ),
+    (
+        "nested sections: the CLOSER ancestor's page_template wins over a farther one",
+        {
+            "content/guides/_index.md": (
+                '+++\ntitle = "Guides"\npage_template = "faq.html"\n+++\nbody\n'
+            ),
+            "content/guides/sizing/_index.md": (
+                '+++\ntitle = "Sizing"\npage_template = "sizing-guide.html"\n+++\nbody\n'
+            ),
+            # No template of its own; nearest ancestor (guides/sizing) sets
+            # page_template = sizing-guide.html — must NOT pick up the
+            # farther content/guides/ ancestor's faq.html instead. A sizing
+            # fixture validated as faq (extra.questions required) would
+            # fail; validated as sizing-guide (extra.sizes required) is
+            # the correct outcome and is what this fixture supplies.
+            "content/guides/sizing/shirt.md": (
+                '+++\ntitle = "Shirt Sizing"\n\n[extra]\naudience = "customers"\n'
+                'product_type = "shirt"\nmeasurement_source = "pattern block"\n\n'
+                '[[extra.size_table]]\nsize = "M"\nwaist = "38-40in"\n+++\nbody\n'
+            ),
+        },
+        0,
+        [],
+    ),
+    (
+        "a section with NO page_template of its own does not break the chain — its child inherits from the next ancestor up",
+        {
+            "content/guides/_index.md": (
+                '+++\ntitle = "Guides"\npage_template = "faq.html"\n+++\nbody\n'
+            ),
+            # sizing/_index.md sets no page_template at all — the walk
+            # must skip past it (not stop / not treat "unset" as a match)
+            # and keep going up to content/guides/, inheriting faq.html.
+            "content/guides/sizing/_index.md": '+++\ntitle = "Sizing"\n+++\nbody\n',
+            "content/guides/sizing/note.md": (
+                '+++\ntitle = "A note, not a size chart"\n\n[extra]\naudience = "customers"\n\n'
+                '[[extra.questions]]\nq = "Is this a FAQ page?"\na = "Yes, by inheritance."\n+++\nbody\n'
+            ),
+        },
+        0,
+        [],
+    ),
+    (
+        "a malformed ancestor _index.md does not crash the run: its own error is reported once, and it contributes nothing to the cascade (sibling section unaffected)",
+        {
+            "content/guides/_index.md": '+++\ntitle = "Guides"\npage_template = "faq.html\n+++\nbody\n',  # unterminated string — malformed TOML
+            "content/other/_index.md": '+++\ntitle = "Other"\n+++\nbody\n',
+            "content/other/plain.md": '+++\ntitle = "Plain"\n+++\nbody\n',
+        },
+        1,
+        ["content/guides/_index.md"],
+    ),
+    (
+        # WHY this case exists: Path.rglob's walk order is lexicographic
+        # per path segment. "_index.md" (leading "_", 0x5F) sorts BELOW
+        # any letter but ABOVE any ASCII digit (0x30-0x39), so a sibling
+        # directory named "2026-faq" sorts, and so is visited, BEFORE its
+        # own section's "_index.md" in that same walk. An incremental,
+        # single-pass cascade (recording page_template as the main loop
+        # reaches each _index.md) would visit content/guides/2026-faq/
+        # leaf.md before ever recording content/guides/2026-faq/_index.md's
+        # page_template, and this fixture would silently fall through to
+        # page.schema.json — exactly the un-fixed classifier's failure
+        # mode, just for a different reason. The required full pre-pass
+        # (build_page_template_cascade) makes this order-independent.
+        "cascade resolution does not depend on Path.rglob's traversal order (digit-prefixed subsection sorts before its own _index.md)",
+        {
+            "content/guides/2026-faq/_index.md": (
+                '+++\ntitle = "2026 FAQ"\npage_template = "faq.html"\n+++\nbody\n'
+            ),
+            "content/guides/2026-faq/leaf.md": (
+                '+++\ntitle = "Leaf"\n\n[extra]\naudience = "customers"\n\n'
+                '[[extra.questions]]\nq = "Does order-independence hold?"\na = "Yes, it does."\n+++\nbody\n'
+            ),
+        },
+        0,
+        [],
+    ),
+    (
+        # A page_template value reaching the #60 CONSUMER REGISTRY, not
+        # just the built-in TEMPLATE_SCHEMA_MAP — proves the cascade only
+        # resolves an effective `template`; everything downstream
+        # (registry_hit / fail-closed / MismatchedExtendsError) is the
+        # existing, unmodified pipeline reached the same way an explicit
+        # `template = "consulting.html"` would reach it.
+        "a page_template resolving through the consumer registry (not TEMPLATE_SCHEMA_MAP) is reached the same way an explicit template would be",
+        {
+            "schemas/registry.toml": (
+                '[[entry]]\ntemplate = "consulting.html"\n'
+                'schema = "schemas/consulting.schema.json"\nextends = "page"\n'
+            ),
+            "schemas/consulting.schema.json": (
+                '{\n  "$schema": "https://json-schema.org/draft/2020-12/schema",\n'
+                '  "$id": "https://ardent.tools/schemas/consulting.schema.json",\n'
+                '  "title": "consulting page",\n'
+                '  "allOf": [{"$ref": "https://github.com/forkwright/typikon/schemas/page.core.schema.json"}],\n'
+                '  "properties": {"extra": {\n'
+                '    "allOf": [{"$ref": "https://github.com/forkwright/typikon/schemas/page.core.schema.json#/properties/extra"}],\n'
+                '    "unevaluatedProperties": false,\n'
+                '    "properties": {"ardent": {"type": "object", "additionalProperties": false,\n'
+                '      "required": ["kanon_ci"], "properties": {"kanon_ci": {"type": "boolean"}}}}\n'
+                "  }},\n"
+                '  "unevaluatedProperties": false\n}\n'
+            ),
+            "content/approach/_index.md": (
+                '+++\ntitle = "Approach"\npage_template = "consulting.html"\n+++\nbody\n'
+            ),
+            "content/approach/method.md": (
+                '+++\ntitle = "Method"\n\n[extra.ardent]\nkanon_ci = true\n+++\nbody\n'
+            ),
+        },
+        0,
+        [],
+    ),
+]
+
+
+def run_section_a() -> list[str]:
+    failed = []
+    for label, files, expected_exit, required_substrings in CASES:
+        with tempfile.TemporaryDirectory(prefix="typikon-cascade-check-") as tmp:
+            root = Path(tmp)
+            write_tree(root, files)
+            result = run_validate(root)
+            if result.returncode != expected_exit:
+                failed.append(
+                    f"{label}: expected exit {expected_exit}, got {result.returncode}\n"
+                    f"  stdout: {result.stdout.strip()}\n  stderr: {result.stderr.strip()}"
+                )
+                continue
+            missing = [s for s in required_substrings if s not in result.stderr]
+            if missing:
+                failed.append(f"{label}: stderr missing expected substring(s) {missing}\n  stderr: {result.stderr.strip()}")
+    return failed
+
+
+# ── Section B: `_cascade_lookup` in isolation ──────────────────────────
+
+def run_section_b() -> list[str]:
+    failed = []
+    lookup = _tv._cascade_lookup
+
+    # nearest ancestor wins over a farther one that also sets page_template
+    cascade = {
+        Path("content"): "page.html",
+        Path("content/a"): "faq.html",
+        Path("content/a/b"): "sizing-guide.html",
+    }
+    got = lookup(Path("content/a/b"), cascade)
+    if got != "sizing-guide.html":
+        failed.append(f"nearest-wins: expected 'sizing-guide.html', got {got!r}")
+
+    # a directory with no cascade entry of its own is skipped, not treated as a stop
+    got = lookup(Path("content/a/b/c"), cascade)  # b/c has no entry; nearest SET ancestor is content/a/b
+    if got != "sizing-guide.html":
+        failed.append(f"skip-unset-directory-still-finds-nearest-SET-ancestor: expected 'sizing-guide.html', got {got!r}")
+
+    # only content/a set (b sets nothing): inherits from content/a
+    cascade2 = {Path("content"): "page.html", Path("content/a"): "faq.html"}
+    got = lookup(Path("content/a/b"), cascade2)
+    if got != "faq.html":
+        failed.append(f"inherit-past-non-setting-section: expected 'faq.html', got {got!r}")
+
+    # nothing set anywhere in the chain -> None, no exception walking past content/
+    got = lookup(Path("content/a/b"), {})
+    if got is not None:
+        failed.append(f"no-ancestor-sets-page_template: expected None, got {got!r}")
+
+    # root section itself (content/) is checked, not skipped
+    cascade3 = {Path("content"): "index.html"}
+    got = lookup(Path("content"), cascade3)
+    if got != "index.html":
+        failed.append(f"root-section-checked: expected 'index.html', got {got!r}")
+
+    return failed
+
+
+def main() -> int:
+    failed = run_section_a() + run_section_b()
+    if failed:
+        for line in failed:
+            print(f"FAIL: {line}", file=sys.stderr)
+        return 1
+    print(json.dumps({"checked": len(CASES) + 5, "passed": len(CASES) + 5, "failed": 0}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/check-page-template-cascade.py
+++ b/ci/check-page-template-cascade.py
@@ -84,7 +84,7 @@ VALIDATE = THEME_ROOT / "bin" / "typikon-validate"
 _loader = importlib.machinery.SourceFileLoader("typikon_validate_cascade", str(VALIDATE))
 _spec = importlib.util.spec_from_loader("typikon_validate_cascade", _loader)
 _tv = importlib.util.module_from_spec(_spec)
-sys.modules["typikon_validate_cascade"] = _tv  # dataclass() resolves types via sys.modules[__module__]
+sys.modules["typikon_validate_cascade"] = _tv  # WHY: dataclass() resolves types via sys.modules[__module__]
 _spec.loader.exec_module(_tv)
 
 
@@ -102,12 +102,12 @@ def run_validate(root: Path) -> subprocess.CompletedProcess:
     )
 
 
-# ── Section A: subprocess, full pipeline ───────────────────────────────
+# NOTE: ── Section A: subprocess, full pipeline ──────────────────────────
 
 # NOTE: each case is (label, files, expected_exit, required_stderr_substrings)
 CASES: list[tuple[str, dict[str, str], int, list[str]]] = [
     (
-        # REQUIRED NEGATIVE FIXTURE for #159. Pre-fix command + failure,
+        # WHY: REQUIRED NEGATIVE FIXTURE for #159. Pre-fix command + failure,
         # captured verbatim (git stash of the pre-fix bin/typikon-validate
         # run against this exact fixture):
         #   $ python3 bin/typikon-validate <this fixture>
@@ -156,7 +156,7 @@ CASES: list[tuple[str, dict[str, str], int, list[str]]] = [
             "content/guides/_index.md": (
                 '+++\ntitle = "Guides"\npage_template = "faq.html"\n+++\nbody\n'
             ),
-            # A nested section index: structurally a section (name ==
+            # WHY: A nested section index: structurally a section (name ==
             # "_index.md"), so it must classify via section.schema.json
             # regardless of the ancestor's page_template. If the cascade
             # wrongly applied here, this would be validated against
@@ -178,7 +178,7 @@ CASES: list[tuple[str, dict[str, str], int, list[str]]] = [
             "content/guides/sizing/_index.md": (
                 '+++\ntitle = "Sizing"\npage_template = "sizing-guide.html"\n+++\nbody\n'
             ),
-            # No template of its own; nearest ancestor (guides/sizing) sets
+            # WHY: No template of its own; nearest ancestor (guides/sizing) sets
             # page_template = sizing-guide.html — must NOT pick up the
             # farther content/guides/ ancestor's faq.html instead. A sizing
             # fixture validated as faq (extra.questions required) would
@@ -199,7 +199,7 @@ CASES: list[tuple[str, dict[str, str], int, list[str]]] = [
             "content/guides/_index.md": (
                 '+++\ntitle = "Guides"\npage_template = "faq.html"\n+++\nbody\n'
             ),
-            # sizing/_index.md sets no page_template at all — the walk
+            # WHY: sizing/_index.md sets no page_template at all — the walk
             # must skip past it (not stop / not treat "unset" as a match)
             # and keep going up to content/guides/, inheriting faq.html.
             "content/guides/sizing/_index.md": '+++\ntitle = "Sizing"\n+++\nbody\n',
@@ -214,7 +214,7 @@ CASES: list[tuple[str, dict[str, str], int, list[str]]] = [
     (
         "a malformed ancestor _index.md does not crash the run: its own error is reported once, and it contributes nothing to the cascade (sibling section unaffected)",
         {
-            "content/guides/_index.md": '+++\ntitle = "Guides"\npage_template = "faq.html\n+++\nbody\n',  # unterminated string — malformed TOML
+            "content/guides/_index.md": '+++\ntitle = "Guides"\npage_template = "faq.html\n+++\nbody\n',  # NOTE: unterminated string — malformed TOML
             "content/other/_index.md": '+++\ntitle = "Other"\n+++\nbody\n',
             "content/other/plain.md": '+++\ntitle = "Plain"\n+++\nbody\n',
         },
@@ -222,7 +222,7 @@ CASES: list[tuple[str, dict[str, str], int, list[str]]] = [
         ["content/guides/_index.md"],
     ),
     (
-        # WHY this case exists: Path.rglob's walk order is lexicographic
+        # WHY: Path.rglob's walk order is lexicographic
         # per path segment. "_index.md" (leading "_", 0x5F) sorts BELOW
         # any letter but ABOVE any ASCII digit (0x30-0x39), so a sibling
         # directory named "2026-faq" sorts, and so is visited, BEFORE its
@@ -248,7 +248,7 @@ CASES: list[tuple[str, dict[str, str], int, list[str]]] = [
         [],
     ),
     (
-        # A page_template value reaching the #60 CONSUMER REGISTRY, not
+        # WHY: A page_template value reaching the #60 CONSUMER REGISTRY, not
         # just the built-in TEMPLATE_SCHEMA_MAP — proves the cascade only
         # resolves an effective `template`; everything downstream
         # (registry_hit / fail-closed / MismatchedExtendsError) is the
@@ -305,13 +305,13 @@ def run_section_a() -> list[str]:
     return failed
 
 
-# ── Section B: `_cascade_lookup` in isolation ──────────────────────────
+# NOTE: ── Section B: `_cascade_lookup` in isolation ─────────────────────
 
 def run_section_b() -> list[str]:
     failed = []
     lookup = _tv._cascade_lookup
 
-    # nearest ancestor wins over a farther one that also sets page_template
+    # WHY: nearest ancestor wins over a farther one that also sets page_template
     cascade = {
         Path("content"): "page.html",
         Path("content/a"): "faq.html",
@@ -321,23 +321,23 @@ def run_section_b() -> list[str]:
     if got != "sizing-guide.html":
         failed.append(f"nearest-wins: expected 'sizing-guide.html', got {got!r}")
 
-    # a directory with no cascade entry of its own is skipped, not treated as a stop
-    got = lookup(Path("content/a/b/c"), cascade)  # b/c has no entry; nearest SET ancestor is content/a/b
+    # WHY: a directory with no cascade entry of its own is skipped, not treated as a stop
+    got = lookup(Path("content/a/b/c"), cascade)  # NOTE: b/c has no entry; nearest SET ancestor is content/a/b
     if got != "sizing-guide.html":
         failed.append(f"skip-unset-directory-still-finds-nearest-SET-ancestor: expected 'sizing-guide.html', got {got!r}")
 
-    # only content/a set (b sets nothing): inherits from content/a
+    # WHY: only content/a set (b sets nothing): inherits from content/a
     cascade2 = {Path("content"): "page.html", Path("content/a"): "faq.html"}
     got = lookup(Path("content/a/b"), cascade2)
     if got != "faq.html":
         failed.append(f"inherit-past-non-setting-section: expected 'faq.html', got {got!r}")
 
-    # nothing set anywhere in the chain -> None, no exception walking past content/
+    # WHY: nothing set anywhere in the chain -> None, no exception walking past content/
     got = lookup(Path("content/a/b"), {})
     if got is not None:
         failed.append(f"no-ancestor-sets-page_template: expected None, got {got!r}")
 
-    # root section itself (content/) is checked, not skipped
+    # WHY: root section itself (content/) is checked, not skipped
     cascade3 = {Path("content"): "index.html"}
     got = lookup(Path("content"), cascade3)
     if got != "index.html":

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -7,6 +7,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 python3 "$ROOT/ci/check-triad-schema.py"
 python3 "$ROOT/ci/check-consumer-schema-registry.py"
+python3 "$ROOT/ci/check-page-template-cascade.py"
 python3 "$ROOT/ci/check-font-coverage.py"
 python3 "$ROOT/ci/check-release-config.py"
 python3 "$ROOT/ci/check-asset-provenance.py"


### PR DESCRIPTION
## Finding

`bin/typikon-validate`'s `classify()` read only a file's own frontmatter `template` field. It did not simulate Zola's `page_template` cascade: a section's `_index.md` can set `page_template = "..."` and Zola applies that template to every descendant page that sets no `template` of its own — recursively through nested sections, with the nearest ancestor that sets one winning, and a page's own `template` always taking priority over any ancestor's. `classify()` had no notion of any of this and fell through to path-based classification instead.

Verified against Zola's own documentation before implementing (not guessed — the issue explicitly warns that a guessed precedence "produces a validator that is confidently wrong"). Fetched and grepped the raw HTML of https://www.getzola.org/documentation/content/section/ directly (not summarized secondhand) — the section docs read verbatim:

> "Template to use to render this section page. template = 'section.html' # The given template is applied to ALL pages below the section, recursively. # If you have several nested sections, each with a page_template set, the page # will always use the closest to itself. # However, a page's own `template` variable will always have priority."

## Evidence

- `bin/typikon-validate:183-238` (pre-fix, `origin/main`): `classify()` reads `frontmatter.get("template")` only — no ancestor walk, no `page_template` reference anywhere in the file.
- Reproduced the issue's own report directly against `origin/main`'s `bin/typikon-validate`, with an explicit `template = "journal-entry.html"` on the leaf (isolating the cascade question from the template's OWN reachability — see the follow-up issue below):
  ```
  $ python3 bin/typikon-validate <fixture: content/writing/_index.md sets page_template="journal-entry.html">
  {"file": "content/writing/foo.md", "schema": "page", "pointer": "/extra", "error": "Unevaluated properties are not allowed ('components', 'words' were unexpected)"}
  ```
- Fix: `bin/typikon-validate` — `build_page_template_cascade()` (new, pre-scans every `content/**/_index.md`), `_cascade_lookup()` (new, nearest-ancestor-wins walk), `classify()` (now resolves an effective `template` from the cascade when the page sets none — `bin/typikon-validate:311-313`), `main()` (builds the cascade once before the per-file walk — `bin/typikon-validate:619-622`).

## Why this matters

`page_template` is a first-class, documented field on `section.core.schema.json` — the validator shipped a schema that describes the cascade without implementing it. Any consumer using the pattern typikon's own theme ships as its canonical example (`examples/sample-blog/content/journal/_index.md:6` sets `page_template = "journal-entry.html"`, consumed per `templates/journal-entry.html:7`'s own setup comment: "content/journal/_index.md -- transparent + page_template default makes children inherit") for a NON-canonical section directory got silently wrong validation for every child page, and #154's closure of `page.schema.json`'s `extra` turned "silently wrong" into "silently broken" the moment a consumer bumps its submodule pin.

## Desired correction

`classify()` now resolves a file's effective template by walking up to the nearest ancestor `_index.md` that actually sets `page_template`, when the file sets no `template` of its own — mirroring Zola's cascade exactly, including a child's own `template` overriding it, and INCLUDING a nested section without its own `page_template` not breaking the inheritance chain from further up. The resolution is fed into the *existing* `TEMPLATE_SCHEMA_MAP` / registry / fail-closed pipeline unchanged, so a cascade-resolved template is indistinguishable from an explicitly-set one — this is the literal reading of the issue's "Done when."

`main()`'s file-walk ordering, not just `classify()`'s signature, changes: `build_page_template_cascade` is a full separate pre-pass over `content/**/_index.md`, run before any file is validated — see the code comment for why an incremental single-pass build would be wrong (`Path.rglob` sorts `_index.md` below any letter but ABOVE ascii digits, so a numerically-prefixed subdirectory would be visited before its own section's index file).

### Acceptance criteria (from #159)

**Done when:** *"a leaf page with no template of its own, under a section whose _index.md sets page_template, classifies (and validates) as if it had explicitly set that template — verified by a case in ci/check-consumer-schema-registry.py (or a new script) that fails on the un-fixed classifier and passes once the cascade is implemented."*

- Leaf page with no template, under a section setting `page_template`, classifies as if it had explicitly set it: `bin/typikon-validate:311-313` (`_cascade_lookup` result flows into the same `template` variable the explicit-frontmatter path uses). Verified by `ci/check-page-template-cascade.py` case 1 (REQUIRED negative fixture, see below) and case 8 (registry-routed template, not just `TEMPLATE_SCHEMA_MAP`).
- New script, since #159's own text scopes this "distinct from the #60 consumer registry": `ci/check-page-template-cascade.py` (new file), wired into `ci/run-fixtures.sh:10`.
- Fails on the un-fixed classifier, passes once implemented: verified directly — ran `ci/check-page-template-cascade.py`'s Section A against `origin/main`'s pre-fix `bin/typikon-validate`; 5 of 8 subprocess cases fail (the 3 that pass in both states are deliberate regression guards — own-template-wins, section-itself-unaffected, malformed-ancestor-doesn't-crash — not cascade-dependent). All 13 cases (8 subprocess + 5 unit) pass against the shipped fix.

One nuance stated plainly, not implied: "as if it had explicitly set that template" is an *equivalence* claim, not "always resolves to the intuitively-right schema." `TEMPLATE_SCHEMA_MAP` has no entry for `journal-entry.html` — that's true whether the template arrives by cascade or by explicit frontmatter, both before and after this fix (verified above, and unchanged by this PR). Making `journal-entry.html`-templated content off the canonical `content/journal/` path fully green requires that *and* extending `journal-entry.schema.json`'s `extra` with fields (`figure`, `figure_alt`, `tier`) it doesn't recognize yet — two separate, narrower gaps, filed as forkwright/typikon#163 rather than folded in here (mixing "cascade resolution" with "template-map completeness" would have made this PR's own negative fixture untestable against a template with well-defined explicit-set behavior, and #159's text explicitly scopes registry/routing completeness out).

## Negative fixture

Negative fixture: `ci/check-page-template-cascade.py` (case 1, "leaf page with no template, under a section with page_template=faq.html, cascades to faq.schema.json") — watched failing by `python3 bin/typikon-validate <tmpdir>` against the pre-fix `bin/typikon-validate` (`git show origin/main:bin/typikon-validate`, run from a `bin/` + `schemas/` shim so `THEME_ROOT` resolves correctly), which produced:
```
{"file": "content/guides/shipping.md", "schema": "page", "pointer": "/extra", "error": "Unevaluated properties are not allowed ('questions' was unexpected)"}
{"checked": 2, "passed": 1, "failed": 1}
exit=1
```
before the fix, and `{"checked": 2, "passed": 2, "failed": 0}` / exit 0 after. `questions` is `faq.schema.json`'s own required field — `page.schema.json`'s `extra` has never heard of it, which is exactly the "confidently wrong schema" the issue reports. Also stress-tested the walk's own arithmetic (Section B, `_cascade_lookup` in isolation): deliberately broke it to skip the immediate ancestor (an off-by-one in the exact shape the issue warns about — "guessing the precedence produces a validator that is confidently wrong") and confirmed 2 of 5 unit assertions catch it (`nearest-wins`, `root-section-checked`); reverted before committing.

## Verification run locally

`kanon lint bin/typikon-validate --precision low` / `kanon lint ci/check-page-template-cascade.py --precision low`: clean, 0 findings (both exit 0). `python3 ci/check-consumer-schema-registry.py` (15/15) and `python3 ci/check-triad-schema.py` (4/4): unaffected, no regressions. Real fixture corpora unaffected: `bin/typikon-validate examples/sample-blog` (5/5) and `examples/sample-shop` (9/9) both still pass clean. Full `ci/run-fixtures.sh` run locally (zola/lychee present locally): every stage passes including `zola-build`, `csp-enforce`, `asset-provenance`, `lychee`, `playwright-smoke`, `playwright-coverage`; the only failure is `pa11y` (`pa11y-ci not on PATH`), a pre-existing local-environment gap unrelated to this diff (no templates/CSS/HTML touched) — CI has it installed and will grade it for real.

Closes #159

## Review round 2 (addressed)

- **Comment tags** (`ci/check-page-template-cascade.py`): every explanatory comment block now leads with `WHY:` or `NOTE:`, matching the sibling scripts' convention (`ci/check-triad-schema.py`, `ci/check-consumer-schema-registry.py`) — no freeform comments remain. `python3 ci/check-page-template-cascade.py` still reports `{"checked": 13, "passed": 13, "failed": 0}` after the edit (comment-only change, no logic touched).
- **`docs/AGENTIC.md` citation** ("Why this matters", above): corrected. That file has zero occurrences of `page_template` — it was a wrong citation carried over from #159's own text without re-verification. The real canonical example is `examples/sample-blog/content/journal/_index.md:6` + `templates/journal-entry.html:7`, now cited directly. The underlying cascade-precedence claim itself (nearest-set-ancestor wins, own `template` always wins, applies to descendant pages not the section's own `_index.md`) was independently re-verified against a fresh fetch of https://www.getzola.org/documentation/content/section/ and against the shipped implementation (`_cascade_lookup`/`build_page_template_cascade`/`classify` in `bin/typikon-validate:196-313`) — unchanged and accurate.

