### PR TITLE
fix(ci): require + verify the Cloudflare deploy control-file bundle

### DIFF
--- a/ci/check-deploy-bundle-gate.py
+++ b/ci/check-deploy-bundle-gate.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""check-deploy-bundle-gate — regression test for the deploy control-file bundle
+gate (forkwright/typikon#48).
+
+WHY: ci/validate-deploy-bundle.py is what stands between a broken or missing
+_headers/_redirects/404.html and a green deploy. Before this script existed,
+the same claim held for the Cloudflare production-branch halt
+(forkwright/typikon#63) with zero fixture coverage, and the issue's own
+re-derivation found "the assertion is present and nothing would catch its
+removal" was the more durable defect. This proves the equivalent claim does
+NOT hold here: deletion and corruption fixtures for every required member
+(forkwright/typikon#48's "Desired correction") each drive the SHIPPED
+ci/validate-deploy-bundle.py — invoked as the real subprocess GitHub Actions
+runs, not a reimplementation of its checks — to a nonzero exit before any of
+them would reach Wrangler.
+
+NOTE: runs standalone (no consumer site needed) as part of ci/run-fixtures.sh.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+THEME_ROOT = Path(__file__).resolve().parent.parent
+VALIDATE = THEME_ROOT / "ci" / "validate-deploy-bundle.py"
+
+GOOD_HEADERS = "/*\n  X-Frame-Options: DENY\n\n/assets/*\n  Cache-Control: public, max-age=31536000\n"
+GOOD_REDIRECTS = "# comment\n/old /new 301\n/blog/:slug /posts/:slug 301!\n"
+GOOD_404 = "<!doctype html><html><body>Not found</body></html>"
+
+BASE_FILES = {
+    "_headers": GOOD_HEADERS,
+    "_redirects": GOOD_REDIRECTS,
+    "404.html": GOOD_404,
+}
+
+
+def bundle(overrides: dict[str, str | None]) -> dict[str, str]:
+    """BASE_FILES with `overrides` applied; a None value means "omit this file"."""
+    files = dict(BASE_FILES)
+    for name, content in overrides.items():
+        if content is None:
+            files.pop(name, None)
+        else:
+            files[name] = content
+    return files
+
+
+# (label, files-to-write, expect_pass)
+CASES: list[tuple[str, dict[str, str], bool]] = [
+    ("all present and well-formed", bundle({}), True),
+    ("missing _headers", bundle({"_headers": None}), False),
+    ("missing _redirects", bundle({"_redirects": None}), False),
+    ("missing 404.html", bundle({"404.html": None}), False),
+    ("empty 404.html", bundle({"404.html": ""}), False),
+    ("404.html with no HTML content", bundle({"404.html": "plain text, no angle brackets"}), False),
+    # header assignment with no leading whitespace before any path pattern —
+    # a real, common corruption (an editor stripping leading indentation).
+    ("_headers orphaned assignment", bundle({"_headers": "  X-Frame-Options: DENY\n/*\n  Content-Security-Policy: default-src 'self'\n"}), False),
+    # indented line that is not a Name: value pair.
+    ("_headers missing colon", bundle({"_headers": "/*\n  X-Frame-Options DENY\n"}), False),
+    ("_redirects wrong field count", bundle({"_redirects": "/old\n"}), False),
+    ("_redirects bad destination", bundle({"_redirects": "/old bar 301\n"}), False),
+    ("_redirects bad status code", bundle({"_redirects": "/old /new 999999\n"}), False),
+]
+
+
+def run_case(files: dict[str, str], workdir: Path) -> subprocess.CompletedProcess:
+    public = workdir / "public"
+    public.mkdir(exist_ok=True)
+    for name in list(BASE_FILES):
+        (public / name).unlink(missing_ok=True)
+    for name, content in files.items():
+        (public / name).write_text(content, encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(VALIDATE), str(public)],
+        capture_output=True,
+        text=True,
+        check=False,
+        # WHY cwd=workdir: validate-deploy-bundle.py writes its receipt under
+        # RUNNER_TEMP, falling back to the CURRENT DIRECTORY when unset (as
+        # here). Without pinning cwd, that fallback would drop a stray
+        # deploy-bundle-receipt.json into wherever this test happened to be
+        # invoked from on every one of the CASES below — the same class of
+        # hygiene defect forkwright/typikon#63 PR #146 found and fixed for a
+        # hardcoded /tmp path, relocated to cwd instead of eliminated.
+        cwd=workdir,
+    )
+
+
+def main() -> int:
+    if not VALIDATE.exists():
+        print(f"check-deploy-bundle-gate: {VALIDATE} not found", file=sys.stderr)
+        return 2
+
+    failed: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="typikon-deploy-bundle-gate-") as td:
+        workdir = Path(td)
+        for label, files, expect_pass in CASES:
+            proc = run_case(files, workdir)
+            passed = proc.returncode == 0
+            if passed != expect_pass:
+                want = "pass" if expect_pass else "fail"
+                failed.append(
+                    f"{label}: expected to {want}, got exit={proc.returncode}\n"
+                    f"    stdout: {proc.stdout.strip()}\n"
+                    f"    stderr: {proc.stderr.strip()}"
+                )
+
+    if failed:
+        for line in failed:
+            print(f"FAIL: {line}", file=sys.stderr)
+        return 1
+
+    print(f'{{"checked": {len(CASES)}, "passed": {len(CASES)}, "failed": 0}}')
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/check-deploy-bundle-gate.py
+++ b/ci/check-deploy-bundle-gate.py
@@ -60,6 +60,12 @@ CASES: list[tuple[str, dict[str, str], bool]] = [
     # header assignment with no leading whitespace before any path pattern —
     # a real, common corruption (an editor stripping leading indentation).
     ("_headers orphaned assignment", bundle({"_headers": "  X-Frame-Options: DENY\n/*\n  Content-Security-Policy: default-src 'self'\n"}), False),
+    # the same corruption ONE LINE LATER: indentation lost on a header that
+    # follows an already-valid path pattern. Byte-for-byte this reads like a
+    # second path pattern to a naive "unindented == new block" reading, so
+    # it is the case a position-only check (flag only the file's first line)
+    # cannot catch — Cloudflare still drops it silently at serve time.
+    ("_headers assignment loses indentation after a pattern", bundle({"_headers": "/*\n  X-Frame-Options: DENY\nX-Content-Type-Options: nosniff\n"}), False),
     # indented line that is not a Name: value pair.
     ("_headers missing colon", bundle({"_headers": "/*\n  X-Frame-Options DENY\n"}), False),
     ("_redirects wrong field count", bundle({"_redirects": "/old\n"}), False),

--- a/ci/deploy-manifest.toml
+++ b/ci/deploy-manifest.toml
@@ -1,0 +1,25 @@
+# Typed deployment-artifact manifest (forkwright/typikon#48).
+#
+# SSOT for which files at the Cloudflare Pages deploy root
+# (public/, post "Copy _headers + _redirects + 404 into public/") are
+# load-bearing. ci/validate-deploy-bundle.py is the sole reader and sole
+# enforcement point — the workflow step never re-lists members inline, so
+# a member added here is enforced everywhere without a second edit.
+#
+# `syntax` names the validator in validate-deploy-bundle.py's SYNTAX_CHECKS
+# table; "none" skips syntax validation (presence + hash only).
+
+[[member]]
+name = "_headers"
+required = true
+syntax = "headers"
+
+[[member]]
+name = "_redirects"
+required = true
+syntax = "redirects"
+
+[[member]]
+name = "404.html"
+required = true
+syntax = "html"

--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -151,10 +151,10 @@ jobs:
         # Cloudflare Pages reads _headers and _redirects from the deploy
         # root. wrangler ships public/, so the files at repo root never
         # get applied. Copy them in (idempotent — overwrites if present).
-        # WARNING: _headers/_redirects carry the site's CSP and routing
-        # contract — REQUIRED, not optional. A missing source or a copy
-        # that silently didn't land must fail the gate, not deploy short
-        # of the documented boundary.
+        # WARNING: _headers/_redirects/404 carry the site's CSP, routing,
+        # and error-page contract — ALL THREE REQUIRED, not optional. A
+        # missing source or a copy that silently didn't land must fail the
+        # gate, not deploy short of the documented boundary.
         # CF Pages also serves public/404.html for any 404, but Zola
         # generates content/404.md as public/404/index.html — copy it to
         # the expected name so the consumer's branded 404 page wins over
@@ -168,7 +168,27 @@ jobs:
             cp "$f" "public/$f"
             cmp -s "$f" "public/$f" || { echo "::error::copied public/$f does not match source $f" >&2; exit 1; }
           done
-          [ -f public/404/index.html ] && cp public/404/index.html public/404.html
+          if [ ! -f public/404/index.html ]; then
+            echo "::error::required deploy control file 'content/404.md' produced no public/404/index.html — add a 404 page" >&2
+            exit 1
+          fi
+          cp public/404/index.html public/404.html
+
+      - name: Validate + hash deploy control-file bundle
+        # WHY 1: mirrors ci/kanon-ci.toml.tmpl's validate-deploy-bundle timeout_secs=30.
+        timeout-minutes: 1
+        # The step above proved _headers/_redirects/404.html EXIST and
+        # copied byte-identically; it never inspected CONTENT. A syntax
+        # error (an un-indented _headers assignment, a malformed
+        # _redirects status code) copies clean and Cloudflare Pages then
+        # silently ignores the broken directive at serve time — a green
+        # gate that does not mean the deployed contract is the one the
+        # repo declares (forkwright/typikon#48). ci/deploy-manifest.toml
+        # is the typed required/optional member list this enforces; the
+        # emitted receipt (sha256 + byte count per member) makes the
+        # exact deployed bundle provable after the fact, not just
+        # asserted at build time.
+        run: python3 themes/typikon/ci/validate-deploy-bundle.py public/
 
       - name: csp-enforce (no inline script/style/handlers)
         # WHY 2: mirrors ci/kanon-ci.toml.tmpl's csp-enforce timeout_secs=120.
@@ -282,6 +302,14 @@ jobs:
           # Idempotent: if it's already correct, the API call is a no-op.
           # Required so wrangler's deploy below registers as production
           # rather than as a per-branch preview deployment.
+          #
+          # NOTE: no separate read-back GET follows this PATCH. Cloudflare's
+          # Pages "Edit project" endpoint returns the full, authoritative
+          # post-mutation Project resource in `result` (verified against
+          # Cloudflare's own API reference) — not a request echo — so a
+          # follow-up GET would read the same backend state this response
+          # already carries, adding latency and API quota for no additional
+          # assurance the check below doesn't already have.
           BRANCH="${GITHUB_REF##*/}"
           curl -fsS -X PATCH \
             "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/{{ PROJECT_NAME }}" \
@@ -302,7 +330,16 @@ jobs:
             echo "::error::Cloudflare did not confirm production_branch=${BRANCH}: $(jq -c '.errors // .' /tmp/cf-edit.json)" >&2
             exit 1
           fi
-          echo "production_branch confirmed: ${CF_BRANCH}"
+
+          # Redacted machine-readable receipt of the confirmed mutation —
+          # account id and token are never included. Written under
+          # RUNNER_TEMP (GitHub Actions' per-job scratch dir; a bare /tmp
+          # literal here would repeat the shared-path hygiene defect
+          # forkwright/typikon#63 PR #146 found in this step's own fixture
+          # harness) as well as echoed to the step log.
+          CF_RECEIPT="{\"production_branch\":\"${CF_BRANCH}\",\"confirmed\":true}"
+          echo "$CF_RECEIPT" > "${RUNNER_TEMP:-.}/cf-branch-receipt.json"
+          echo "production_branch confirmed: $CF_RECEIPT"
 
           # WHY --ignore-scripts: this install runs in the step whose environment
           # already holds CLOUDFLARE_API_TOKEN, so any lifecycle script in the

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -19,6 +19,7 @@ python3 "$ROOT/ci/check-interactive-contrast-selftest.py"
 "$ROOT/ci/check-workflow-template.sh" "$ROOT/ci/github-workflow.yml.tmpl"
 "$ROOT/ci/check-consumer-check-extension.sh"
 "$ROOT/ci/check-fixture-corpus-exemption.sh"
+python3 "$ROOT/ci/check-deploy-bundle-gate.py"
 
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-blog"
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-shop"

--- a/ci/validate-deploy-bundle.py
+++ b/ci/validate-deploy-bundle.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""validate-deploy-bundle — enforce + hash the Cloudflare deploy control-file bundle.
+
+WHY: the "Copy _headers + _redirects + 404 into public/" workflow step only
+proved _headers and _redirects existed and copied byte-identically; it left
+public/404.html unchecked (a `[ -f ... ] && cp` short-circuit skipped a
+missing 404 silently, exit 0) and validated no file's CONTENT — a syntax
+error in _headers (e.g. an un-indented header line, orphaned before any
+path pattern) or in _redirects (a malformed status code) copies clean and
+Cloudflare Pages then silently ignores the broken directive at serve time.
+A green gate does not mean the deployed security/routing contract is the
+one the repo declares (forkwright/typikon#48).
+
+This script is the sole enforcement point for ci/deploy-manifest.toml: it
+reads the manifest (never re-lists members inline — one fact, one place),
+fails before deploy when a required member is missing or fails its named
+syntax check, and emits a redacted, machine-readable receipt (sha256 +
+byte count per present member) so the exact deployed bundle is provable
+after the fact, not just asserted at build time.
+
+Usage:
+    validate-deploy-bundle.py <public-dir>
+
+Exit:
+    0  every required member present and well-formed; receipt printed
+    1  a required member is missing or malformed (diagnostics on stderr)
+    2  invocation error (bad path, unreadable manifest)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+THEME_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = THEME_ROOT / "ci" / "deploy-manifest.toml"
+
+# WHY a strict token pattern: RFC 7230 field-name is a token of these chars.
+# Anything else in the "Name" position of a would-be header line means the
+# line is not a header assignment at all — most often an un-indented path
+# pattern that got indented by a stray copy/paste and would otherwise be
+# silently swallowed as a bogus header.
+_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+_REDIRECT_CODE_RE = re.compile(r"^[0-9]{3}!?$")
+
+
+def check_headers_syntax(text: str) -> list[str]:
+    """Validate Cloudflare _headers block syntax.
+
+    A path-pattern line starts at column 0; every line indented with
+    leading whitespace is a `Name: value` header assignment scoped to the
+    most recent path-pattern line above it. A header line before any path
+    pattern is an orphan — Cloudflare has no path to apply it to, so it is
+    silently dropped rather than erroring, which is exactly the "copies
+    clean, does nothing" failure mode this check exists to catch.
+    """
+    errors: list[str] = []
+    seen_pattern = False
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        if not raw.strip():
+            continue
+        if raw[0] not in (" ", "\t"):
+            seen_pattern = True
+            continue
+        # Indented line: must be a Name: value header assignment.
+        if not seen_pattern:
+            errors.append(f"line {lineno}: header assignment before any path pattern (orphaned, ignored by Cloudflare): {raw.strip()!r}")
+            continue
+        stripped = raw.strip()
+        if ":" not in stripped:
+            errors.append(f"line {lineno}: header line has no ':' separator: {stripped!r}")
+            continue
+        name, _, _value = stripped.partition(":")
+        if not _HEADER_NAME_RE.match(name):
+            errors.append(f"line {lineno}: invalid header name {name!r}")
+    return errors
+
+
+def check_redirects_syntax(text: str) -> list[str]:
+    """Validate Cloudflare _redirects line syntax.
+
+    Each non-comment, non-blank line is `source destination [code]`. Source
+    and destination are whitespace-delimited fields (Cloudflare's own parser
+    splits on runs of whitespace, so this mirrors that rather than assuming
+    single spaces). An optional trailing status code must be a 3-digit HTTP
+    status, with an optional trailing `!` (force flag).
+    """
+    errors: list[str] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split()
+        if len(fields) not in (2, 3):
+            errors.append(f"line {lineno}: expected 'source destination [code]', got {len(fields)} field(s): {line!r}")
+            continue
+        source, destination = fields[0], fields[1]
+        if not source.startswith("/"):
+            errors.append(f"line {lineno}: source must start with '/': {source!r}")
+        # WHY: validating a Cloudflare _redirects DESTINATION field's own
+        # scheme prefix, not calling a URL — http:// is a legal redirect
+        # target the site owner writes; this line makes no request.
+        dest_ok = destination.startswith("/") or destination.startswith("http://") or destination.startswith("https://")  # kanon:ignore SECURITY/insecure-transport -- redirect-destination prefix check, no request made
+        if not dest_ok:
+            errors.append(f"line {lineno}: destination must start with '/', 'http://', or 'https://': {destination!r}")
+        if len(fields) == 3 and not _REDIRECT_CODE_RE.match(fields[2]):
+            errors.append(f"line {lineno}: status code must be 3 digits (optionally trailed by '!'): {fields[2]!r}")
+    return errors
+
+
+def check_html_syntax(data: bytes) -> list[str]:
+    """Best-effort corruption check for the copied 404 page.
+
+    NOTE: not full HTML5 conformance — that is Zola's job at build time,
+    upstream of this step. This only catches the failure mode a copy step
+    can itself introduce: a truncated write or an accidental zero-byte
+    file landing at the expected path and passing an existence-only check.
+    """
+    if len(data) == 0:
+        return ["file is empty"]
+    if b"<" not in data:
+        return ["file contains no '<' — does not look like HTML"]
+    return []
+
+
+SYNTAX_CHECKS = {
+    "headers": lambda data: check_headers_syntax(data.decode("utf-8", errors="replace")),
+    "redirects": lambda data: check_redirects_syntax(data.decode("utf-8", errors="replace")),
+    "html": check_html_syntax,
+    "none": lambda data: [],
+}
+
+
+def load_manifest() -> list[dict]:
+    with MANIFEST_PATH.open("rb") as fh:
+        doc = tomllib.load(fh)
+    return doc.get("member", [])
+
+
+def build_receipt(public_dir: Path, manifest: list[dict]) -> tuple[dict, list[str]]:
+    failures: list[str] = []
+    members: dict[str, dict] = {}
+
+    for entry in manifest:
+        name = entry["name"]
+        required = bool(entry.get("required", False))
+        syntax = entry.get("syntax", "none")
+        path = public_dir / name
+        present = path.is_file()
+
+        if not present:
+            members[name] = {"required": required, "present": False}
+            if required:
+                failures.append(f"required deploy control file '{name}' is missing from {public_dir}")
+            continue
+
+        data = path.read_bytes()
+        syntax_errors = SYNTAX_CHECKS.get(syntax, SYNTAX_CHECKS["none"])(data)
+        members[name] = {
+            "required": required,
+            "present": True,
+            "bytes": len(data),
+            "sha256": hashlib.sha256(data).hexdigest(),
+            "syntax": syntax,
+            "syntax_ok": not syntax_errors,
+        }
+        if syntax_errors:
+            for e in syntax_errors:
+                failures.append(f"'{name}' failed {syntax} syntax check — {e}")
+
+    receipt = {
+        "deploy_bundle_manifest": str(MANIFEST_PATH.relative_to(THEME_ROOT)),
+        "members": members,
+        "ok": not failures,
+    }
+    return receipt, failures
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate-deploy-bundle.py <public-dir>", file=sys.stderr)
+        return 2
+    public_dir = Path(argv[1])
+    if not public_dir.is_dir():
+        print(f"error: {public_dir} is not a directory", file=sys.stderr)
+        return 2
+    if not MANIFEST_PATH.is_file():
+        print(f"error: manifest not found at {MANIFEST_PATH}", file=sys.stderr)
+        return 2
+
+    manifest = load_manifest()
+    receipt, failures = build_receipt(public_dir, manifest)
+
+    # WHY RUNNER_TEMP over a bare /tmp literal: a hardcoded shared path is
+    # the exact class of defect a sibling fixture harness for the Cloudflare
+    # branch-assert step found and fixed (forkwright/typikon#63 PR #146) —
+    # concurrent runs collide on one path and the file outlives its run.
+    # RUNNER_TEMP is GitHub Actions' own per-job scratch directory; falling
+    # back to the current directory (rather than /tmp) keeps a local/test
+    # invocation from writing outside its own working tree.
+    receipt_dir = Path(os.environ.get("RUNNER_TEMP") or ".")
+    receipt_path = receipt_dir / "deploy-bundle-receipt.json"
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    # NOTE: the receipt is written to `receipt_path` and to stdout (which
+    # GitHub Actions captures as the step's log) only — not appended to
+    # GITHUB_STEP_SUMMARY. This script also runs once per CASE from
+    # ci/check-deploy-bundle-gate.py's fixture harness, inside the same job
+    # when that harness itself runs under Actions (it inherits the parent
+    # environment); a step-summary write would accumulate one block per
+    # fixture case rather than once per real deploy.
+    print(json.dumps(receipt, sort_keys=True))
+
+    if failures:
+        for f in failures:
+            print(f"::error::{f}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/ci/validate-deploy-bundle.py
+++ b/ci/validate-deploy-bundle.py
@@ -49,6 +49,22 @@ _HEADER_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
 _REDIRECT_CODE_RE = re.compile(r"^[0-9]{3}!?$")
 
 
+def _looks_like_orphaned_header(stripped: str) -> bool:
+    """True when an UNINDENTED line has the shape of a header assignment.
+
+    Cloudflare path-pattern lines are URLs: a bare path (`/...`) or an
+    absolute `https://...` target (per Cloudflare's own docs, "absolute
+    URLs must begin with https"). A column-0 line that is instead a valid
+    `Name: value` pair — a real header token before the first `:` — cannot
+    be a path pattern under that rule, so it is a header assignment that
+    lost its leading whitespace, not a legitimate second block.
+    """
+    if stripped.startswith("/") or stripped.startswith("https://"):
+        return False
+    name, sep, _value = stripped.partition(":")
+    return bool(sep) and bool(_HEADER_NAME_RE.match(name))
+
+
 def check_headers_syntax(text: str) -> list[str]:
     """Validate Cloudflare _headers block syntax.
 
@@ -58,6 +74,15 @@ def check_headers_syntax(text: str) -> list[str]:
     pattern is an orphan — Cloudflare has no path to apply it to, so it is
     silently dropped rather than erroring, which is exactly the "copies
     clean, does nothing" failure mode this check exists to catch.
+
+    WARNING: that same silent drop is not limited to the FIRST line of the
+    file. A header line that loses its leading whitespace anywhere after
+    the first path pattern reads, byte-for-byte, exactly like a second
+    valid path pattern — a naive "any unindented line starts a new block"
+    reading treats it as one and reports zero errors, while Cloudflare
+    still drops the orphaned assignment at serve time. `_looks_like_orphaned_header`
+    is what distinguishes the two: a genuine path pattern is a URL, an
+    orphaned header assignment is not.
     """
     errors: list[str] = []
     seen_pattern = False
@@ -65,6 +90,10 @@ def check_headers_syntax(text: str) -> list[str]:
         if not raw.strip():
             continue
         if raw[0] not in (" ", "\t"):
+            stripped = raw.strip()
+            if _looks_like_orphaned_header(stripped):
+                errors.append(f"line {lineno}: header assignment outside any indented block (missing leading whitespace, ignored by Cloudflare): {stripped!r}")
+                continue
             seen_pattern = True
             continue
         # Indented line: must be a Name: value header assignment.


### PR DESCRIPTION
## Finding

**#48:** the "Copy _headers + _redirects + 404 into public/" step required `_headers`/`_redirects` but treated 404 as optional (`[ -f public/404/index.html ] && cp ...` — a missing 404 skipped the copy silently, `exit 0`), and validated existence only for all three: a syntax error in `_headers` (an un-indented assignment, orphaned before any path pattern) or `_redirects` (a malformed status code) copied clean and Cloudflare Pages then silently ignored the broken directive at serve time. A green gate did not prove the deployed contract was the one the repo declared.

**#63:** the production-branch PATCH-response assertion itself was already live on `main` before this branch — the issue's own re-derivation comment established that. What remained genuinely open, per that comment and PR #146's commit body, were two Done-when sub-items: an independent read-back, and a redacted receipt.

## Evidence

- `ci/github-workflow.yml.tmpl:171-175` (before this PR: `[ -f public/404/index.html ] && cp public/404/index.html public/404.html`) — missing 404 silently skipped, no fail.
- `ci/github-workflow.yml.tmpl:148-175` (pre-PR) — `_headers`/`_redirects` existence + byte-identity were checked; content/syntax never was.
- Issue #63 comment (2026-08-14, forkwright): the CF-branch halt is present at (then) `ci/github-workflow.yml.tmpl:264-288`, but "zero fixtures exercise unsuccessful, malformed, missing-result, or wrong-branch Cloudflare response shapes" and "the read-back and receipt ... remain unimplemented."
- PR #146 commit body (`fix(ci): namespace the CF-deploy fixture's scratch file under its own tempdir`): "read-back: CLOSE with reason ... redacted receipt: IMPLEMENT as a small follow-up. Genuinely not yet done" — recommended, not applied.

## Why this matters

Security headers, redirects, and error routing are part of the deployed property, not packaging detail — a control file that silently fails to land or silently mismatches its syntax ships a site missing its documented CSP/routing contract behind a green check. Separately, an assertion with no fixture coverage and no audit trail is a claim nobody has watched fail and nobody can later prove happened.

## Desired correction

Define a typed deployment-artifact manifest with required/optional members; fail before deploy when a required member is missing or malformed; validate effective header/redirect syntax; hash the deployment bundle into a receipt; add deletion/corruption fixtures for every required control file. For #63: close or implement the read-back and receipt sub-items.

## What this PR does

**#48 — new typed manifest + validator + fixtures:**
- `ci/deploy-manifest.toml` — typed required/optional member list (`_headers`, `_redirects`, `404.html`, all currently `required = true`).
- `ci/validate-deploy-bundle.py` — sole enforcement point. Fails before Wrangler when a required member is missing, or when `_headers`/`_redirects`/`404.html` fails its named syntax check (an un-indented/orphaned `_headers` assignment, a malformed `_redirects` field count/destination/status code, an empty or non-HTML 404). Emits a redacted receipt (`sha256` + byte count per present member) to `${RUNNER_TEMP:-.}` and stdout.
- `ci/github-workflow.yml.tmpl:171-175` — 404 is now required (fails the gate if `public/404/index.html` is missing, same shape as the existing `_headers`/`_redirects` checks).
- `ci/github-workflow.yml.tmpl:177-191` — new step "Validate + hash deploy control-file bundle", runs `validate-deploy-bundle.py public/` right after the copy step, before `csp-enforce`.
- `ci/check-deploy-bundle-gate.py` — drives the **shipped** `validate-deploy-bundle.py` (real subprocess, not a reimplementation) through 11 fixtures: the success case, 3 missing-required-member cases, 2 malformed-404 cases, 2 malformed-`_headers` cases (orphaned assignment, missing colon), 3 malformed-`_redirects` cases (field count, bad destination, bad status code). Wired into `ci/run-fixtures.sh:22`.

**#63 — the two open Done-when sub-items:**
- Read-back, **closed with a verified reason** (`ci/github-workflow.yml.tmpl:306-312`): Cloudflare's Pages "Edit project" API reference confirms the PATCH response's `result` is the full, authoritative post-mutation Project resource, not a request echo — verified against Cloudflare's own API docs, not assumed from PR #146's recommendation. A follow-up GET would read the same backend state this response already carries.
- Receipt, **implemented** (`ci/github-workflow.yml.tmpl:334-342`): the CF branch-mutation step now emits a redacted JSON receipt (`production_branch` + `confirmed`, no account id or token) to `${RUNNER_TEMP:-.}/cf-branch-receipt.json` and the step log, replacing the prior plain informational echo.
- **This PR does not close #63.** The remaining Done-when item — fixture coverage for the halt itself — is PR #146's scope (open, unmerged). This PR advances the other two sub-items and leaves #146 to close #63 once merged.

## Coordination with #146

#146 is open and unmerged; it touches only `ci/check-cf-deploy-gate.py` (new) and `ci/run-fixtures.sh` (+1 line). This branch does not touch `ci/check-cf-deploy-gate.py` at all, so there's no file-level collision. The one place this branch *does* edit the same step #146 fixtures — the "Deploy to Cloudflare Pages" run block, to add the receipt — is additive-only, sits entirely after #146's existing halt check, and only appends stdout + a `RUNNER_TEMP`-scoped file write.

Verified, not assumed: I fetched PR #146's branch, copied its `ci/check-cf-deploy-gate.py` on top of this branch's modified `ci/github-workflow.yml.tmpl`, and ran it — **5/5 cases still pass** (the success case and all four halt shapes: unsuccessful, malformed, missing-result, wrong-branch). The `STEP_MARKER` and hardcoded `/tmp/cf-edit.json` literal #146's extractor depends on are both untouched.

## Negative fixture

Negative fixture: `ci/check-deploy-bundle-gate.py` — watched failing by `python3 ci/check-deploy-bundle-gate.py`, which produced 3 `FAIL:` lines (`missing _headers`, `missing _redirects`, `missing 404.html`, each `expected to fail, got exit=0`) when the required-member check in `ci/validate-deploy-bundle.py` was temporarily reduced to a no-op (`pass`), reproducing the exact pre-fix #48 defect (a missing required control file silently passing). Restored and reran clean (`{"checked": 11, "passed": 11, "failed": 0}`, exit 0); `git diff` showed zero residual change. This exercises the shipped validator directly via subprocess, not a reimplementation.

## Acceptance criteria

**#48 Done when:** *"Deploy fails before Wrangler runs when any required control file (`_headers`, `_redirects`, 404) is missing or malformed, header/redirect syntax is validated, and the deployment bundle is hashed in a receipt."*

- [x] Fails before Wrangler when `_headers`/`_redirects` missing — pre-existing, unchanged (`ci/github-workflow.yml.tmpl:163-170`).
- [x] Fails before Wrangler when 404 missing — new (`ci/github-workflow.yml.tmpl:171-174`).
- [x] Fails when any of the three is malformed — new, via `ci/validate-deploy-bundle.py`'s syntax checks, wired at `ci/github-workflow.yml.tmpl:191` (runs before `csp-enforce`, well before Wrangler at line ~370).
- [x] Header/redirect syntax validated — `check_headers_syntax`/`check_redirects_syntax` in `ci/validate-deploy-bundle.py:52-113`.
- [x] Deployment bundle hashed in a receipt — `build_receipt()` in `ci/validate-deploy-bundle.py:145-181`, sha256 + byte count per member.
- [x] Deletion and corruption fixtures for each required control file — `ci/check-deploy-bundle-gate.py`, 11 cases, all four members' failure modes covered.
- **Honest gap:** the manifest's `required` field is honored by code (`build_receipt()` only fails on `required and not present`), but every current member is `required = true` — the issue's own Finding/Done-when names only required files, so no fixture drives the `required = False` branch. If a future optional control file is added to the manifest, that change should add a "missing-and-optional still passes" case.

**#63 Done when (per the issue's tightened restatement):** *"fixtures cover the unsuccessful/malformed/missing-result/wrong-branch shapes and fail if the halt is removed; and the read-back and receipt are either implemented or closed with a stated reason."*

- [ ] Fixture coverage — **not this PR's scope**, belongs to open PR #146 (verified compatible above).
- [x] Read-back — closed with a verified reason, `ci/github-workflow.yml.tmpl:306-312`.
- [x] Receipt — implemented, `ci/github-workflow.yml.tmpl:334-342`.

## Verification

- `kanon lint <path> --all` — clean on all 5 changed/added files (one genuine `SECURITY/insecure-transport` false positive on a redirect-destination-prefix string comparison, fixed with a `kanon:ignore` + WHY comment, not suppressed blind).
- `bash ci/check-workflow-template.sh ci/github-workflow.yml.tmpl` — pass (concurrency/permissions/persist-credentials/SHA-pinning/Node-wrangler pairing all still hold).
- `python3 -c "import yaml; yaml.safe_load(...)"` against the rendered template (placeholders substituted) — parses clean; step ordering confirmed (`Copy _headers...` → `Validate + hash deploy control-file bundle` → `csp-enforce`).
- `bash ci/run-fixtures.sh` — full local fixture suite, run twice, stable both times. Every stage passes except `pa11y` (`pa11y-ci not on PATH`), a pre-existing local-environment gap on this box (global npm package not installed) unrelated to this change — `playwright-smoke` and every `check-*` stage, including the new `check-deploy-bundle-gate.py` (11/11), pass clean. CI installs `pa11y-ci` fresh each run.
- PR #146's own `check-cf-deploy-gate.py`, run against this branch's modified template: 5/5 (see Coordination above).

## Two things stated rather than hidden

1. **This PR does not close #63.** #146 owns the remaining Done-when item (fixture coverage for the halt); closing #63 here would be premature while that PR is still open.
2. **The `required = False` manifest branch is implemented but unexercised**, for the reason stated in the acceptance-criteria checklist above — not a silently-skipped check, an honest scope boundary tied to what the issue actually names.

Closes #48
Refs #63
