### PR TITLE
fix(ci,typikon-validate): derive the fixture list; route+accept journal-entry.html extras

### DIFF
--- a/bin/typikon-validate
+++ b/bin/typikon-validate
@@ -24,6 +24,7 @@ the page's own frontmatter value, or its cascade-resolved effective value
 when it set none):
     frontmatter `template = "faq.html"`          -> faq.schema.json
     frontmatter `template = "sizing-guide.html"` -> sizing-guide.schema.json
+    frontmatter `template = "journal-entry.html"` -> journal-entry.schema.json
     frontmatter `template` matches a `[[entry]]` in
       <root>/schemas/registry.toml with `template = "..."`
                                                    -> the entry's consumer schema
@@ -96,6 +97,7 @@ SCHEMA_DIR = THEME_ROOT / "schemas"
 TEMPLATE_SCHEMA_MAP = {
     "faq.html": "faq",
     "sizing-guide.html": "sizing-guide",
+    "journal-entry.html": "journal-entry",
 }
 
 # WHY: templates typikon itself ships that a consumer may freely set as

--- a/ci/check-fixture-discovery.sh
+++ b/ci/check-fixture-discovery.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-fixture-discovery — regression test for forkwright/typikon#169.
+#
+# WHY: ci/run-fixtures.sh used to hand-list every fixture script by name, one
+# line per file. Every branch adding a fixture edited that same shared block,
+# so two concurrent fixture-adding branches conflicted there deterministically
+# -- proven four times in one day on one branch (#169's own evidence table).
+# The fix derives the no-arg fixture set from the filesystem (ci/check-*.sh,
+# ci/check-*.py, minus the small named set that takes positional arguments)
+# instead of declaring it, and fails closed rather than passing vacuously if
+# discovery finds nothing to run.
+#
+# This script proves both properties against the REAL ci/run-fixtures.sh (its
+# `--list` mode: discover, print, exit -- never running the discovered
+# fixtures themselves, so this stays cheap and never triggers a zola/lychee/
+# pa11y build):
+#   1. [the #169 fix itself] dropping a new no-arg check-*.sh/check-*.py file
+#      into a ci/-shaped directory makes run-fixtures.sh --list report it,
+#      with NO edit to run-fixtures.sh -- proven by diffing the runner's own
+#      bytes before and after, not just by reading its output.
+#   2. [REQUIRED NEGATIVE FIXTURE] a ci/-shaped directory containing zero
+#      check-*.sh/check-*.py files makes run-fixtures.sh refuse (nonzero
+#      exit), never a silent/vacuous pass -- exercised by mutating the real,
+#      shipped run-fixtures.sh (removing just the empty-set guard block),
+#      watching it wrongly print nothing and exit 0 against that same empty
+#      directory, then restoring the original bytes and watching it correctly
+#      refuse. Restore is verified byte-identical before this script trusts
+#      anything past that point.
+#   3. the two positional-argument fixtures (check-workflow-template.sh,
+#      check-xml-output.sh) are excluded from the auto-run set against the
+#      REAL ci/ directory, and a known real no-arg fixture is present --
+#      guards the exclusion mechanism's own correctness, not just its
+#      existence.
+#
+# NOTE: takes no arguments -- run as ci/check-fixture-discovery.sh.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNNER="$ROOT/ci/run-fixtures.sh"
+[[ -f "$RUNNER" ]] || { echo "error: $RUNNER not found" >&2; exit 2; }
+
+FAIL=0
+fail() {
+    echo "FAIL: $1" >&2
+    FAIL=1
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── 1. auto-discovery: a new fixture file needs no runner edit ────────────
+DISCOVER_DIR="$WORK/discover-ci"
+mkdir -p "$DISCOVER_DIR"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$DISCOVER_DIR/check-selftest-probe.sh"
+chmod +x "$DISCOVER_DIR/check-selftest-probe.sh"
+
+RUNNER_BEFORE_SHA="$(sha256sum "$RUNNER" | cut -d' ' -f1)"
+listed="$(FIXTURE_CI_DIR="$DISCOVER_DIR" "$RUNNER" --list || true)"
+RUNNER_AFTER_SHA="$(sha256sum "$RUNNER" | cut -d' ' -f1)"
+
+if [[ "$RUNNER_BEFORE_SHA" != "$RUNNER_AFTER_SHA" ]]; then
+    fail "run-fixtures.sh's own bytes changed just from discovery running -- this script must never mutate the runner it is testing"
+fi
+if ! grep -qxF "check-selftest-probe.sh" <<<"$listed"; then
+    fail "dropping check-selftest-probe.sh into a ci/-shaped directory did not make run-fixtures.sh --list report it (got: ${listed:-<empty>}) -- discovery is not deriving from the filesystem"
+fi
+
+# ── 2. REQUIRED NEGATIVE FIXTURE: empty discovery must refuse, not pass ───
+EMPTY_DIR="$WORK/empty-ci"
+mkdir -p "$EMPTY_DIR"
+touch "$EMPTY_DIR/not-a-check.txt"  # WHY: present but non-matching, proves the glob (not "dir is empty") is what's checked
+
+RUNNER_ORIGINAL="$(cat "$RUNNER")"
+
+# WHY: strip the empty-set guard block (between the "_fixtures=()" reset and
+# the "--list" branch) to reproduce what run-fixtures.sh looked like before
+# this property existed, then watch it wrongly pass. Restored unconditionally
+# in the trap below even if an assertion here raises.
+restore_runner() {
+    printf '%s' "$RUNNER_ORIGINAL" > "$RUNNER"
+}
+trap 'restore_runner; rm -rf "$WORK"' EXIT
+
+python3 - "$RUNNER" <<'PY'
+import sys
+path = sys.argv[1]
+text = open(path).read()
+start = 'if [[ "${#_fixtures[@]}" -eq 0 ]]; then'
+end = 'fi\n\nif [[ "${1:-}" == "--list" ]]'
+i = text.index(start)
+j = text.index(end)
+open(path, "w").write(text[:i] + text[j + 3:])
+PY
+
+mutated_rc=0
+mutated_out="$(FIXTURE_CI_DIR="$EMPTY_DIR" "$RUNNER" --list 2>&1)" || mutated_rc=$?
+
+restore_runner
+if [[ "$(cat "$RUNNER")" != "$RUNNER_ORIGINAL" ]]; then
+    fail "run-fixtures.sh did not restore byte-identical after the guard-removal mutation -- the real runner is left corrupted"
+fi
+
+if [[ "$mutated_rc" -eq 0 ]]; then
+    : # expected: pre-guard shape vacuously passes on zero discovered fixtures
+else
+    fail "the guard-removed runner was expected to vacuously pass (exit 0) on an empty ci/ dir to prove the guard is the thing preventing it, but exited $mutated_rc: $mutated_out"
+fi
+
+guarded_rc=0
+guarded_out="$(FIXTURE_CI_DIR="$EMPTY_DIR" "$RUNNER" --list 2>&1)" || guarded_rc=$?
+if [[ "$guarded_rc" -eq 0 ]]; then
+    fail "the restored (guarded) runner exited 0 against a ci/ dir with zero check-*.sh/check-*.py files -- vacuous pass, the exact #169 'Fail if the glob matches nothing' regression"
+elif [[ "$guarded_out" != *"vacuous pass"* ]]; then
+    fail "the restored runner correctly failed (exit $guarded_rc) but without the expected 'vacuous pass' message; got: $guarded_out"
+fi
+
+# ── 3. exclusion correctness against the REAL ci/ directory ───────────────
+real_listed="$("$RUNNER" --list)"
+for excluded in check-workflow-template.sh check-xml-output.sh; do
+    if grep -qxF "$excluded" <<<"$real_listed"; then
+        fail "$excluded is a positional-argument fixture (invoked explicitly, with its argument, later in run-fixtures.sh) but appeared in the auto-run --list output -- it would now run twice, once with no argument"
+    fi
+done
+if ! grep -qxF "check-triad-schema.py" <<<"$real_listed"; then
+    fail "check-triad-schema.py (a known real no-arg fixture) is missing from run-fixtures.sh --list against the real ci/ directory"
+fi
+
+if [[ "$FAIL" -eq 0 ]]; then
+    echo '{"checked":"fixture-discovery","status":"pass"}'
+fi
+
+exit "$FAIL"

--- a/ci/check-interactive-contrast-selftest.py
+++ b/ci/check-interactive-contrast-selftest.py
@@ -32,7 +32,12 @@ is the #64 regression and the coverage-scan gap from the PR body's own
 five-mutation list, now committed instead of hand-typed.
 
 NOTE: runs standalone (no consumer site or zola build needed) as part of
-ci/run-fixtures.sh, immediately after the checker it tests.
+ci/run-fixtures.sh. Order relative to check-interactive-contrast.py in that
+run is NOT guaranteed (forkwright/typikon#169: the runner discovers
+ci/check-*.py alphabetically rather than declaring an order, and
+"-selftest.py" sorts before ".py") -- harmless here because Part B invokes
+check-interactive-contrast.py itself as a real subprocess against a
+guaranteed-restored file rather than depending on a prior run's state.
 """
 
 from __future__ import annotations

--- a/ci/check-journal-entry-routing.py
+++ b/ci/check-journal-entry-routing.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""check-journal-entry-routing — regression test for forkwright/typikon#163.
+
+WHY: TEMPLATE_SCHEMA_MAP (bin/typikon-validate) had entries for faq.html and
+sizing-guide.html only. journal-entry.html is a KNOWN_TEMPLATES member -- a
+consumer may set `template = "journal-entry.html"` explicitly, or reach it
+via the #159 page_template cascade, without tripping the fail-closed
+UnregisteredTemplateError -- but because it was absent from
+TEMPLATE_SCHEMA_MAP, classify() never routed it to journal-entry.schema.json
+by template name; only content/journal/<slug>.md's PATH rule reached that
+schema. A page whose effective template is journal-entry.html but whose path
+is NOT content/journal/ (forkwright/ardent-tools-site's content/writing/, the
+exact #159 cascade case) silently fell through to page.schema.json instead --
+the same fail-open shape the #60 consumer-schema-registry work closed for
+truly-custom templates, just left open for this one built-in.
+
+Independently, journal-entry.schema.json's `extra` (additionalProperties:
+false) had no entries for figure, figure_alt, or tier -- real fields
+forkwright/ardent-tools-site's journal-entry content sets (verified directly
+against the live site: content/writing/coordination-that-isnt-voting.md sets
+all three; templates/journal-section.html there groups the listing by
+extra.tier and fails closed if any entry lacks it). Even a page correctly
+routed to journal-entry.schema.json still failed on these three fields.
+
+This proves both fixes, and both together, against the REAL bin/typikon-
+validate CLI (subprocess -- the actual classify()/validate_file()/main()
+path, not a reimplementation):
+
+  1. [REQUIRED NEGATIVE FIXTURE] a leaf page with no template of its own,
+     under a section whose _index.md sets page_template = "journal-entry.html"
+     (a non-canonical section, mirroring ardent-tools-site's content/writing/
+     exactly), with figure/figure_alt/tier extras matching that site's real
+     content -- must validate against journal-entry.schema.json, not
+     page.schema.json.
+  2. the same, with `template = "journal-entry.html"` set directly on the
+     leaf page instead of cascaded -- the Done-when's second named case.
+  3. [isolates the schema-shape half] a page ALREADY routed correctly via the
+     path rule (content/journal/<slug>.md, unaffected by the TEMPLATE_SCHEMA_
+     MAP fix either way) still needs the schema to accept figure/figure_alt/
+     tier.
+  4. extra.figure without extra.figure_alt fails closed (dependentRequired)
+     -- proves the guard's OWN logic links the two fields, not just that
+     each is independently accepted.
+  5. an invalid extra.tier value fails closed (enum) -- proves the tier
+     vocabulary is enforced, not merely documented.
+  6. CONTROL: an existing content/journal/<slug>.md fixture with no figure/
+     tier and no explicit template still validates clean -- the
+     TEMPLATE_SCHEMA_MAP addition must not perturb on-path behavior at all
+     (the issue's own "Verified safe" claim, checked empirically here rather
+     than trusted).
+  7. CONTROL: a genuinely unregistered custom template still raises
+     UnregisteredTemplateError -- the fail-closed net for templates typikon
+     truly does not know is unaffected by adding one more KNOWN entry to
+     TEMPLATE_SCHEMA_MAP.
+
+NOTE: runs standalone (no consumer site needed) as part of ci/run-fixtures.sh.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+THEME_ROOT = Path(__file__).resolve().parent.parent
+VALIDATE = THEME_ROOT / "bin" / "typikon-validate"
+
+# NOTE: mirrors forkwright/ardent-tools-site's real
+# content/writing/coordination-that-isnt-voting.md frontmatter exactly
+# (audience/components/words/words_source are typikon's own required
+# journal-entry extras; figure/figure_alt/tier are the #163 additions).
+REAL_EXTRAS = (
+    'audience = "readers evaluating multi-agent coordination claims"\n'
+    'components = "Why voting and hub-orchestration both fail on hard tasks, '
+    'and a third coordination shape that isn\'t a blend of them."\n'
+    'words = "~1470 words"\n'
+    'words_source = "manual count"\n'
+    'tier = "research"\n'
+    'figure = "img/coordination-shapes.svg"\n'
+    'figure_alt = "Three coordination shapes side by side: vote, where isolated '
+    'agents fan in to an aggregator with no connections between them; hub, where '
+    'a hub farms pieces out to workers and assembles them back with no lateral '
+    'edges; and lateral, where agents influence each other during solve before '
+    'an integrator composes."\n'
+)
+
+
+def write_tree(root: Path, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+
+def run_validate(root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(VALIDATE), str(root)],
+        capture_output=True, text=True, check=False,
+    )
+
+
+# NOTE: each case is (label, files, expected_exit, required_stderr_substrings)
+CASES: list[tuple[str, dict[str, str], int, list[str]]] = [
+    (
+        "leaf page with no template, under a non-canonical section whose "
+        "_index.md cascades page_template=journal-entry.html, with real "
+        "figure/figure_alt/tier extras -- validates as journal-entry, not page",
+        {
+            "content/writing/_index.md": (
+                '+++\ntitle = "Writing"\ntemplate = "journal-section.html"\n'
+                'page_template = "journal-entry.html"\n+++\nbody\n'
+            ),
+            "content/writing/coordination.md": (
+                '+++\ntitle = "Coordination that isn\'t voting"\n'
+                'description = "Voting and hub-orchestration are the two default '
+                'shapes of multi-agent coordination, and why a third needs its own '
+                f'emergence conditions."\ndate = 2026-07-20\n\n[extra]\n{REAL_EXTRAS}+++\nbody\n'
+            ),
+        },
+        0,
+        [],
+    ),
+    (
+        "leaf page setting template=journal-entry.html directly (not cascaded), "
+        "under a non-canonical section -- the Done-when's second named case",
+        {
+            "content/writing/direct.md": (
+                '+++\ntitle = "Directly Templated"\ntemplate = "journal-entry.html"\n'
+                'description = "A leaf page that sets journal-entry.html on itself, '
+                'with no ancestor cascade involved at all."\ndate = 2026-07-21\n\n'
+                f'[extra]\n{REAL_EXTRAS}+++\nbody\n'
+            ),
+        },
+        0,
+        [],
+    ),
+    (
+        "content/journal/<slug>.md (path-based routing, unaffected either way "
+        "by TEMPLATE_SCHEMA_MAP) still needs the schema to accept figure/tier",
+        {
+            "content/journal/entry.md": (
+                '+++\ntitle = "A Journal Entry"\n'
+                'description = "Ordinary path-routed journal entry carrying the '
+                'same real figure/figure_alt/tier extras."\ndate = 2026-07-22\n\n'
+                f'[extra]\n{REAL_EXTRAS}+++\nbody\n'
+            ),
+        },
+        0,
+        [],
+    ),
+    (
+        "extra.figure without extra.figure_alt fails closed (dependentRequired)",
+        {
+            "content/journal/no-alt.md": (
+                '+++\ntitle = "Missing Alt"\ndescription = "A figure with no alt '
+                'text must fail, not silently render an empty alt attribute."\n'
+                'date = 2026-07-23\n\n[extra]\naudience = "readers"\n'
+                'components = "a tag line long enough to pass"\nwords = "~10 words"\n'
+                'words_source = "manual count"\nfigure = "img/x.svg"\n+++\nbody\n'
+            ),
+        },
+        1,
+        ["'figure_alt' is a dependency of 'figure'"],
+    ),
+    (
+        "an invalid extra.tier value fails closed (enum)",
+        {
+            "content/journal/bad-tier.md": (
+                '+++\ntitle = "Bad Tier"\ndescription = "A tier value outside the '
+                'notes/research vocabulary must fail, not pass silently."\n'
+                'date = 2026-07-24\n\n[extra]\naudience = "readers"\n'
+                'components = "a tag line long enough to pass"\nwords = "~10 words"\n'
+                'words_source = "manual count"\ntier = "bogus"\n+++\nbody\n'
+            ),
+        },
+        1,
+        ["'bogus' is not one of"],
+    ),
+    (
+        "CONTROL: an ordinary content/journal/<slug>.md entry with no template, "
+        "no figure, no tier still validates clean -- on-path behavior unperturbed",
+        {
+            "content/journal/plain.md": (
+                '+++\ntitle = "Plain Entry"\ndescription = "An ordinary entry with '
+                'none of the #163 fields set at all, proving the fix changes '
+                'nothing for existing content."\ndate = 2026-07-25\n\n[extra]\n'
+                'audience = "readers"\ncomponents = "a tag line long enough to pass"\n'
+                'words = "~10 words"\nwords_source = "manual count"\n+++\nbody\n'
+            ),
+        },
+        0,
+        [],
+    ),
+    (
+        "CONTROL: a genuinely unregistered custom template still fails closed",
+        {
+            "content/writing/custom.md": (
+                '+++\ntitle = "Custom"\ntemplate = "totally-unregistered.html"\n+++\nbody\n'
+            ),
+        },
+        1,
+        ["totally-unregistered.html", "has no schema registration"],
+    ),
+]
+
+
+def run_cases() -> list[str]:
+    failed = []
+    for label, files, expected_exit, required_substrings in CASES:
+        with tempfile.TemporaryDirectory(prefix="typikon-journal-routing-check-") as tmp:
+            root = Path(tmp)
+            write_tree(root, files)
+            result = run_validate(root)
+            if result.returncode != expected_exit:
+                failed.append(
+                    f"{label}: expected exit {expected_exit}, got {result.returncode}\n"
+                    f"  stdout: {result.stdout.strip()}\n  stderr: {result.stderr.strip()}"
+                )
+                continue
+            missing = [s for s in required_substrings if s not in result.stderr]
+            if missing:
+                failed.append(f"{label}: stderr missing expected substring(s) {missing}\n  stderr: {result.stderr.strip()}")
+    return failed
+
+
+def main() -> int:
+    failed = run_cases()
+    if failed:
+        for line in failed:
+            print(f"FAIL: {line}", file=sys.stderr)
+        return 1
+    print(json.dumps({"checked": len(CASES), "passed": len(CASES), "failed": 0}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/run-fixtures.sh
+++ b/ci/run-fixtures.sh
@@ -5,26 +5,54 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-python3 "$ROOT/ci/check-triad-schema.py"
-python3 "$ROOT/ci/check-consumer-schema-registry.py"
-python3 "$ROOT/ci/check-page-template-cascade.py"
-python3 "$ROOT/ci/check-font-coverage.py"
-python3 "$ROOT/ci/check-release-config.py"
-python3 "$ROOT/ci/check-asset-provenance.py"
-python3 "$ROOT/ci/check-favicon-path.py"
-python3 "$ROOT/ci/check-init-favicon-path.py"
-python3 "$ROOT/ci/check-asset-path-existence.py"
-python3 "$ROOT/ci/check-init-staging-scope.py"
-python3 "$ROOT/ci/check-control-contrast.py"
-python3 "$ROOT/ci/check-home-heading.py"
-python3 "$ROOT/ci/check-content-heading-collision.py"
-python3 "$ROOT/ci/check-interactive-contrast.py"
-python3 "$ROOT/ci/check-interactive-contrast-selftest.py"
+# WHY(forkwright/typikon#169): overridable only so ci/check-fixture-discovery.sh
+# can point discovery at a scratch ci/-shaped directory and exercise the
+# discovery + empty-set guard below without running the real (zola/lychee/
+# pa11y-dependent, slow) fixture suite. Unset in every real invocation, so
+# production behavior always resolves to the ROOT-derived ci/ directory below.
+FIXTURE_CI_DIR="${FIXTURE_CI_DIR:-$ROOT/ci}"
+
+# WHY: these two check-* scripts take positional arguments (a template path,
+# a built-site dir) and are invoked explicitly, with those arguments, further
+# down. The no-arg glob discovery below cannot express that call shape, so
+# each exclusion is named here with the reason it is not auto-run.
+declare -A ARG_TAKING_FIXTURES=(
+    [check-workflow-template.sh]="invoked below with github-workflow.yml.tmpl"
+    [check-xml-output.sh]="invoked below per-example against the built public/ dir"
+)
+
+mapfile -t _discovered < <(
+    find "$FIXTURE_CI_DIR" -maxdepth 1 -type f \( -name 'check-*.sh' -o -name 'check-*.py' \) -printf '%f\n' \
+        | LC_ALL=C sort
+)
+
+# WHY(forkwright/typikon#169 "Fail if the glob matches nothing, rather than
+# reporting a vacuous pass"): a runner that discovers zero fixtures and
+# exits 0 is the empty-keep-set defect class, just in a new shape.
+_fixtures=()
+for _f in "${_discovered[@]}"; do
+    [[ -n "${ARG_TAKING_FIXTURES[$_f]:-}" ]] && continue
+    _fixtures+=("$_f")
+done
+
+if [[ "${#_fixtures[@]}" -eq 0 ]]; then
+    echo "run-fixtures: ci/check-*.sh + ci/check-*.py under $FIXTURE_CI_DIR found ${#_discovered[@]} file(s), ${#ARG_TAKING_FIXTURES[@]} of them excluded (arg-taking) -- 0 left to run. Refusing to report a vacuous pass." >&2
+    exit 1
+fi
+
+if [[ "${1:-}" == "--list" ]]; then
+    printf '%s\n' "${_fixtures[@]}"
+    exit 0
+fi
+
+for _f in "${_fixtures[@]}"; do
+    case "$_f" in
+        *.py) python3 "$FIXTURE_CI_DIR/$_f" ;;
+        *.sh) "$FIXTURE_CI_DIR/$_f" ;;
+    esac
+done
+
 "$ROOT/ci/check-workflow-template.sh" "$ROOT/ci/github-workflow.yml.tmpl"
-"$ROOT/ci/check-consumer-check-extension.sh"
-"$ROOT/ci/check-fixture-corpus-exemption.sh"
-python3 "$ROOT/ci/check-deploy-bundle-gate.py"
-python3 "$ROOT/ci/check-cf-deploy-gate.py"
 
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-blog"
 "$ROOT/bin/typikon-check" "$ROOT/examples/sample-shop"

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -10,6 +10,7 @@ JSON Schema definitions for every content type a typikon-consuming site can auth
 |----------------------------------------------------------|------------------------------|
 | frontmatter `template = "faq.html"`                     | faq                            |
 | frontmatter `template = "sizing-guide.html"`             | sizing-guide                   |
+| frontmatter `template = "journal-entry.html"`            | journal-entry                  |
 | frontmatter `template` matches a `schemas/registry.toml` `template` entry | that entry's consumer schema |
 | `_index.md` (root or section)                           | section                        |
 | `journal/<slug>.md`                                     | journal-entry                  |
@@ -142,9 +143,11 @@ list_caption = "Newest at top."
 
 ## journal-entry (`schemas/journal-entry.schema.json`)
 
-Pages under `content/journal/` (excluding `_index.md`). Stricter than page: requires `description`, `date`, and the entry-level extras so the auto-generated journal listing renders cleanly.
+Pages under `content/journal/` (excluding `_index.md`), OR any page whose effective `template` — explicit or resolved through the `page_template` cascade (see the routing table above) — is `journal-entry.html`, regardless of its path. Stricter than page: requires `description`, `date`, and the entry-level extras so the auto-generated journal listing renders cleanly.
 
 **Required:** `title`, `description`, `date`, `extra.audience`, `extra.components`, `extra.words`, `extra.words_source`.
+
+**Optional `[extra]`:** `seo_title`, `body_class`, `og_image`, `og_type`, `author`, `skip_sitemap`, `figure`, `figure_alt`, `tier`.
 
 **Constraints:**
 - description: 20–200 chars
@@ -153,6 +156,10 @@ Pages under `content/journal/` (excluding `_index.md`). Stricter than page: requ
 - extra.components: 5–120 chars (the conceptual-tags line)
 - extra.words: matches `^~?\d+( words)?$`
 - extra.words_source: 3–200 chars. Source for the rendered word-count claim
+- extra.og_image: ends in `.svg|.png|.jpg|.webp`
+- extra.figure: ends in `.svg|.png|.jpg|.webp`. Not consumed by typikon's own stock `journal-entry.html` — a consumer shadow template renders it as furniture above the entry body (forkwright/typikon#163)
+- extra.figure_alt: 5–500 chars. **Required whenever `extra.figure` is set** (enforced via `dependentRequired`, not just documented)
+- extra.tier: one of `notes | research`. Not consumed by typikon's own stock `journal-section.html` — a consumer shadow template that groups its listing by tier reads it (forkwright/typikon#163)
 
 **Example:**
 

--- a/schemas/journal-entry.schema.json
+++ b/schemas/journal-entry.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/forkwright/typikon/schemas/journal-entry.schema.json",
   "title": "typikon journal entry",
-  "description": "Frontmatter contract for a journal entry (content/journal/<slug>.md). Stricter than the page schema: date and the entry-level extras are required so the auto-generated journal-section listing renders cleanly.",
+  "description": "Frontmatter contract for a journal entry: content/journal/<slug>.md, or any page whose effective template (explicit or page_template-cascaded) is journal-entry.html. Stricter than the page schema: date and the entry-level extras are required so the auto-generated journal-section listing renders cleanly.",
   "type": "object",
   "required": ["title", "description", "date", "extra"],
   "additionalProperties": false,
@@ -52,7 +52,26 @@
         "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|webp)$" },
         "og_type": { "type": "string", "enum": ["website", "article", "profile"] },
         "author": { "type": "string", "description": "Per-entry author override; falls back to config.extra.author.name." },
-        "skip_sitemap": { "type": "boolean", "description": "Exclude this entry from sitemap.xml." }
+        "skip_sitemap": { "type": "boolean", "description": "Exclude this entry from sitemap.xml." },
+        "figure": {
+          "type": "string",
+          "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|webp)$",
+          "description": "Optional orienting image rendered as furniture above the entry body, never inside page.content (so the Atom feed carries no asset dependency). Not consumed by typikon's own stock journal-entry.html; a consumer shadow template renders it (see forkwright/typikon#163)."
+        },
+        "figure_alt": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 500,
+          "description": "Accessible description of extra.figure. A diagram description runs long by nature, so the ceiling sits well above a typical alt-text bound rather than at the shorter bound used elsewhere in this schema family (e.g. product.schema.json's images[].alt)."
+        },
+        "tier": {
+          "type": "string",
+          "enum": ["notes", "research"],
+          "description": "Weight class for a consumer that groups its journal listing by tier instead of one flat date-sorted list. Not consumed by typikon's own stock journal-section.html, which lists chronologically regardless of tier."
+        }
+      },
+      "dependentRequired": {
+        "figure": ["figure_alt"]
       }
     }
   }


### PR DESCRIPTION
## Summary

Two fixes, bundled per the assigned unit:

1. **#169** — `ci/run-fixtures.sh` derives its no-arg fixture set from the filesystem (`ci/check-*.sh`, `ci/check-*.py`, sorted deterministically) instead of hand-listing every fixture. Adding a fixture is now just adding a file — no shared line left to conflict on.
2. **#163** — `TEMPLATE_SCHEMA_MAP` now routes `journal-entry.html` (explicit or `page_template`-cascaded) to `journal-entry.schema.json`, and that schema now accepts the real `figure`/`figure_alt`/`tier` extras `forkwright/ardent-tools-site`'s journal content actually sets.

Both defects were confirmed still live on `origin/main` before any change (see "Confirmed live" below).

## #169 — derive the fixture list

**Confirmed live:** `ci/run-fixtures.sh` on `origin/main` hand-lists 19 no-arg fixtures as literal `python3 "$ROOT/ci/check-X.py"` / `"$ROOT/ci/check-X.sh"` lines — verified `grep -c check-issue169-demo ci/run-fixtures.sh` (a not-yet-existing name) returns `0` on the shipped file, i.e. the runner's exact executable text has zero mechanism to notice a new fixture.

### Mechanism

`ci/run-fixtures.sh:24-27` — `find "$FIXTURE_CI_DIR" -maxdepth 1 -type f \( -name 'check-*.sh' -o -name 'check-*.py' \) -printf '%f\n' | LC_ALL=C sort`. `FIXTURE_CI_DIR` defaults to `$ROOT/ci` in every real invocation (`run-fixtures.sh:13`) and exists only so the new regression test can point discovery at a scratch directory without ever running the real zola/lychee/pa11y-dependent suite.

Two fixtures (`check-workflow-template.sh`, `check-xml-output.sh`) take positional arguments the glob can't express — named in `ARG_TAKING_FIXTURES` (`run-fixtures.sh:19-22`) with the reason each is excluded, and still invoked explicitly, with their arguments, further down (`run-fixtures.sh:55, 69-70`). An explicit skip-list with a stated reason, per the issue's own "worth specifying" note — one line per exception, not one line per fixture.

### Done when (from the issue) — checked against this diff

- **"`ci/run-fixtures.sh` discovers its fixtures from the filesystem"** — `ci/run-fixtures.sh:24-27`.
- **"adding a fixture file requires no edit to the runner"** — `ci/check-fixture-discovery.sh:52-67` drops a new `check-selftest-probe.sh` into a scratch dir, runs the real `run-fixtures.sh --list` against it, asserts the new name appears AND that the runner's own sha256 is unchanged before/after (`run-fixtures.sh:58-65`). Also demonstrated directly against the real `ci/` dir during development: dropped `ci/check-issue169-demo.sh` in, `run-fixtures.sh --list` picked it up immediately, `git diff --stat -- ci/run-fixtures.sh` showed zero further change to the runner; removed the demo file afterward (not shipped).
- **"the runner fails rather than passing when it discovers none"** — `ci/run-fixtures.sh:38-41`. `check-fixture-discovery.sh:69-116` is the required negative fixture (below).
- **"two branches each adding a fixture no longer conflict"** — structural consequence of the first two: a branch that adds a fixture adds a new file under `ci/` and touches zero lines of `run-fixtures.sh`. Two such branches have disjoint diffs on the one file that used to collide.

### Negative fixture

> Negative fixture: `ci/check-fixture-discovery.sh` — watched failing by mutating the real, shipped `ci/run-fixtures.sh` in place (stripping just the empty-set guard block, lines 38-41) and running `FIXTURE_CI_DIR=<scratch-dir-with-zero-check-files> ci/run-fixtures.sh --list`, which produced empty output and `exit 0` (the exact vacuous pass #169 warns against) before the fix; restored the runner byte-identical (verified via `sha256sum` equality) and re-ran the same command, which now produces `run-fixtures: ci/check-*.sh + ci/check-*.py under <dir> found 0 file(s), 2 of them excluded (arg-taking) -- 0 left to run. Refusing to report a vacuous pass.` and `exit 1`. This exact mutate/watch/restore sequence is wired into `ci/check-fixture-discovery.sh` (section 2, `run-fixtures.sh:69-116` in the test) so it runs on every future push, not just once by hand.

Also verified: `check-fixture-discovery.sh` section 3 (`run-fixtures.sh:118-127`) asserts `check-workflow-template.sh`/`check-xml-output.sh` are excluded from the real `--list` output (else they'd run twice — once bare, once with their argument) and that a known real fixture (`check-triad-schema.py`) is present.

### Side fix

`ci/check-interactive-contrast-selftest.py`'s docstring claimed it runs "immediately after the checker it tests" — true under the old hand-list, false under alphabetical discovery (`-selftest.py` sorts before `.py`; confirmed with `LC_ALL=C sort`). Corrected the comment rather than leaving a stale ordering claim; harmless in practice since Part B of that fixture invokes `check-interactive-contrast.py` itself as a real subprocess against a guaranteed-restored file, not a prior run's state.

## #163 — journal-entry.html routing + schema shape

**Confirmed live**, both halves, against `origin/main`'s `bin/typikon-validate`:

```
$ python3 ci/check-journal-entry-routing.py   # run against unmodified origin/main
FAIL: leaf page with no template, under a non-canonical section whose _index.md cascades
page_template=journal-entry.html, with real figure/figure_alt/tier extras -- validates as
journal-entry, not page: expected exit 0, got 1
  stderr: {"file": "content/writing/coordination.md", "schema": "page", "pointer": "/extra",
  "error": "Unevaluated properties are not allowed ('components', 'figure', 'figure_alt',
  'tier', 'words', 'words_source' were unexpected)"}
... (4 more failures; 5 of 7 cases fail, the 2 controls pass)
```

Applying **only** the `TEMPLATE_SCHEMA_MAP` fix moved the failure from `"schema": "page"` to `"schema": "journal-entry"`, still failing on `('figure', 'figure_alt', 'tier' were unexpected)` — the two defects are independent and both real, exactly as the issue's "two compounding gaps" framing says.

### Fixes

- `bin/typikon-validate:97-101` — `TEMPLATE_SCHEMA_MAP["journal-entry.html"] = "journal-entry"`. Docstring table (`bin/typikon-validate:22-27`) updated to match.
- `schemas/journal-entry.schema.json:56-75` — `figure` (asset-path pattern, reused verbatim from the existing `og_image` pattern in the same file), `figure_alt` (5-500 chars — real content runs to 308 chars, so the bound sits above the shorter alt-text bound used elsewhere in this schema family, e.g. `product.schema.json`'s `images[].alt` at 200), `tier` (enum `notes | research` — the exact two values `ardent-tools-site`'s `journal-section.html` shadow groups by), and `dependentRequired: {figure: [figure_alt]}` so an image without alt text fails closed instead of silently rendering `alt=""`.
- `docs/SCHEMAS.md` + the schema's own `$id`-adjacent `description` — brought back in sync with both the new routing rule and the newly-optional extras (this file already omitted the pre-existing optional extras `seo_title`/`body_class`/`og_image`/`og_type`/`author`/`skip_sitemap` too; added the complete list rather than just the three new ones).

**Field shapes are not guessed.** `figure`/`figure_alt`/`tier` are consumed by NEITHER of typikon's own stock `journal-entry.html`/`journal-section.html` templates (verified: `grep -rn "extra\.figure\|extra\.tier" templates/` on this repo returns nothing) — they're rendered by `forkwright/ardent-tools-site`'s own shadow templates. Read that consumer's real shadow templates and real content directly (`~/metis-ops/projects/ardent-tools-site/templates/journal-entry.html:37-44`, `journal-section.html:1-7,25-27`, `content/writing/coordination-that-isnt-voting.md`) rather than inventing shapes — the issue's own "read the template before guessing shapes" instruction, applied to the template that actually renders these fields.

### Done when (from the issue) — checked against this diff

> "a leaf page under a non-canonical section whose ancestor sets `page_template = "journal-entry.html"` (or a page setting `template = "journal-entry.html"` directly), with `figure`/`figure_alt`/`tier` extras matching forkwright/ardent-tools-site's real content, validates clean against `journal-entry.schema.json` — verified by a fixture case that fails on the current schema/map and passes once both are corrected."

- Cascade case: `ci/check-journal-entry-routing.py` case 1 (`ci/check-journal-entry-routing.py:106-124`) — ancestor `_index.md` sets `page_template = "journal-entry.html"`, leaf sets none, extras mirror `ardent-tools-site`'s real `coordination-that-isnt-voting.md` byte-for-byte in content.
- Direct-template case: case 2 (`:125-138`) — `template = "journal-entry.html"` set directly on the leaf, no ancestor cascade involved.
- Both fail on unmodified `origin/main` (shown above) and pass once `bin/typikon-validate:97-101` + `schemas/journal-entry.schema.json:56-75` are both applied — confirmed by the three-checkpoint run above (baseline fail → routing-only-fixed still fails on schema → both-fixed passes, all 7/7 cases).

### Negative fixture

> Negative fixture: `ci/check-journal-entry-routing.py` — watched failing by `python3 ci/check-journal-entry-routing.py` against unmodified `origin/main`, which produced `FAIL: ... expected exit 0, got 1` on 5 of 7 cases (both routing cases and the schema-shape case) with the exact `Unevaluated properties are not allowed ('figure', 'figure_alt', 'tier' ...)` / `"schema": "page"` errors quoted above, before the fix, and `{"checked": 7, "passed": 7, "failed": 0}` / exit 0 after both `bin/typikon-validate` and `schemas/journal-entry.schema.json` are corrected. Also covers, as genuine fail-closed guards (not just "field accepted"): `extra.figure` without `extra.figure_alt` fails on `'figure_alt' is a dependency of 'figure'` (case 4, `dependentRequired` fires, not just documentation); an invalid `extra.tier` fails on `'bogus' is not one of ['notes', 'research']` (case 5, enum fires); and two controls confirming the fix perturbs nothing pre-existing (an ordinary `content/journal/*.md` entry with none of these fields, and a genuinely-unregistered custom template still raising `UnregisteredTemplateError`).

## Self-check against the fleet's own "fix carries the bug class" pattern

- **Error path**: `dependentRequired` is JSON-Schema-native, evaluated by the same `Draft202012Validator.iter_errors` call every other constraint in this file goes through (`bin/typikon-validate:419`) — no separate code path to diverge from the rest of the schema's enforcement.
- **Write path / guard's own logic**: is the guard reachable by every route, or only some? `TEMPLATE_SCHEMA_MAP` is checked first in `classify()` (`bin/typikon-validate:315-316`), before any path-based fallback — so both the cascade-resolved and the explicitly-set `template = "journal-entry.html"` cases hit it identically (verified by cases 1 and 2 both passing, not just one). Confirmed the addition doesn't loosen the fail-closed net elsewhere: an actually-unregistered template still raises `UnregisteredTemplateError` (case 7, control) — `KNOWN_TEMPLATES` already contained `journal-entry.html` before this PR, so that fail-closed boundary is unmoved.
- **On-path regression**: an ordinary `content/journal/<slug>.md` entry with no `template` set and none of the three new fields still validates identically before and after (case 6, control) — the issue's own "Verified safe" claim, checked empirically here rather than trusted.
- For #169: the empty-set guard is the shipped code path itself (not a copy) exercised via `FIXTURE_CI_DIR`, and the mutate-then-restore proof in `check-fixture-discovery.sh` re-verifies the runner is byte-identical after restoration before trusting anything downstream of it — so a future accidental removal of the guard is caught by the SAME assertion this PR's own development used to prove the guard exists.

## Verification run locally

`kanon lint . --all`: clean, 0 findings across the repo. All 21 no-arg fixtures discovered by the new `run-fixtures.sh --list` run individually and pass (the 19 pre-existing + the 2 new ones this PR adds, auto-discovered with zero edits to the runner) — including `check-page-template-cascade.py` (13/13) and `check-consumer-schema-registry.py` (15/15), confirming no regression in the #159/#60 machinery this PR routes through. `check-workflow-template.sh` (the one arg-taking fixture not needing a zola build) also passes. Did not run the two zola-build-dependent stages (`typikon-check` on the example sites, `check-xml-output.sh`) locally per this box's no-full-build constraint — CI will grade those for real.

**verda-build gate**: attempted (`ssh verda-build '~/gate-repo.sh typikon fix/169-derive-fixture-list'`) — `fixtures-gate` fails there on `zola not on PATH`. Checked this is a pre-existing box gap, not something this branch introduced: `/tmp/gate-typikon-main.log` and `/tmp/gate-typikon-chore-align-rust-toolchain.log` on the same box both fail `fixtures-gate` too, on a *different* missing dependency (`jsonschema package required`) — i.e. `ci/run-fixtures.sh`'s zola/jsonschema toolchain has never once been fully provisioned on this particular verda-build worktree, across three separate branches including unmodified `main`. GitHub Actions installs zola explicitly (`.github/workflows/gate-attestation.yml`) and is the real gate for this public repo.

Closes #169
Closes #163
