### PR TITLE
docs(writing): clear the kanon lint queue to zero violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,7 @@
 
 All notable changes to this project are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project follows semantic versioning.
 
-No version has been cut yet — everything below is unreleased work on `main`. Once release-please automation is wired (RELEASES.md § Required configuration files), version cuts populate this file with dated, tagged sections below `## Unreleased`.
+No version has been cut yet — everything below is unreleased work on `main`. Once release-please automation is wired (RELEASES.md § Required configuration files), version cuts populate this file with dated, tagged sections below `## Unreleased`. <!-- kanon:ignore STANDARDS/citation-must-be-resolvable -- cross-repo fleet-canon citation per SSOT-or-derive; heading exists at kanon crates/basanos/standards/RELEASES.md:170. Resolver only ever checks a CWD-relative kanon-repo path. Filed kanon (forge) issue #10073. -->
 
 ## Unreleased
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Web-property-specific standards live alongside as kanon STANDARDS/WEB.md (filed 
 - **Self-hosted fonts**: WOFF2 under `static/fonts/`. Zero external CDN at visitor runtime. OFL families only.
 - **Push authority**: `origin` is GitHub (`forkwright/typikon`); no forge remote is configured. The typed forge/GitHub authority split is unresolved — forkwright/kanon#3045 owns it.
 - **License**: AGPL-3.0-or-later. Matches dioptron, aletheia. AI-training prohibition in NOTICE.
-- **Consumer schema registry**: a consumer site's custom-templated content types register in `schemas/registry.toml` and validate against their own schema, composed from typikon's open `page.core.schema.json`/`section.core.schema.json` building blocks and closed with `unevaluatedProperties: false`. A custom `template` with no registry entry fails validation naming the missing registration rather than falling back to `page`'s shape. See `docs/SCHEMAS.md#consumer-schema-registry`.
+- **Consumer schema registry**: a consumer site's custom-templated content types register in `schemas/registry.toml` and validate against their own schema, composed from typikon's open `page.core.schema.json`/`section.core.schema.json` building blocks and closed with `unevaluatedProperties: false`. A custom `template` with no registry entry fails validation naming the missing registration rather than falling back to `page`'s shape. See `docs/SCHEMAS.md#consumer-schema-registry`. <!-- kanon:ignore STANDARDS/citation-must-be-resolvable -- anchor exists at docs/SCHEMAS.md:26. Resolver drops the docs/ prefix and checks the wrong directory. Filed kanon (forge) issue #10073. -->
 
 ## How an agent operates here
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 > τυπικόν: the rule by which a thing of a given kind is enacted.
 
-A Zola theme + frontmatter schemas + agentic scaffolding + CI gates. The fleet's web-property substrate. Sites consume typikon as a git submodule; typikon governs how those sites are built, validated, and deployed.
+A Zola theme + frontmatter schemas + agentic scaffolding + CI gates. The fleet's web-property substrate. Sites consume typikon as a git submodule. Typikon governs how those sites are built, validated, and deployed.
 
-A typikon does not contain the service. It governs how the service is enacted.
+A typikon does not contain the service. It governs how the site enacts the service.
 
 ## Design
 
@@ -18,7 +18,7 @@ Optimized for agentic operation. Humans should not need to develop here. The sub
 
 ## Visitor runtime
 
-- Self-hosted WOFF2 fonts; zero external CDN dependencies at visitor runtime.
+- Self-hosted WOFF2 fonts. Zero external CDN dependencies at visitor runtime.
 - Strict CSP with no `unsafe-inline` anywhere. Inline scripts and styles are CI failures.
 - All third-party form actions explicitly allowlisted in CSP `form-action`.
 
@@ -55,7 +55,7 @@ See `docs/AGENTIC.md` for the agent contract, `docs/SCHEMAS.md` for the frontmat
 
 AGPL-3.0-or-later. See LICENSE and NOTICE.
 
-Self-hosted fonts under `static/fonts/` are OFL-1.1; see NOTICE for attributions.
+Self-hosted fonts under `static/fonts/` are OFL-1.1. See NOTICE for attributions.
 
 <!-- kanon:auto-start -->
 ## Repository Metadata

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -1,6 +1,6 @@
 # Agentic operation
 
-Every agent working on typikon itself or on any consumer site follows the contract below. Typikon is operated by AI agents; human edits are exceptions.
+Every agent working on typikon itself or on any consumer site follows the contract below. AI agents operate typikon. Human edits are exceptions.
 
 If you are a human reading this: every constraint here is also good for humans, but the bias is toward machine ergonomics. When in doubt, optimize for the agent.
 
@@ -19,9 +19,9 @@ Every content type has a JSON Schema in `schemas/`:
 | FAQ | `schemas/faq.schema.json` | Any page with `template = "faq.html"` |
 | Sizing guide | `schemas/sizing-guide.schema.json` | Any page with `template = "sizing-guide.html"` |
 
-The schema defines: required fields, optional fields, value types, value patterns, length limits. Do not invent fields. If a frontmatter field is not in the schema, do not write it — every one of the six is closed, so an unrecognized field fails validation, not silently passes.
+The schema defines: required fields, optional fields, value types, value patterns, length limits. Do not invent fields. If a frontmatter field is not in the schema, do not write it — the schema closes every one of the six, so an unrecognized field fails validation instead of silently passing.
 
-A consumer site's own custom template (not one of the six above) needs its own schema, registered in `schemas/registry.toml` — see `docs/SCHEMAS.md#consumer-schema-registry`. An unregistered custom template fails validation naming the missing registration; it does not fall back to `page`'s shape.
+A consumer site's own custom template (not one of the six above) needs its own schema, registered in `schemas/registry.toml` — see `docs/SCHEMAS.md#consumer-schema-registry`. An unregistered custom template fails validation naming the missing registration. It does not fall back to `page`'s shape.
 
 ### 2. Use the scaffolder
 
@@ -39,7 +39,7 @@ If you find yourself wanting to hand-write frontmatter, file an issue requesting
 bin/typikon-validate <consumer-site-root>
 ```
 
-Runs every content file in the consumer site against its appropriate schema. Output is JSONL on stderr; exit 0 = all valid, exit 1 = any failure.
+Runs every content file in the consumer site against its appropriate schema. Output is JSONL on stderr. Exit 0 = all valid, exit 1 = any failure.
 
 JSONL line shape:
 
@@ -55,7 +55,7 @@ Run this in your authoring loop. Do not push without it passing.
 bin/typikon-check <consumer-site-root>
 ```
 
-Runs every stage below, in order; a stage failing does not stop the ones after it (each records its own verdict — see `bin/typikon-check`'s Exit codes for how the run's overall result is decided):
+Runs every stage below, in order. A stage failing does not stop the ones after it (each records its own verdict — see `bin/typikon-check`'s Exit codes for how it decides the run's overall result):
 
 1. `typikon-validate` (frontmatter against JSON Schema)
 2. `zola check` (internal links + assets)
@@ -67,7 +67,7 @@ Runs every stage below, in order; a stage failing does not stop the ones after i
 8. `pa11y-ci --config ci/pa11y.config.js` (WCAG 2.1 AA, against `public-local/`)
 9. `playwright test` (per-route smoke assertions, against `public-local/`)
 
-Output is JSONL summarizing each gate. If anything fails, fix; do not push to bypass.
+Output is JSONL summarizing each gate. If anything fails, fix it. Do not push to bypass.
 
 ### 5. No inline scripts, styles, or event handlers
 
@@ -90,11 +90,11 @@ Do not fork the theme into a consumer to satisfy a one-off need. Forks become pe
 
 ### 7. Schema changes are migrations, where a migration is possible
 
-When a schema field is renamed, removed, or changed incompatibly, the typikon PR also ships a migration script in `bin/typikon-migrate-<from>-<to>`. The script:
+When a typikon PR renames, removes, or changes a schema field incompatibly, it also ships a migration script in `bin/typikon-migrate-<from>-<to>`. The script:
 
 - Runs against a consumer site root
 - Reads every content file, applies the transformation, writes back
-- Is idempotent (re-running is a no-op if already migrated)
+- Is idempotent (re-running is a no-op if already migrated) <!-- kanon:ignore WRITING/passive-voice -- idempotent is a predicate adjective, not a participle, with no actor to name — filed kanon (forge) issue #10074 -->
 - Exits 0 on success with summary of files changed
 
 The PR description must list every consumer affected and link the migration runs.
@@ -107,22 +107,22 @@ script can supply it.
 That matters most for the provenance fields — `words_source`, `price_source`,
 `measurement_source`. Each states where a rendered number came from. A migration that
 filled them with a placeholder would be writing a false provenance claim into content,
-which is the exact failure the fields were added to prevent. A schema that guarantees
-"this price is traceable" is worth less than nothing if the guarantee can be satisfied
-by a generated string.
+which is the exact failure the fields exist to prevent. A schema that guarantees
+"this price is traceable" is worth less than nothing if a generated string can satisfy
+the guarantee.
 
 So typikon ships no migration for added required fields. The consequence is real and
 falls on the consumer: it cannot bump the theme submodule until it has authored the
 new fields for every affected content file. Budget that as content work, not as a
 version bump — `themes/typikon/bin/typikon-validate .` names each file and pointer, so
-the work is enumerable before it is started.
+you can enumerate the work before starting it.
 
 The PR adding a required field must say so in its description, and list the consumers
 it blocks.
 
 ### 8. Check the push authority before pushing
 
-`origin` is GitHub (`forkwright/typikon`). No forge remote is configured and there is no mirror step, so a push to `origin` is a push to GitHub. Check with `git remote -v` instead of assuming either shape.
+`origin` is GitHub (`forkwright/typikon`). This repo configures no forge remote and has no mirror step, so a push to `origin` is a push to GitHub. Check with `git remote -v` instead of assuming either shape.
 
 Whether the fleet returns to a forge-primary split is an open question that forkwright/kanon#3045 owns.
 
@@ -141,7 +141,7 @@ alt = "Close-up of saddle stitch on belt edge"
 caption = "Two needles work the same thread from opposite sides."
 ```
 
-The product-gallery partial (auto-included by page.html) renders a responsive `<picture>` per image — Zola's `resize_image()` generates 400 / 800 / 1200 px WebP variants automatically. First image is the hero (eager-loaded); the rest lazy-load.
+The product-gallery partial (auto-included by page.html) renders a responsive `<picture>` per image — Zola's `resize_image()` generates 400 / 800 / 1200 px WebP variants automatically. First image is the hero (eager-loaded). The rest lazy-load.
 
 When real photos arrive, drop the placeholder `<div class="product-images">…image-placeholder-list…</div>` block from the markdown body — the gallery takes its visual slot.
 
@@ -180,7 +180,7 @@ When a new fleet site enters the family, do not fork or copy. Consume the substr
 typikon-init <site-slug> ~/dev/<site-slug>
 ```
 
-The scaffolder writes `config.toml`, the `themes/typikon` submodule, `_headers`, `_redirects`, the GitHub Actions workflow, a starter `content/_index.md`, and the operator brief at `CLAUDE.md`. The first commit lands automatically; the operator pushes once the forge repo exists (`kanon forge init forkwright/<site-slug>`).
+The scaffolder writes `config.toml`, the `themes/typikon` submodule, `_headers`, `_redirects`, the GitHub Actions workflow, a starter `content/_index.md`, and the operator brief at `CLAUDE.md`. The first commit lands automatically. Once the forge repo exists, the operator pushes (`kanon forge init forkwright/<site-slug>`).
 
 ### 2. Brand identity (consumer-side, not theme-side)
 
@@ -229,4 +229,4 @@ When a typikon schema changes incompatibly, the same PR ships a migration script
 - It does not say what the design language is. That is in `templates/` + `static/` and is read, not derived.
 - It does not say how to make decisions about scope. Use kanon's standard escalation surfaces (issues, plans).
 
-When in doubt, run the gate. If the gate is green, you are not breaking anything. If the gate is red, the gate is the source of truth.
+When in doubt, run the gate. If the gate is green, you are not breaking anything. If the gate is red, the gate is the source of truth. <!-- kanon:ignore WRITING/passive-voice -- green and red are CI-status adjectives, not participles, with no actor to name — filed kanon (forge) issue #10074 -->

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -8,7 +8,7 @@ Two separate binaries cover the lifecycle of a consumer site: `bin/typikon-init`
 bin/typikon-init <site-name> <destination-path>
 ```
 
-`site-name` must be lowercase ASCII, starting with a letter (`^[a-z][a-z0-9-]*$`); it becomes the forge/GitHub repo slug. `destination-path` is created if absent.
+`site-name` must be lowercase ASCII, starting with a letter (`^[a-z][a-z0-9-]*$`). It becomes the forge/GitHub repo slug. The scaffolder creates `destination-path` if absent.
 
 Environment overrides:
 
@@ -21,16 +21,16 @@ Environment overrides:
 
 Behavior:
 
-1. `git init -b main` if `.git` is absent; add `origin` (forge) and `github` (mirror) remotes.
-2. Add `themes/typikon` as a git submodule if missing; otherwise `git pull --ff-only origin main` inside it (best-effort — failure doesn't abort the run).
+1. Run `git init -b main` when `.git` does not exist yet. Add `origin` (forge) and `github` (mirror) remotes.
+2. Add `themes/typikon` as a git submodule if missing. Otherwise, run `git pull --ff-only origin main` inside it (best-effort — failure doesn't abort the run).
 3. Copy `_headers.tmpl` → `_headers` and `_redirects.tmpl` → `_redirects` verbatim, skipping either that already exists. These are one-time copies: consumers hand-edit them afterward, and `typikon-init`/`typikon-refresh` never overwrite them again.
 4. Render `ci/kanon-ci.toml.tmpl` → `.kanon-ci.toml` and `ci/github-workflow.yml.tmpl` → `.github/workflows/deploy.yml`, substituting `{{ PROJECT_NAME }}`, `{{ ZOLA_VERSION }}`, and `{{ WRANGLER_VERSION }}`. Skipped if the destination file already exists — re-rendering an existing consumer's CI files is `typikon-refresh`'s job, not `typikon-init`'s.
 5. Write `.gitignore`, `config.toml` (Zola config, `theme = "typikon"`, stub `[extra]` block), `content/_index.md`, `content/about.md`, `content/contact.md`, and `CLAUDE.md` (the consumer-specific operator brief) — each only if absent, so re-running against an existing destination never clobbers consumer-edited content.
 6. Create `static/img/.gitkeep` and `tests/smoke/.gitkeep`.
-7. Force-add `CLAUDE.md` (excluded by the operator's global gitignore by default), stage everything, and commit if this is the first commit; otherwise leave the refresh staged.
+7. Force-add `CLAUDE.md` (excluded by the operator's global gitignore by default), stage everything, and commit if this is the first commit. Otherwise, leave the refresh staged.
 8. Print next steps: run `bin/typikon-check .`, push with `ALLOW_PROTECTED_PUSH=1` on the first push, `kanon forge init` the new repo.
 
-Idempotency is per-file: `write_if_absent` and `copy_template` steps (3–5) skip anything already on disk; only the submodule pointer (step 2) is bumped on a re-run. There is no `--refresh` flag — re-running `typikon-init` against an existing destination fills in anything still missing, it does not re-render already-scaffolded CI templates.
+Idempotency is per-file: `write_if_absent` and `copy_template` steps (3–5) skip anything already on disk. Only a re-run bumps the submodule pointer (step 2). There is no `--refresh` flag — re-running `typikon-init` against an existing destination fills in anything still missing, it does not re-render already-scaffolded CI templates.
 
 ## `bin/typikon-refresh` — bump a consumer to the latest typikon
 
@@ -54,12 +54,12 @@ Behavior:
 1. Sanity-check: must run from a consumer root containing `themes/typikon/theme.toml`, from the matching submodule checkout, inside a git repo.
 2. `cd themes/typikon && git pull --ff-only origin main`. Exits 1 if the submodule has diverged from `origin/main` — reconcile manually and re-run.
 3. Derive `PROJECT_NAME`, `ZOLA_VERSION`, and `WRANGLER_VERSION` (env override or default).
-4. Unconditionally re-render `ci/kanon-ci.toml.tmpl` → `.kanon-ci.toml` and `ci/github-workflow.yml.tmpl` → `.github/workflows/deploy.yml`. This is the only place these two files are re-rendered post-init; hand-edits to them are lost by design (per-site CI deltas belong in sibling files or an operator-authored follow-up commit). `_headers`/`_redirects` are never touched here — they're one-time copies from step 3 of `typikon-init`.
+4. Unconditionally re-render `ci/kanon-ci.toml.tmpl` → `.kanon-ci.toml` and `ci/github-workflow.yml.tmpl` → `.github/workflows/deploy.yml`. This is the only place these two files are re-rendered post-init. Hand-edits to them are lost by design (per-site CI deltas belong in sibling files or an operator-authored follow-up commit). `_headers`/`_redirects` are never touched here — they're one-time copies from step 3 of `typikon-init`.
 5. Stage the bumped submodule pointer and each re-rendered file (named `git add`, not `-A`, so unrelated operator-side work isn't swept in).
-6. Print a summary (submodule SHA before/after, `PROJECT_NAME`, `ZOLA_VERSION`, what was rendered/skipped) and the staged diffstat.
+6. Print a summary (submodule SHA before/after, `PROJECT_NAME`, `ZOLA_VERSION`, what it rendered or skipped) and the staged diffstat.
 
-`typikon-refresh` never commits — it stages and prints a suggested commit message; the operator or agent reviews `git diff --cached` and authors the commit. Idempotent: re-running with no upstream change is a no-op (the re-render is byte-identical, so nothing new gets staged beyond what's already there).
+`typikon-refresh` never commits — it stages and prints a suggested commit message. The operator or agent reviews `git diff --cached` and authors the commit. Idempotent: re-running with no upstream change is a no-op (the re-render is byte-identical, so nothing new gets staged beyond what's already there).
 
 ## Schema migrations
 
-When a schema change is incompatible, the migration ships as `bin/typikon-migrate-<from>-<to>` in the same PR. Running `typikon-refresh` bumps the submodule to the version carrying the migration script; the operator runs the migration script against the consumer separately — `typikon-refresh` itself does not invoke migrations.
+When a schema change is incompatible, the migration ships as `bin/typikon-migrate-<from>-<to>` in the same PR. Running `typikon-refresh` bumps the submodule to the version carrying the migration script. The operator runs the migration script against the consumer separately — `typikon-refresh` itself does not invoke migrations.

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -91,7 +91,14 @@ Top-level pages and section children that aren't journal entries or products. Bu
 
 **Optional `[extra]`:** `seo_title`, `body_class`, `og_image`, `og_type`, `audience`, `price`, `price_source`, `stripe_url`.
 
-**Constraints:** title ≤80 chars; description ≤200; path matches `^/[a-z0-9/_-]*/?$`; template matches `^[a-z0-9_-]+\.html$`; og_image ends in `.svg|.png|.jpg|.webp`. Setting any one of `price`, `stripe_url`, or `price_source` triggers `ld-product` JSON-LD in `page.html`, which then requires all four of `audience`, `price`, `price_source`, and `stripe_url` together (enforced by the schema's `if`/`then` on `extra`, matching the template's assertions exactly). A dedicated product page under `content/products/` should use the `product` schema instead — these fields exist here for the rare non-product-section page that still needs a buy block.
+**Constraints:**
+- title: ≤80 chars
+- description: ≤200 chars
+- path: matches `^/[a-z0-9/_-]*/?$`
+- template: matches `^[a-z0-9_-]+\.html$`
+- og_image: ends in `.svg|.png|.jpg|.webp`
+
+Setting any one of `price`, `stripe_url`, or `price_source` triggers `ld-product` JSON-LD in `page.html`, which then requires all four of `audience`, `price`, `price_source`, and `stripe_url` together (enforced by the schema's `if`/`then` on `extra`, matching the template's assertions exactly). A dedicated product page under `content/products/` should use the `product` schema instead — these fields exist here for the rare non-product-section page that still needs a buy block.
 
 **Example:**
 
@@ -176,7 +183,7 @@ Pages under `content/products/`. Required for the purchase block to render.
 - price_source: 3–200 chars. Source for the rendered price claim
 - stripe_url: matches `^https://buy\.stripe\.com/[A-Za-z0-9_]+$`
 - shipping_note (optional): ≤200 chars
-- images (optional): array of `{src, alt, caption?}`; Zola's `resize_image` produces 400/800/1200px WebP variants automatically, and the product-gallery partial renders responsive `<picture>` per item
+- images (optional): array of `{src, alt, caption?}`. Zola's `resize_image` produces 400/800/1200px WebP variants automatically, and the product-gallery partial renders responsive `<picture>` per item
 
 **Example:**
 
@@ -213,7 +220,7 @@ Any page with `template = "faq.html"`. Renders a definition-list FAQ with anchor
 - audience: 3–120 chars
 - q: 5–200 chars
 - a: 5–2000 chars. Supports `\n\n` for paragraph breaks (template splits on it)
-- anchor (optional): `^[a-z0-9-]+$`; slugified from `q` if omitted
+- anchor (optional): `^[a-z0-9-]+$`. Slugified from `q` if omitted
 - additionalProperties on each question: false (strict)
 
 **Example:**
@@ -249,10 +256,10 @@ Any page with `template = "sizing-guide.html"`. Renders a measurement table, an 
 - measurement_source: 3–200 chars. Source for numeric sizing claims
 - product_type: 2–40 chars
 - measurement_unit (optional): `inches | centimeters | both` (default `inches`)
-- size_table rows: required `size`; optional `waist`, `length`, `width`, `note`; column rendering is conditional on the first row's keys
-- diagram (optional): path under static/ to an `.svg` file; loaded inline via `load_data`
+- size_table rows: required `size`. Optional `waist`, `length`, `width`, `note`. Column rendering is conditional on the first row's keys
+- diagram (optional): path under static/ to an `.svg` file. Loaded inline via `load_data`
 - decision_tree (optional): array of strings, rendered as ordered list
-- duration (optional): ISO 8601 duration, hours/minutes/seconds only (e.g. `PT2M`); requires duration_source; emitted as HowTo `totalTime` only when both are set — never guessed
+- duration (optional): ISO 8601 duration, hours/minutes/seconds only (e.g. `PT2M`). Requires duration_source. Emitted as HowTo `totalTime` only when both are set — never guessed
 
 **Example:**
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -4,7 +4,7 @@ JSON Schema definitions for every content type a typikon-consuming site can auth
 
 ## How the validator routes a file to a schema
 
-`typikon-validate` reads `<root>/content/**/*.md` and classifies in this order; first match wins:
+`typikon-validate` reads `<root>/content/**/*.md` and classifies in this order. First match wins:
 
 | Rule                                                    | Schema                        |
 |----------------------------------------------------------|------------------------------|
@@ -19,13 +19,13 @@ JSON Schema definitions for every content type a typikon-consuming site can auth
 
 Template-driven dispatch comes first so per-page overrides (FAQ on a non-FAQ section, sizing-guide for a non-product section) escape the path-based default. To add a new template-routed type, extend `TEMPLATE_SCHEMA_MAP` in `bin/typikon-validate`.
 
-Renaming path-routed sections (`journal/` → `notes/`) requires updating the classifier. Out of scope for v1; file an issue when needed.
+Renaming path-routed sections (`journal/` → `notes/`) requires updating the classifier. Out of scope for v1. File an issue when needed.
 
 **Fail-closed:** a `template` value that is neither one of typikon's own shipped templates (`KNOWN_TEMPLATES` in `bin/typikon-validate`) nor a registered `schemas/registry.toml` entry is a validation FAILURE naming the exact missing registration — it does not fall through to `page`. See [Consumer schema registry](#consumer-schema-registry) below.
 
 ## Consumer schema registry
 
-A typikon-consuming site's own custom templates (a page type typikon does not ship — an "our approach" page, a case-study template, a domain-specific index) have no built-in schema. Before this mechanism existed, such a file fell through the table above to `page` or `section`, whose `extra` object accepted any additional field without checking its shape — a typo like `kanon_ci = "false"` was schema-valid and became truthy wherever a template did `bool(...)` on it (forkwright/typikon#60). The registry closes that: every custom template or custom-path content type gets its own strict, checked-in schema, and an *unregistered* one is a hard failure, not a silent fallback.
+A typikon-consuming site's own custom templates (a page type typikon does not ship — an "our approach" page, a case-study template, a domain-specific index) have no built-in schema. Before this mechanism existed, such a file fell through the table above to `page` or `section`, whose `extra` object accepted any additional field without checking its shape. A typo like `kanon_ci = "false"` was schema-valid and became truthy wherever a template did `bool(...)` on it (forkwright/typikon#60). The registry closes that: every custom template or custom-path content type gets its own strict, checked-in schema, and an *unregistered* one is a hard failure, not a silent fallback.
 
 ### Registering a custom type
 
@@ -56,7 +56,7 @@ A typikon-consuming site's own custom templates (a page type typikon does not sh
 
    **Namespace your extension.** Put every custom field under one object keyed by your own name (`extra.ardent` above, not bare `extra.kanon_ci`) so a future typikon-owned field can never collide with a consumer one.
 
-   **WARNING:** the `$ref` targets must be the open `*.core.schema.json` files, never `page.schema.json`/`section.schema.json` themselves. Composing a schema that is *already* closed (via `unevaluatedProperties`) from inside another closed schema corrupts jsonschema 4.23's annotation collection for the whole document — verified failure mode, not a style preference: every top-level field, not just the extension, gets spuriously rejected. `page.schema.json` and `section.schema.json` demonstrate the correct pattern (they compose the core exactly this way, once, standalone) — mirror them, don't reference them.
+   **WARNING:** the `$ref` targets must be the open `*.core.schema.json` files, never `page.schema.json`/`section.schema.json` themselves. Composing a schema that is *already* closed (via `unevaluatedProperties`) from inside another closed schema corrupts jsonschema 4.23's annotation collection for the whole document. This is a verified failure mode, not a style preference: every top-level field, not just the extension, gets spuriously rejected. `page.schema.json` and `section.schema.json` demonstrate the correct pattern (they compose the core exactly this way, once, standalone) — mirror them, don't reference them.
 
 2. Add an entry to `<consumer-root>/schemas/registry.toml`:
 
@@ -67,13 +67,13 @@ A typikon-consuming site's own custom templates (a page type typikon does not sh
    extends = "page"                                 # "page" or "section" — which core it composes
    ```
 
-   Exactly one of `template` (matched against frontmatter `template`) or `path_prefix` (matched against the content-relative path, e.g. `"systems/"` catches `content/systems/<anything>.md`) is required per entry. `template` wins when both a template and a path could match the same file — same precedent as `TEMPLATE_SCHEMA_MAP`.
+   The registry entry requires exactly one of `template` (matched against frontmatter `template`) or `path_prefix` (matched against the content-relative path, e.g. `"systems/"` catches `content/systems/<anything>.md`). `template` wins when both a template and a path could match the same file — same precedent as `TEMPLATE_SCHEMA_MAP`.
 
-   **`extends` must match what the matched file structurally is, not just what you intended the entry to cover.** A `_index.md` is always a Zola section; every other file is always a Zola page — that split is Zola's, not the registry's to override. `path_prefix = "systems/"` also textually matches `content/systems/_index.md`, not just its leaf pages: if that entry's `extends = "page"`, the index file fails with a `MismatchedExtendsError` instead of silently validating against the wrong shape (missing section-only fields like `sort_by`/`page_template`/`extra.triad`). Scope the prefix past the index file, or give the section index its own `template`-keyed entry with `extends = "section"`, if you need both covered.
+   **`extends` must match what the matched file structurally is, not just what you intended the entry to cover.** A `_index.md` is always a Zola section. Every other file is always a Zola page — that split is Zola's, not the registry's to override. `path_prefix = "systems/"` also textually matches `content/systems/_index.md`, not just its leaf pages. If that entry's `extends = "page"`, the index file fails with a `MismatchedExtendsError` instead of silently validating against the wrong shape (missing section-only fields like `sort_by`/`page_template`/`extra.triad`). Scope the prefix past the index file, or give the section index its own `template`-keyed entry with `extends = "section"`, if you need both covered.
 
-3. Run `typikon-validate <consumer-root>` (or `typikon-check`, which calls it). A malformed registry entry — both discriminators set, neither set, `extends` naming a type with no composable core, a missing schema file, a schema missing `$id`, a duplicate discriminator, or a discriminator matching a file whose structural kind disagrees with `extends` — fails immediately with the specific problem, before that file's content is checked.
+3. Run `typikon-validate <consumer-root>` (or `typikon-check`, which calls it). A malformed registry entry fails immediately with the specific problem, before typikon-validate checks that file's content. Malformed means: both discriminators set, neither set, `extends` naming a type with no composable core, a missing schema file, a schema missing `$id`, a duplicate discriminator, or a discriminator matching a file whose structural kind disagrees with `extends`.
 
-A consumer with no custom templates needs no `schemas/registry.toml` at all; its absence is not an error and every existing consumer validates unchanged.
+A consumer with no custom templates needs no `schemas/registry.toml` at all. Its absence is not an error, and every existing consumer validates unchanged.
 
 Only `page` and `section` have a `*.core.schema.json` building block today — those are the two shapes a real consumer has needed to extend. Extending `journal-entry`, `product`, `faq`, or `sizing-guide` the same way means splitting that schema into a `.core.schema.json` + closed wrapper first, following `schemas/page.schema.json`'s pattern exactly, then adding its slug to `COMPOSABLE_CORE_SLUGS` in `bin/typikon-validate`.
 
@@ -145,7 +145,7 @@ Pages under `content/journal/` (excluding `_index.md`). Stricter than page: requ
 - extra.audience: 3–120 chars
 - extra.components: 5–120 chars (the conceptual-tags line)
 - extra.words: matches `^~?\d+( words)?$`
-- extra.words_source: 3–200 chars; source for the rendered word-count claim
+- extra.words_source: 3–200 chars. Source for the rendered word-count claim
 
 **Example:**
 
@@ -173,7 +173,7 @@ Pages under `content/products/`. Required for the purchase block to render.
 - description: 30–200 chars
 - audience: 3–120 chars
 - price: matches `^\$?\d{1,5}(\.\d{2})?$` (e.g. `$150`, `85`, `12.50`)
-- price_source: 3–200 chars; source for the rendered price claim
+- price_source: 3–200 chars. Source for the rendered price claim
 - stripe_url: matches `^https://buy\.stripe\.com/[A-Za-z0-9_]+$`
 - shipping_note (optional): ≤200 chars
 - images (optional): array of `{src, alt, caption?}`; Zola's `resize_image` produces 400/800/1200px WebP variants automatically, and the product-gallery partial renders responsive `<picture>` per item
@@ -212,7 +212,7 @@ Any page with `template = "faq.html"`. Renders a definition-list FAQ with anchor
 **Constraints (per question):**
 - audience: 3–120 chars
 - q: 5–200 chars
-- a: 5–2000 chars; supports `\n\n` for paragraph breaks (template splits on it)
+- a: 5–2000 chars. Supports `\n\n` for paragraph breaks (template splits on it)
 - anchor (optional): `^[a-z0-9-]+$`; slugified from `q` if omitted
 - additionalProperties on each question: false (strict)
 
@@ -246,7 +246,7 @@ Any page with `template = "sizing-guide.html"`. Renders a measurement table, an 
 
 **Constraints:**
 - audience: 3–120 chars
-- measurement_source: 3–200 chars; source for numeric sizing claims
+- measurement_source: 3–200 chars. Source for numeric sizing claims
 - product_type: 2–40 chars
 - measurement_unit (optional): `inches | centimeters | both` (default `inches`)
 - size_table rows: required `size`; optional `waist`, `length`, `width`, `note`; column rendering is conditional on the first row's keys
@@ -292,7 +292,7 @@ This section is for a type shared by ≥2 consumers, landing in typikon itself (
 
 1. Identify the type. If two existing types could absorb it via an optional field, use that instead.
 2. Write `schemas/<type>.schema.json`, extending the page shape where possible.
-3. Add a template `templates/<type>.html` (extend `page.html` when the override is content-only; replace it when the head/body shape needs to change).
+3. Add a template `templates/<type>.html` — extend `page.html` when the override changes content only, replace it when the head/body shape needs to change.
 4. Update `bin/typikon-validate`:
    - if path-routed: extend the path classifier
    - if template-routed: add an entry to `TEMPLATE_SCHEMA_MAP`
@@ -309,7 +309,7 @@ When a schema changes incompatibly:
 2. Replace the `migrate(frontmatter, file_path)` body with the field transformation. Idempotence rule: running it twice on the same input must produce the same output as once.
 3. The script walks a consumer site root, parses frontmatter, runs `migrate()`, and writes back when the result differs.
 4. The typikon PR description lists every consumer affected.
-5. On merge, run the migration against each consumer in a separate consumer-side PR; that captures the rewrite as a reviewable diff.
+5. On merge, run the migration against each consumer in a separate consumer-side PR. That captures the rewrite as a reviewable diff.
 
 The skeleton handles parsing, idempotence checking, basic TOML serialization, and JSONL change reporting. It uses `tomli_w` when installed and falls back to a minimal emitter otherwise. Install `tomli_w` via `uv tool install tomli_w` if your migration needs round-trip fidelity for inline tables or multi-line strings.
 


### PR DESCRIPTION
## Review response (must_fix addressed)

An independent adversarial review of this PR found two problems, both fixed by commit
`c053ed6` (in this PR, on top of `af784d7`):

1. **The sweep was not exhaustive.** `docs/SCHEMAS.md` had six more prose semicolons
   masked by the same `WRITING/semicolon` skip-pattern defect this PR diagnoses
   (kanon forge issue #10074), at lines 94, 179, 216, 252, 253, 255 — left in place by
   the original commit despite the body's "fixed all ten... without leaving genuine
   prose defects in place" claim. Fixed in `c053ed6`; see that commit's message for the
   per-line breakdown (line 94's four-semicolon Constraints paragraph, masked as a whole
   line rather than semicolon-by-semicolon, needed reformatting to a bulleted list —
   every other fix is a straight sentence split, consistent with the rest of this PR).
2. **The stated count didn't match the itemized list.** The body said "Ten prose
   semicolons" but its own location list had eleven entries. Both numbers were wrong:
   the real count, now that the sweep is complete, is **seventeen** — the original
   eleven plus the six above. Every occurrence of the count below is now seventeen, and
   the location list is authoritative (count it if you don't trust the number).

`kanon lint` still reports **0 violations / 5 suppressed** after `c053ed6` — unchanged,
because these were never in its count either way (masked, not just missed). Re-verified:
`ci/check-consumer-schema-registry.py`, `ci/check-release-config.py`,
`ci/check-fixture-corpus-exemption.sh`, `ci/check-consumer-check-extension.sh` all pass
against the current head.

---

## Finding

`kanon lint` reported 41 unsuppressed violations against `typikon` at `origin/main` (3014055): 0 SHELL findings, 0 YAML/missing-concurrency findings (both already fixed by PR #129 / commit f962068 — `ci/local-base-gate-check.sh:2` already carries `set -euo pipefail`), 2 `STANDARDS/citation-must-be-resolvable`, and 39 `WRITING/semicolon` + `WRITING/passive-voice` + `WRITING/run-on-sentence` across `README.md`, `docs/AGENTIC.md`, `docs/BOOTSTRAP.md`, `docs/SCHEMAS.md`.

## Evidence

- **Shell strict-mode already fixed on `main`** — `ci/local-base-gate-check.sh:2` reads `set -euo pipefail` with a WARNING comment at lines 4-9 explaining why `-e` matters. Confirmed by reading current `origin/main`, not by trusting the issue text.
- **28 → 41 is not a regression, it's the same underlying debt measured live** — a prior collab comment on #75 already found the SHELL/YAML findings gone and a live count of 33; a few commits later (3014055) the live count was 41, all still the same WRITING/STANDARDS classes.
- Two `STANDARDS/citation-must-be-resolvable` findings were **false positives** (see "False positives" below), suppressed inline with a filed kanon issue each.
- Four `WRITING/passive-voice` findings matched predicate ADJECTIVES the heuristic misreads as past participles (`idempotent`, `absent`, `green`/`red`, `content-only`) — two fixed by rewording (`absent`, `content-only`), two suppressed because the vocabulary is load-bearing technical/idiomatic usage (`idempotent`, `green`/`red`).
- **Seventeen additional genuine prose semicolons were silently un-reported** by `kanon lint` at every precision tier, including `--strict` — the semicolon rule's own skip patterns (a cross-code-span backtick match, and an over-broad "line starts with backtick" match) mask them, and the match check is whole-line: one qualifying backtick-adjacent substring anywhere on a line hides every semicolon on that line, not just the one next to it. Fixed all seventeen in this PR (eleven in the first commit, six more in `docs/SCHEMAS.md` in a follow-up commit after review) anyway since they are genuine `WRITING.md` § No-semicolons violations regardless of the tool's own blind spot, and filed the tool defect.
- All 5 remaining suppressions verified load-bearing: `kanon lint --precision low --strict` (bypasses every suppression class) reproduces exactly these 5 findings and no others; `kanon lint --detect-stale-suppressions` reports none stale.

## Why this matters

`set -uo pipefail` without `-e` was the one finding in the original queue with runtime consequence; it's already fixed. What remained was purely a "the lint queue must read zero" bar — but a checker that silently under-reports (the 17 masked semicolons) is the same failure shape the original issue was filed over: a gate that green-lights on its own internal error.

## Desired correction

Clear every unsuppressed finding to zero without suppressing anything that isn't a genuine tool false positive, and without leaving genuine prose defects in place merely because the tool failed to flag them.

## False positives found (filed, not silently ignored)

- **`STANDARDS/citation-must-be-resolvable`** — two false positives, one rule-defect issue: **kanon (forge) issue #10073**. (1) `CLAUDE.md:54`'s citation of `` `docs/SCHEMAS.md#consumer-schema-registry` `` — the anchor genuinely exists at `docs/SCHEMAS.md:26`; the identical citation from `docs/AGENTIC.md` (same directory as the target) resolves cleanly, proving the defect is path-prefix handling, not anchor correctness. (2) `CHANGELOG.md:132`'s citation of `RELEASES.md § Required configuration files` — a cross-repo fleet-canon citation per the fleet's "SSOT or derive" doctrine; the heading exists at `kanon/crates/basanos/standards/RELEASES.md:170`, but the resolver only ever checks a CWD-relative `crates/basanos/standards/` path that exists solely inside kanon's own checkout.
- **`WRITING/passive-voice`** — matches any predicate adjective ending in `-ed/-en/-wn/-nt/-un`, not just genuine past participles: **kanon (forge) issue #10074** (same issue also covers the semicolon-masking defect below). Evidence: `docs/AGENTIC.md:97` (`Is idempotent`), `docs/AGENTIC.md:232` (`is green` / `is red`).
- **`WRITING/semicolon`** — two of its four skip patterns produce false NEGATIVES (mask real violations instead of over-flagging): tracked in the same **kanon (forge) issue #10074**. Seventeen prose semicolons across `docs/AGENTIC.md:24,183` and `docs/BOOTSTRAP.md:11,24,25,33,57,61,65` and `docs/SCHEMAS.md:7,72,94,179,216,252,253,255` were silently unreported at every precision tier including `--strict`. All are fixed in this PR.

## Negative fixture

Negative fixture: the six changed doc files in this diff — watched failing by `kanon lint <repo> --all` (equivalently `mcp__kanon__lint_check`), which reported **41 unsuppressed violations** against `origin/main` (3014055) before this fix and reports **0** after (5 suppressed, each confirmed still-firing under `--strict`, none stale under `--detect-stale-suppressions`). This exercises the shipped `kanon` binary against the shipped repo tree, not a re-implementation, and the same command that will grade this PR in CI.

```
# before (origin/main, 3014055)
$ kanon lint /home/ck/dispatch-wt/typikon-w2-75 --all --precision low
# 41 violations, 1 suppressed

# after (this branch)
$ kanon lint /home/ck/dispatch-wt/typikon-w2-75 --all --precision low
# 0 violations, 5 suppressed

$ kanon lint /home/ck/dispatch-wt/typikon-w2-75 --all --precision low --strict
# 5 violations -- exactly the 5 suppressed findings, confirming each suppression is load-bearing
```

## Acceptance criteria (from #75)

- [x] `Done when: kanon lint reports 0 total violations for the repo.` — confirmed above: `total_violations: 0`, `suppressed_count: 5`, all 5 verified load-bearing and none stale.
- [x] `Add -e to ci/local-base-gate-check.sh:37.` — already done on `main` (`ci/local-base-gate-check.sh:2`, commit f962068 / PR #129), predating this PR. Verified by reading the current file, not the issue text.
- [x] `Clear the remaining WRITING/semicolon and WRITING/passive-voice findings in the four named docs.` — `README.md`, `docs/AGENTIC.md`, `docs/BOOTSTRAP.md`, `docs/SCHEMAS.md` all clear; see per-file diff.
- [x] `Add the missing YAML concurrency block wherever YAML/missing-concurrency is anchored.` — already suppressed inline on `main` (`.github/workflows/gate-attestation.yml:1`, reason: `hybrid-gate.yml` declares the shared group already) — pre-existing, unrelated to this PR's diff, confirmed still firing+suppressed under `--strict`.

## Local verification run

- `kanon lint <repo> --all --precision low` (via `mcp__kanon__lint_check`): 0 violations, 5 suppressed (was 41, 1 suppressed).
- `kanon lint <repo> --all --precision low --strict`: exactly the 5 suppressed findings reproduced, nothing else.
- `kanon lint <repo> --all --precision low --detect-stale-suppressions`: `No stale suppressions detected.`
- `ci/check-release-config.py`, `ci/check-fixture-corpus-exemption.sh`, `ci/check-consumer-schema-registry.py`, `ci/check-consumer-check-extension.sh` (the CI scripts that reference the changed doc files): all pass.
- `ci/run-fixtures.sh` (the full local CI fixture gate — typikon-check against both example sites, including zola build/check, CSP enforce, asset provenance, lychee, and Playwright smoke): every stage passes except `pa11y` (`pa11y-ci not on PATH` — an npm package missing from this local box, not a regression; my diff touches zero HTML/CSS/templates and CI installs pa11y-ci itself).

Not run: full GitHub Actions CI (pushed for that grade, per repo convention — public repo, unmetered hosted minutes).

## Scope note

This diff is prose-only (`README.md`, `CLAUDE.md`, `CHANGELOG.md`, `docs/AGENTIC.md`, `docs/BOOTSTRAP.md`, `docs/SCHEMAS.md`) — no templates, schemas, CSS, or CI config touched. Seventeen of the fixed semicolons were not in the originally-reported 41-violation set; they were reported by `kanon lint` as clean due to the rule's own defect (see above) but are genuine `WRITING.md` § No-semicolons violations in the same four files this issue already scopes, so they're fixed here rather than left for a second pass.

Closes #75
