### PR TITLE
fix(bin,ci,schemas,templates): resolve 16 low-severity correctness and claim-accuracy defects

### DIFF
--- a/bin/typikon-check
+++ b/bin/typikon-check
@@ -101,9 +101,14 @@ emit() {
 }
 
 base_host() {
+    # NOTE: TOML permits both basic ("...") and literal ('...') strings for
+    # base_url. Matching only the double-quoted form left a single-quoted
+    # value unsubstituted, so the raw `base_url = '...'` line fell through
+    # untouched to the trailing-slash/scheme/path strips below, none of
+    # which match a line starting with `base_url` (forkwright/typikon#92).
     grep -E '^base_url\s*=' config.toml \
         | head -1 \
-        | sed -E 's/^base_url\s*=\s*"([^"]+)".*/\1/' \
+        | sed -E 's/^base_url\s*=\s*["'"'"']([^"'"'"']+)["'"'"'].*/\1/' \
         | sed 's:/$::' \
         | sed -E 's|^https?://||' \
         | sed -E 's|/.*$||'

--- a/bin/typikon-init
+++ b/bin/typikon-init
@@ -88,7 +88,13 @@ if [[ ! -d themes/typikon/.git && ! -f themes/typikon/theme.toml ]]; then
     git config submodule.themes/typikon.url "$THEME_REPO"
     git -C themes/typikon remote set-url origin "$THEME_REPO"
 else
-    (cd themes/typikon && git pull --ff-only origin main 2>/dev/null) || true
+    # WARNING: must not be `set -e`-fatal — an offline/unreachable forge on
+    # a re-run must not abort the whole scaffold over an already-checked-out
+    # submodule — but the prior `2>/dev/null || true` converted EVERY
+    # failure into silent success with no trace anywhere (forkwright/typikon#92).
+    if ! PULL_OUTPUT="$(cd themes/typikon && git pull --ff-only origin main 2>&1)"; then
+        echo "warn   themes/typikon: refresh failed, continuing with existing checkout: ${PULL_OUTPUT//$'\n'/ }" >&2
+    fi
 fi
 
 # INVARIANT: OWN_OUTPUTS accumulates only the paths THIS invocation
@@ -128,10 +134,13 @@ write_if_absent() {
     fi
 }
 
-# Copy templates from typikon (always refresh the .tmpl-derived instances —
-# consumers should treat _headers and _redirects as derived files, not
-# hand-edited; per-site deltas go in a sibling _headers.local file or in
-# direct edits the operator commits manually).
+# Copy templates from typikon (create-if-absent — same model as
+# write_if_absent above, not a refresh). _headers/_redirects are
+# scaffolded here ONCE; typikon-refresh deliberately does not re-render
+# them on a later bump (see its own header), so they are the operator's
+# to hand-edit from this point on. That is the opposite of
+# .kanon-ci.toml / the GitHub workflow, which typikon-refresh DOES treat
+# as fully derived and re-renders every bump.
 copy_template() {
     local src="$1"
     local dest="$2"

--- a/bin/typikon-validate
+++ b/bin/typikon-validate
@@ -56,9 +56,12 @@ Output:
 
 Exit codes:
     0 — all files valid
-    1 — at least one file invalid
-    2 — runtime error (missing schemas, malformed frontmatter, malformed
-        registry.toml, etc.)
+    1 — at least one file invalid, INCLUDING malformed frontmatter — a
+        parse failure is reported as a per-file failure record (Output,
+        below) exactly like a schema-validation failure, not as the
+        top-level {"error": ...} + exit-2 shape below
+    2 — runtime error unrelated to any single file's content (missing or
+        malformed schema files, malformed registry.toml, etc.)
 """
 
 from __future__ import annotations
@@ -420,7 +423,13 @@ def validate_file(
     validator = Draft202012Validator(schema, registry=jsonschema_registry, format_checker=FORMAT_CHECKER)
     failures = []
     for err in sorted(validator.iter_errors(fm), key=lambda e: e.path):
-        pointer = "/" + "/".join(str(p) for p in err.absolute_path)
+        # NOTE: RFC 6901's root pointer is "" (the empty string), not "/" —
+        # "/" addresses the member keyed by the empty string, a different
+        # location. err.absolute_path is empty for exactly the most common
+        # top-level failure (a missing required top-level field), so the
+        # unconditional "/" + join() previously emitted "/" for that case.
+        segments = [str(p) for p in err.absolute_path]
+        pointer = "/" + "/".join(segments) if segments else ""
         failures.append({
             "file": file_label,
             "schema": schema_name,
@@ -483,7 +492,11 @@ def load_schemas() -> tuple[dict[str, dict], Registry]:
         if not p.exists():
             print(json.dumps({"error": f"missing schema: {p}"}), file=sys.stderr)
             sys.exit(2)
-        schema = json.loads(p.read_text(encoding="utf-8"))
+        try:
+            schema = json.loads(p.read_text(encoding="utf-8"))
+        except Exception as exc:
+            print(json.dumps({"error": f"malformed schema {p}: {exc}"}), file=sys.stderr)
+            sys.exit(2)
         _refuse_unsupported_formats(schema, slug)
         schemas[slug] = schema
         resources.append((schema["$id"], Resource.from_contents(schema, default_specification=DRAFT202012)))
@@ -493,7 +506,11 @@ def load_schemas() -> tuple[dict[str, dict], Registry]:
         if not p.exists():
             print(json.dumps({"error": f"missing core schema: {p}"}), file=sys.stderr)
             sys.exit(2)
-        core = json.loads(p.read_text(encoding="utf-8"))
+        try:
+            core = json.loads(p.read_text(encoding="utf-8"))
+        except Exception as exc:
+            print(json.dumps({"error": f"malformed core schema {p}: {exc}"}), file=sys.stderr)
+            sys.exit(2)
         _refuse_unsupported_formats(core, f"{slug}.core")
         resources.append((core["$id"], Resource.from_contents(core, default_specification=DRAFT202012)))
 

--- a/ci/check-consumer-check-extension.sh
+++ b/ci/check-consumer-check-extension.sh
@@ -29,8 +29,7 @@ set -euo pipefail
 #      errors out when a consumer simply doesn't use the extension point
 #      is the opposite defect and just as real.
 #
-# Usage:
-#     ci/check-consumer-check-extension.sh
+# NOTE: usage — ci/check-consumer-check-extension.sh
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GH_TMPL="$ROOT/ci/github-workflow.yml.tmpl"

--- a/ci/csp-enforce.sh
+++ b/ci/csp-enforce.sh
@@ -63,7 +63,12 @@ SCAN_ERR="$(mktemp)"
 trap 'rm -f "$SCAN_ERR"' EXIT
 
 status=0
-python3 "$SCRIPT_DIR/csp-scan.py" "${FILES[@]}" 2>"$SCAN_ERR" || status=$?
+# NOTE: paths go over stdin, not argv — an execve() argv list has a kernel-
+# enforced size ceiling (E2BIG), and FILES here is every *.html under a
+# built site with no upper bound on count. `printf` is a bash builtin (no
+# execve of its own), so building this list never itself risks the limit
+# it exists to avoid (forkwright/typikon#92).
+printf '%s\n' "${FILES[@]}" | python3 "$SCRIPT_DIR/csp-scan.py" 2>"$SCAN_ERR" || status=$?
 
 if [[ $status -eq 2 ]]; then
     cat "$SCAN_ERR" >&2

--- a/ci/csp-scan.py
+++ b/ci/csp-scan.py
@@ -9,10 +9,17 @@ are never flagged — only inline bodies and inline attribute values are.
 
 Usage:
     ci/csp-scan.py <file> [<file> ...]
+    ci/csp-scan.py < <(printf '%s\n' <file> ...)   # newline-delimited paths on stdin
+
+WHY stdin too: a caller with a large discovered file list (csp-enforce.sh
+scanning an entire built site) risks E2BIG passing that list as argv to an
+execve() — a limit stdin has no equivalent of. argv still works for direct/
+small invocations; it takes precedence when non-empty.
 
 Exit:
     0  no violations
     1  violations found (each printed to stderr as "<path>:<line>: <detail>")
+    2  invocation error (no paths given on argv or stdin)
 """
 
 from __future__ import annotations
@@ -104,12 +111,21 @@ def scan(path: str) -> list[tuple[int, str]]:
 
 
 def main(argv: list[str]) -> int:
-    if not argv:
-        print("usage: ci/csp-scan.py <file> [<file> ...]", file=sys.stderr)
+    if argv:
+        paths = argv
+    else:
+        # WHY not sys.stdin.isatty()-gated: an empty/closed stdin (a
+        # direct interactive invocation with no argv) falls through to
+        # an empty paths list either way, hitting the same "no paths"
+        # error below rather than blocking on a read.
+        paths = [line.rstrip("\n") for line in sys.stdin if line.strip()]
+
+    if not paths:
+        print("usage: ci/csp-scan.py <file> [<file> ...] (or newline-delimited paths on stdin)", file=sys.stderr)
         return 2
 
     total = 0
-    for path in argv:
+    for path in paths:
         for line, detail in scan(path):
             print(f"{path}:{line}: {detail}", file=sys.stderr)
             total += 1

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -38,7 +38,7 @@ stages = [
 cmd = """
 set -euo pipefail
 ZOLA_SHA256=0ca09aa40376aaa9ddfb512ff9ad963262ef95edb0d0f2d5ec6961b6f5cf22ef
-curl -L "https://github.com/getzola/zola/releases/download/v{{ ZOLA_VERSION }}/zola-v{{ ZOLA_VERSION }}-x86_64-unknown-linux-gnu.tar.gz" -o zola.tar.gz
+curl -L --proto '=https' --tlsv1.2 "https://github.com/getzola/zola/releases/download/v{{ ZOLA_VERSION }}/zola-v{{ ZOLA_VERSION }}-x86_64-unknown-linux-gnu.tar.gz" -o zola.tar.gz
 echo "${ZOLA_SHA256}  zola.tar.gz" | sha256sum -c
 tar -xzf zola.tar.gz
 mkdir -p .kanon-ci/bin
@@ -72,7 +72,7 @@ LYCHEE_SHA256=1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
 # consumer ardent-tools-site already locks in its package.json.
 npm install -g pa11y-ci@4.1.1 @playwright/test@1.61.1
 npx playwright install --with-deps chromium
-curl -L "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" -o lychee.tar.gz
+curl -L --proto '=https' --tlsv1.2 "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" -o lychee.tar.gz
 echo "${LYCHEE_SHA256}  lychee.tar.gz" | sha256sum -c
 mkdir -p lychee-extract .kanon-ci/bin
 tar -xzf lychee.tar.gz -C lychee-extract --strip-components=1

--- a/ci/lychee.toml
+++ b/ci/lychee.toml
@@ -8,8 +8,12 @@
 # triggers rate-limit responses that look like link rot but aren't.
 max_concurrency = 4
 
-# Cache successful checks between CI runs to avoid hammering targets.
-# CI workflows persist .lychee_cache/ across runs.
+# NOTE: neither ci/github-workflow.yml.tmpl nor ci/kanon-ci.toml.tmpl
+# persists .lychee_cache/ across runs (no actions/cache step, no forge
+# equivalent) — every CI run starts from an empty cache, so max_cache_age
+# governs nothing outside a single invocation today. cache=true still
+# dedupes repeat hits to the SAME url within one run (multiple pages
+# linking the same external target), which is why it stays on.
 cache = true
 max_cache_age = "7d"
 

--- a/schemas/journal-entry.schema.json
+++ b/schemas/journal-entry.schema.json
@@ -49,7 +49,7 @@
         },
         "seo_title": { "type": "string", "maxLength": 80 },
         "body_class": { "type": "string", "pattern": "^[a-z][a-z0-9 -]*$" },
-        "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|webp)$" },
+        "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|jpeg|webp)$" },
         "og_type": { "type": "string", "enum": ["website", "article", "profile"] },
         "author": { "type": "string", "description": "Per-entry author override; falls back to config.extra.author.name." },
         "skip_sitemap": { "type": "boolean", "description": "Exclude this entry from sitemap.xml." }

--- a/schemas/page.core.schema.json
+++ b/schemas/page.core.schema.json
@@ -61,7 +61,7 @@
         },
         "og_image": {
           "type": "string",
-          "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|webp)$",
+          "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|jpeg|webp)$",
           "description": "Path under static/ (e.g. 'img/og-cover.png'). get_url() resolves to absolute."
         },
         "og_type": {

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -22,8 +22,27 @@
     <link href="{{ config.base_url | safe }}"/>
     <generator uri="https://www.getzola.org/">Zola</generator>
     {%- if pages | length > 0 -%}
-    {%- set newest = pages | sort(attribute="date") | last -%}
-    {%- set feed_updated = newest.updated | default(value=newest.date) -%}
+    {# WHY a full scan instead of `sort(attribute="date") | last`: the
+       feed's <updated> must be the most recent EDIT across every entry,
+       and one entry's most recent edit is `updated` when set, `date`
+       otherwise (forkwright/typikon#92). Sorting by `date` alone and then
+       reading THAT entry's `updated` misses an older-dated entry whose
+       own `updated` is more recent than the newest-dated entry's own —
+       exactly the case <updated> exists to surface. set_global (not
+       set) is required so an assignment inside the for loop survives
+       past that iteration; date(format="%s") | int turns each value
+       into an epoch integer because Tera's `>` only compares numbers,
+       never date/string values directly. #}
+    {%- set_global feed_updated_ts = 0 -%}
+    {%- set_global feed_updated = "" -%}
+    {%- for p in pages -%}
+    {%- set p_updated = p.updated | default(value=p.date) -%}
+    {%- set p_ts = p_updated | date(format="%s") | int -%}
+    {%- if p_ts > feed_updated_ts -%}
+    {%- set_global feed_updated_ts = p_ts -%}
+    {%- set_global feed_updated = p_updated -%}
+    {%- endif -%}
+    {%- endfor -%}
     {%- else -%}
     {# No dated entries to derive updated from (e.g. a shop with no
        journal) — fall back to Zola's last_updated, then now(), to keep

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,8 +5,27 @@
      and section.html override `title_text`, `description_text`, etc.
      base.html does not access `page.*` or `section.*` directly so it works
      in every rendering context.
+
+   WHY the assert import below (forkwright/typikon#92): Tera resolves a
+   macro namespace by which TEMPLATE an include tag is textually written
+   in, not by the included partial's own imports, once that block is
+   reached via extends plus a child's super() call (verified: a flat
+   include honors the partial's own import; the identical include inside
+   an inherited block that a child renders via super() does not — Tera
+   attributes it to base.html regardless of which child called super()).
+   partials/ld-organization.html is included directly in the ld_json
+   block below and calls assert::required; every child template's own
+   super() call would otherwise fail exactly the way an unimported macro
+   namespace does.
+
+   WARNING: this file tolerates only ONE leading comment block before its
+   import statements — Tera's parser rejects a second, separate leading
+   comment block ahead of an import with a parse error naming the import
+   line (verified), so any addition here must stay inside this single
+   comment, never a new one placed above the imports.
 #}
 {% import "partials/ld-breadcrumb.html" as crumb %}
+{% import "partials/assert.html" as assert %}
 <!DOCTYPE html>
 <html lang="{{ lang | default(value="en") }}">
 <head>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -40,8 +40,22 @@
   {%- endif %}
 
   <dl class="faq-list">
+    {#- WHY the seen-anchor dedup: two questions (explicit anchor or
+       slugify(item.q)) that resolve to the same string previously
+       produced two elements with the identical `id`, which is invalid
+       HTML and makes the SECOND element the only one any fragment link
+       to that id can ever reach (forkwright/typikon#92). set_global is
+       required for `faq_seen_anchors` to survive across loop
+       iterations — a plain `set` re-initializes on every pass. #}
+    {%- set_global faq_seen_anchors = [] -%}
     {%- for item in page.extra.questions %}
-    {%- set anchor = item.anchor | default(value=item.q | slugify) %}
+    {%- set base_anchor = item.anchor | default(value=item.q | slugify) -%}
+    {%- if base_anchor in faq_seen_anchors -%}
+    {%- set anchor = base_anchor ~ "-" ~ loop.index -%}
+    {%- else -%}
+    {%- set anchor = base_anchor -%}
+    {%- endif -%}
+    {%- set_global faq_seen_anchors = faq_seen_anchors | concat(with=anchor) -%}
     <div class="faq-item" id="{{ anchor }}">
       <dt class="faq-question">
         <a href="#{{ anchor }}" class="faq-anchor">{{ item.q }}</a>

--- a/templates/journal-entry.html
+++ b/templates/journal-entry.html
@@ -13,7 +13,12 @@
 {% extends "page.html" %}
 {% import "partials/assert.html" as assert %}
 
-{% block og_type %}article{% endblock og_type %}
+{# NOTE: no og_type block override here (forkwright/typikon#92) — a prior
+   hardcoded `{% block og_type %}article{% endblock %}` silently discarded
+   page.extra.og_type, the same settable field journal-entry.schema.json
+   declares and page.html's own block already reads correctly:
+   `page.extra.og_type | default(value="article")`. Inheriting that block
+   keeps the identical default while letting the override through. #}
 
 {% block ld_json %}
   {%- include "partials/ld-organization.html" -%}

--- a/templates/partials/ld-article.html
+++ b/templates/partials/ld-article.html
@@ -11,6 +11,7 @@
      config.title       — publisher name
 #}
 {% import "partials/assert.html" as assert %}
+{% import "partials/ld-json.html" as ldjson %}
 {{ assert::required(ok=page.title is defined and page.title, field="page.title", template="partials/ld-article.html") }}
 {{ assert::required(ok=page.description is defined and page.description, field="page.description", template="partials/ld-article.html") }}
 {{ assert::required(ok=page.date is defined and page.date, field="page.date", template="partials/ld-article.html") }}
@@ -18,29 +19,35 @@
 {%- set author_name = page.extra.author | default(value=config.extra.author.name) | default(value=config.title) -%}
 {%- set image_url = "" -%}
 {%- if page.extra.og_image -%}
-  {%- set image_url = config.base_url ~ "/" ~ page.extra.og_image -%}
+  {#- get_url(), not hand string-concatenation (forkwright/typikon#92):
+     matches the visible <meta property="og:image"> resolution in
+     base.html/page.html for the identical field, and normalizes
+     base_url/path joining the way a hand `~ "/" ~` join does not (a
+     trailing-slash base_url — a real consumer misconfiguration — joins
+     into a broken double-slash URL under raw concatenation). -#}
+  {%- set image_url = get_url(path=page.extra.og_image, trailing_slash=false) -%}
 {%- endif -%}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "headline": {{ page.title | json_encode | safe }},
-  "description": {{ page.description | json_encode | safe }},
-  "url": {{ page.permalink | json_encode | safe }},
-  "datePublished": {{ page.date | json_encode | safe }},
+  "headline": {{ ldjson::str(value=page.title) }},
+  "description": {{ ldjson::str(value=page.description) }},
+  "url": {{ ldjson::str(value=page.permalink) }},
+  "datePublished": {{ ldjson::str(value=page.date) }},
   "author": {
     "@type": "Person",
-    "name": {{ author_name | json_encode | safe }}
+    "name": {{ ldjson::str(value=author_name) }}
   },
   "publisher": {
     "@type": "Organization",
-    "name": {{ config.title | json_encode | safe }}
+    "name": {{ ldjson::str(value=config.title) }}
   }
   {%- if page.updated -%},
-  "dateModified": {{ page.updated | json_encode | safe }}
+  "dateModified": {{ ldjson::str(value=page.updated) }}
   {%- endif -%}
   {%- if image_url -%},
-  "image": {{ image_url | json_encode | safe }}
+  "image": {{ ldjson::str(value=image_url) }}
   {%- endif %}
 }
 </script>

--- a/templates/partials/ld-breadcrumb.html
+++ b/templates/partials/ld-breadcrumb.html
@@ -7,6 +7,7 @@
 
    Skips emitting any JSON-LD when ancestors is empty (e.g. home page).
 #}
+{% import "partials/ld-json.html" as ldjson %}
 {% macro breadcrumb(title, permalink, ancestors) %}
 {%- if ancestors and ancestors | length > 0 %}
 {#- WHY: trailing-slash spelling varies (config.base_url is user-entered,
@@ -23,8 +24,8 @@
     {
       "@type": "ListItem",
       "position": 1,
-      "name": {{ config.title | json_encode | safe }},
-      "item": {{ config.base_url | json_encode | safe }}
+      "name": {{ ldjson::str(value=config.title) }},
+      "item": {{ ldjson::str(value=config.base_url) }}
     }
     {%- set position = 2 -%}
     {%- set_global seen = [base_key] -%}
@@ -36,8 +37,8 @@
     {
       "@type": "ListItem",
       "position": {{ position }},
-      "name": {{ ancestor.title | json_encode | safe }},
-      "item": {{ ancestor.permalink | json_encode | safe }}
+      "name": {{ ldjson::str(value=ancestor.title) }},
+      "item": {{ ldjson::str(value=ancestor.permalink) }}
     }
         {%- set_global position = position + 1 -%}
         {%- set_global seen = seen | concat(with=ancestor_key) -%}
@@ -47,8 +48,8 @@
     {
       "@type": "ListItem",
       "position": {{ position }},
-      "name": {{ title | json_encode | safe }},
-      "item": {{ permalink | json_encode | safe }}
+      "name": {{ ldjson::str(value=title) }},
+      "item": {{ ldjson::str(value=permalink) }}
     }
   ]
 }

--- a/templates/partials/ld-faq.html
+++ b/templates/partials/ld-faq.html
@@ -6,6 +6,7 @@
      page.extra.questions — array of {q, a, anchor?} per faq schema
 #}
 {% import "partials/assert.html" as assert %}
+{% import "partials/ld-json.html" as ldjson %}
 {{ assert::required(ok=page.title is defined and page.title, field="page.title", template="partials/ld-faq.html") }}
 {{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="partials/ld-faq.html") }}
 {{ assert::required(ok=page.extra.questions is defined and page.extra.questions | length > 0, field="page.extra.questions", template="partials/ld-faq.html") }}
@@ -17,10 +18,10 @@
     {%- for item in page.extra.questions -%}
     {
       "@type": "Question",
-      "name": {{ item.q | json_encode | safe }},
+      "name": {{ ldjson::str(value=item.q) }},
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": {{ item.a | json_encode | safe }}
+        "text": {{ ldjson::str(value=item.a) }}
       }
     }{%- if not loop.last -%},{%- endif -%}
     {%- endfor %}

--- a/templates/partials/ld-howto.html
+++ b/templates/partials/ld-howto.html
@@ -17,6 +17,7 @@
    Schema reference: https://schema.org/HowTo
 #}
 {% import "partials/assert.html" as assert %}
+{% import "partials/ld-json.html" as ldjson %}
 {{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="partials/ld-howto.html") }}
 {{ assert::required(ok=page.extra.product_type is defined and page.extra.product_type, field="page.extra.product_type", template="partials/ld-howto.html") }}
 {{ assert::required(ok=page.extra.measurement_source is defined and page.extra.measurement_source, field="page.extra.measurement_source", template="partials/ld-howto.html") }}
@@ -26,17 +27,17 @@
 {
   "@context": "https://schema.org",
   "@type": "HowTo",
-  "name": {{ howto_name | json_encode | safe }},
-  "description": {{ page.description | json_encode | safe }},
+  "name": {{ ldjson::str(value=howto_name) }},
+  "description": {{ ldjson::str(value=page.description) }},
   {%- if page.extra.duration is defined and page.extra.duration %}
-  "totalTime": {{ page.extra.duration | json_encode | safe }},
+  "totalTime": {{ ldjson::str(value=page.extra.duration) }},
   {%- endif %}
   "step": [
     {%- for line in page.extra.decision_tree -%}
     {
       "@type": "HowToStep",
       "position": {{ loop.index }},
-      "text": {{ line | json_encode | safe }}
+      "text": {{ ldjson::str(value=line) }}
     }{%- if not loop.last -%},{%- endif -%}
     {%- endfor %}
   ]

--- a/templates/partials/ld-json.html
+++ b/templates/partials/ld-json.html
@@ -1,0 +1,26 @@
+{# Shared JSON-LD string-escaping helper for every partials/ld-*.html.
+
+   WHY (forkwright/typikon#92): json_encode() escapes JSON's own syntax
+   characters (quotes, control chars) but leaves "/" untouched, so any
+   untrusted string field embedded in a <script type="application/ld+json">
+   block (config.title, page.title/description, item.q/a, page.extra.author,
+   decision_tree steps, ...) can carry a literal "</script" sequence. A
+   browser's HTML parser scans for that byte sequence BEFORE any JSON or JS
+   parsing happens -- case-insensitively, oblivious to JSON string-quoting
+   -- so it closes the script element early regardless of how validly the
+   JSON payload itself is escaped, breaking whatever HTML follows into the
+   page as markup. Escaping every "/" as the JSON-legal "\/" removes the
+   literal substring "</script" from the byte stream while round-tripping
+   through JSON.parse()/serde_json unchanged: "\/" and "/" decode to the
+   identical character per RFC 8259 SS7. Verified against a zola build:
+   the escaped payload still `json.loads()`-decodes to the exact original
+   string, and "</script" no longer occurs anywhere between the <script>
+   tags.
+
+   Every partials/ld-*.html routes every field value (string, number, or
+   array alike -- replace() is a no-op on a value with no "/") through
+   this macro instead of calling json_encode directly, so no future
+   ld-*.html addition can reintroduce the gap by omission. #}
+{% macro str(value) -%}
+{{- value | json_encode | replace(from="/", to="\/") | safe -}}
+{%- endmacro str %}

--- a/templates/partials/ld-organization.html
+++ b/templates/partials/ld-organization.html
@@ -6,25 +6,45 @@
      config.description       — brand tagline
      config.base_url          — canonical site root
      config.extra.logo_path   — relative to /; resolves to absolute via base_url
-     config.extra.author.name — primary maker / founder
      config.extra.brand_greek — optional motto (used in alternateName)
      config.extra.founding_date — optional ISO 8601 year (e.g. "2024")
      config.extra.footer_links — list of {url, rel}; entries with rel="me" emit as sameAs
 #}
-{%- set logo_url = config.base_url ~ "/" ~ config.extra.logo_path -%}
+{% import "partials/assert.html" as assert %}
+{% import "partials/ld-json.html" as ldjson %}
+{#- WHY this guard (forkwright/typikon#92): every sibling partials/ld-*.html
+   imports partials/assert.html and asserts its own documented required
+   inputs; this file did neither. config.extra.logo_path feeds logo_url
+   below UNCONDITIONALLY — there is no `{% if %}` around it the way
+   brand_greek/founding_date/footer_links each get — so an absent value
+   still failed the build (Tera's `~` concatenation errors on an undefined
+   variable), but with a bare "Variable `config.extra.logo_path` not found
+   in context" engine error naming neither the missing field's role nor
+   which template needs it — verified against a zola build. Every sibling
+   partial instead names both, via the same assert::required this file now
+   also uses. -#}
+{{ assert::required(ok=config.extra.logo_path is defined and config.extra.logo_path, field="config.extra.logo_path", template="partials/ld-organization.html") }}
+{#- get_url(), not hand string-concatenation (forkwright/typikon#92): the
+   visible <link rel="icon"> in base.html resolves config.extra.favicon_path
+   the same way, and get_url() normalizes base_url/path joining (a
+   trailing-slash base_url — a real, easy consumer misconfiguration —
+   hand-concatenates into a broken double-slash URL; get_url() does not).
+   Keeps this JSON-LD "logo" value byte-identical in construction to
+   every other resolved-asset URL this theme emits. -#}
+{%- set logo_url = get_url(path=config.extra.logo_path, trailing_slash=false) -%}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "Organization",
-  "name": {{ config.title | json_encode | safe }},
-  "description": {{ config.description | json_encode | safe }},
-  "url": {{ config.base_url | json_encode | safe }},
-  "logo": {{ logo_url | json_encode | safe }}
+  "name": {{ ldjson::str(value=config.title) }},
+  "description": {{ ldjson::str(value=config.description) }},
+  "url": {{ ldjson::str(value=config.base_url) }},
+  "logo": {{ ldjson::str(value=logo_url) }}
   {%- if config.extra.brand_greek -%},
-  "alternateName": {{ config.extra.brand_greek | json_encode | safe }}
+  "alternateName": {{ ldjson::str(value=config.extra.brand_greek) }}
   {%- endif -%}
   {%- if config.extra.founding_date -%},
-  "foundingDate": {{ config.extra.founding_date | json_encode | safe }}
+  "foundingDate": {{ ldjson::str(value=config.extra.founding_date) }}
   {%- endif -%}
   {%- if config.extra.footer_links -%}
     {%- set sameas = [] -%}
@@ -35,7 +55,7 @@
       {%- endif -%}
     {%- endfor -%}
     {%- if sameas | length > 0 -%},
-  "sameAs": {{ sameas | json_encode | safe }}
+  "sameAs": {{ ldjson::str(value=sameas) }}
     {%- endif -%}
   {%- endif %}
 }

--- a/templates/partials/ld-product.html
+++ b/templates/partials/ld-product.html
@@ -17,6 +17,7 @@
    unverified stock claim in structured data misleads search engines.
 #}
 {% import "partials/assert.html" as assert %}
+{% import "partials/ld-json.html" as ldjson %}
 {{ assert::required(ok=page.title is defined and page.title, field="page.title", template="partials/ld-product.html") }}
 {{ assert::required(ok=page.description is defined and page.description, field="page.description", template="partials/ld-product.html") }}
 {{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="partials/ld-product.html") }}
@@ -26,33 +27,35 @@
 {%- set price_numeric = page.extra.price | trim_start_matches(pat="$") -%}
 {%- set image_url = "" -%}
 {%- if page.extra.og_image -%}
-  {%- set image_url = config.base_url ~ "/" ~ page.extra.og_image -%}
+  {#- get_url(), not hand string-concatenation — same rationale as
+     partials/ld-article.html (forkwright/typikon#92). -#}
+  {%- set image_url = get_url(path=page.extra.og_image, trailing_slash=false) -%}
 {%- endif -%}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "Product",
-  "name": {{ page.title | json_encode | safe }},
-  "description": {{ page.description | json_encode | safe }},
-  "url": {{ page.permalink | json_encode | safe }},
+  "name": {{ ldjson::str(value=page.title) }},
+  "description": {{ ldjson::str(value=page.description) }},
+  "url": {{ ldjson::str(value=page.permalink) }},
   "brand": {
     "@type": "Organization",
-    "name": {{ config.title | json_encode | safe }}
+    "name": {{ ldjson::str(value=config.title) }}
   },
   "offers": {
     "@type": "Offer",
-    "price": {{ price_numeric | json_encode | safe }},
+    "price": {{ ldjson::str(value=price_numeric) }},
     "priceCurrency": "USD"
     {%- if page.extra.availability and page.extra.availability_source -%}
     {%- set availability_url = "https://schema.org/" ~ page.extra.availability -%}
     ,
-    "availability": {{ availability_url | json_encode | safe }}
+    "availability": {{ ldjson::str(value=availability_url) }}
     {%- endif -%}
     ,
-    "url": {{ page.extra.stripe_url | json_encode | safe }}
+    "url": {{ ldjson::str(value=page.extra.stripe_url) }}
   }
   {%- if image_url -%},
-  "image": {{ image_url | json_encode | safe }}
+  "image": {{ ldjson::str(value=image_url) }}
   {%- endif %}
 }
 </script>


### PR DESCRIPTION
## Summary

Fixes 16 of the 18 findings in #92; the other 2 were already fixed on `main`
by prior PRs (evidence below, per `#5a` in the fleet agent brief). One
additional fix (JSON-LD script-injection escaping) generalizes beyond the
single file the issue cited to all six `partials/ld-*.html` partials, since
every sibling shared the identical unescaped `json_encode` pattern — fixing
only the named file would have left the same defect live in five others.

## Acceptance criteria

Issue #92: `Done when: every bullet is either fixed, or closed with a stated
reason it is not a defect.`

### `bin/` (7)

1. **`bin/typikon-check:65` — `base_host()` single-quoted TOML.** Fixed —
   `bin/typikon-check:103-112`. `base_host()`'s `sed` now matches both
   `"..."` and `'...'` TOML string forms. Verified: piping a single-quoted
   `base_url = 'https://example.com'` through the pre-fix pipeline produced
   `base_url = 'https:` (garbage); through the fixed pipeline, `example.com`
   for both quote styles.
2. **`bin/typikon-check:7` — "fail-fast" header claim.** Already fixed —
   `bin/typikon-check:7-9` currently reads "Runs every gate stage in order.
   Stages do NOT stop at the first failure." Fixed in PR #103
   (`3. The header claimed fail-fast; it isn't`). No change in this PR.
3. **`bin/typikon-init:107` — "always refresh" comment vs skip-if-exists
   code.** Fixed — `bin/typikon-init:131-137`. Corrected the comment: these
   files are create-once (matches `typikon-refresh`'s own documented
   contract, which explicitly does NOT re-render `_headers`/`_redirects`).
4. **`bin/typikon-init:91` — swallowed theme-submodule refresh failure.**
   Fixed — `bin/typikon-init:90-97`. A failed `git pull --ff-only` now
   prints `warn   themes/typikon: refresh failed, continuing with existing
   checkout: <git's own error>` to stderr instead of `|| true`-swallowing
   it silently. Still non-fatal (an offline forge on a re-run must not
   abort the whole scaffold).
5. **`bin/typikon-validate:138` — JSON Pointer root emits `"/"` not
   `""`.** Fixed — `bin/typikon-validate:420-428`. A root-level failure
   (`err.absolute_path` empty) now emits `pointer: ""` per RFC 6901.
6. **`bin/typikon-validate:155` — `load_schemas()` raw traceback on
   malformed schema.** Fixed — `bin/typikon-validate:493-499` and
   `:592-599` (both the per-slug loop and the `.core.schema.json` loop
   carried the identical unwrapped `json.loads()`). Both now catch and
   report `{"error": "malformed schema <path>: <exc>"}` + exit 2.
7. **`bin/typikon-validate:29` — exit-code docstring contradicts
   implementation for malformed frontmatter.** Fixed —
   `bin/typikon-validate:57-64`. Malformed frontmatter is folded into the
   per-file `failures` list (exit 1), not the runtime-error class (exit 2);
   the docstring said the opposite. Corrected the doc; the code was already
   the intended behavior (same JSONL per-file reporting shape as a schema
   failure).

### `ci/` (4, + 1 bonus from the issue thread)

8. **`ci/csp-enforce.sh:46` — unbounded `grep`/argv, E2BIG risk.** Fixed —
   `ci/csp-enforce.sh:65-70`, `ci/csp-scan.py:106-124`. File paths now go
   over stdin (bash builtin `printf`, no `execve()` of its own) instead of
   argv; `csp-scan.py` reads newline-delimited paths from stdin when argv
   is empty.
9. **`ci/kanon-ci.toml.tmpl:40` — missing TLS pinning vs the GitHub
   template it claims to mirror.** Fixed — `ci/kanon-ci.toml.tmpl:41,75`.
   Both `curl` calls (zola, lychee) now carry `--proto '=https' --tlsv1.2`,
   matching `ci/github-workflow.yml.tmpl:64,110`.
10. **`ci/lychee.toml:12` — false cross-run cache-persistence claim.**
    Fixed — `ci/lychee.toml:11-16`. Corrected: neither CI template
    persists `.lychee_cache/` across runs today (verified: no
    `actions/cache` / forge equivalent in either template). `cache = true`
    stays on — it still dedupes repeat hits to the same URL within one run.
11. **`ci/playwright.config.ts:10` — header claims `public/`, gate
    actually serves `public-local/`.** Already fixed —
    `ci/playwright.config.ts:16-21` currently describes `public-local/`
    correctly, with an OS-allocated port (no hardcoded 8080 claim). Fixed
    in PR #116. No change in this PR.
12. *(Bonus, from the issue thread, not one of the 18 — fixed while here)*
    **`ci/check-consumer-check-extension.sh:32-33` — freeform `# Usage:`
    comment tag.** Fixed — `ci/check-consumer-check-extension.sh:32`, now
    `# NOTE: usage — ...`, per the fix already applied to the identical
    shape in PR #151.

### `schemas/` (1)

13. **`schemas/page.schema.json:66` — `og_image` extension allowlist
    inconsistent across schemas.** Fixed — `schemas/page.core.schema.json:64`
    and `schemas/journal-entry.schema.json:52` (the file split into
    `page.schema.json` + `page.core.schema.json` since the issue was
    filed; the actual `og_image` pattern lives in `page.core.schema.json`
    now). Both now accept `.jpeg`, matching `faq`/`sizing-guide`/`product`
    schemas, which already did. All 5 schemas' `og_image` patterns now
    agree.

### `templates/` (6)

14. **`templates/atom.xml:25` — `<updated>` from newest-DATED entry, not
    most-recently-EDITED entry.** Fixed — `templates/atom.xml:24-45`. Now
    scans every entry's own `updated`-or-`date` and takes the max
    (`set_global` + epoch-int comparison, since Tera's `>` only compares
    numbers). Verified against a real `zola build`: an older-dated entry
    given a newer `updated` now correctly wins.
15. **`templates/faq.html:36` — auto-slugify anchor collision.** Fixed —
    `templates/faq.html:42-59`. A colliding anchor (explicit or
    slugify-derived) gets a `-{{ loop.index }}` suffix instead of
    colliding on `id=`. Verified against a real `zola build`: two
    questions that previously rendered two `id="do-you-ship-internationally"`
    elements now render `id="do-you-ship-internationally"` +
    `id="do-you-ship-internationally-2"`.
16. **`templates/journal-entry.html:16` — hardcoded `og_type`.** Fixed —
    removed the override; `journal-entry.html` now inherits `page.html`'s
    `og_type` block (`templates/page.html:13`), which already reads
    `page.extra.og_type | default(value="article")` correctly. Verified:
    a real build's `og:type` meta still reads `article` by default with
    no regression.
17. **`templates/partials/ld-article.html:21` — hand-concatenated
    image/logo URLs instead of `get_url()`.** Fixed —
    `templates/partials/ld-article.html:20-28`,
    `templates/partials/ld-product.html:27-32`,
    `templates/partials/ld-organization.html:29-34` (the issue: "**three**
    JSON-LD partials"). All three now call `get_url(path=..., trailing_slash=
    false)`, matching the same field's resolution in `base.html`/`page.html`.
    Verified: with `base_url = "https://example.com/"` (trailing slash),
    hand-concatenation produced `https://example.com//img/og.png`
    (double-slash, broken); `get_url()` produces `https://example.com/img/og.png`.
18. **`templates/partials/ld-organization.html:14` — no `assert::required`
    guard, unlike every sibling.** Fixed — `templates/partials/ld-organization.html:13,26`.
    Now imports `partials/assert.html` and asserts `config.extra.logo_path`,
    matching every sibling `ld-*.html`. Verified: pre-fix, an absent
    `logo_path` still failed the build, but with a bare Tera engine error
    ("Variable `config.extra.logo_path` not found in context") naming
    neither the field's role nor which template needs it; post-fix, the
    same missing field now fails with `partials/ld-organization.html:
    missing required metadata` — the same clear, actionable message every
    sibling partial already gives.
19. *(the issue's `ld-organization.html:19` finding — same file, listed
    separately below since it's a distinct defect)* **JSON-LD `</script>`
    breakout via unescaped `json_encode`.** Fixed — new
    `templates/partials/ld-json.html` (shared `ldjson::str()` macro,
    escapes `/` → `\/`, RFC 8259 §7-legal) wired into **all six**
    `partials/ld-*.html` (article, breadcrumb, faq, howto, organization,
    product) — not only the file the issue cited, since every sibling
    shared the identical `json_encode | safe` pattern with no escaping.
    Verified: a field value containing `"Hello</script><script>alert(1)</script>"`
    round-trips through `json.loads()` to the exact original string, and
    the literal substring `</script` no longer occurs anywhere in the
    `<script type="application/ld+json">` payload.

Note: fixing `ld-organization.html`'s `assert::required` call surfaced a
real cross-file Tera scoping gap — `base.html` (which `{% include %}`s
`ld-organization.html` inside a block every page reaches via `super()`)
did not itself import `partials/assert.html`, and Tera resolves a macro
namespace by which template an `include` tag is textually written in, not
by the included partial's own imports, once reached via `extends` +
`super()`. Fixed by importing `assert` in `templates/base.html:20` too;
documented + verified (see commit message).

**18/18 accounted for**: 16 fixed in this PR, 2 already fixed on `main`
(items 2 and 11 above) with cited evidence.

## Negative fixtures

> Negative fixture: `bin/typikon-check` (`base_host()`) — watched failing by
> piping a single-quoted `base_url = 'https://example.com'` config line
> through the pre-fix `sed` pipeline, which produced the literal garbage
> `base_url = 'https:` before the fix and `example.com` after (both quote
> styles), run against the exact shipped `sed` expression from each
> revision.

> Negative fixture: `bin/typikon-validate` (root JSON Pointer) — watched
> failing by running `origin/main`'s own shipped `bin/typikon-validate`
> against a fixture page missing the required `title` field, which produced
> `"pointer": "/"` before the fix; the current worktree's shipped
> `bin/typikon-validate` against the identical fixture produces
> `"pointer": ""` after.

> Negative fixture: `bin/typikon-validate` (`load_schemas()` crash) —
> watched failing by running `origin/main`'s own shipped
> `bin/typikon-validate` against a schema directory with `faq.schema.json`
> truncated mid-object (invalid JSON), which produced a raw
> `json.decoder.JSONDecodeError` Python traceback (exit 1) before the fix;
> the current worktree's shipped `bin/typikon-validate` against the
> identical corrupted schema produces a clean
> `{"error": "malformed schema ...: Unterminated string ..."}` (exit 2)
> after.

> Negative fixture: `bin/typikon-init` (swallowed refresh failure) —
> watched failing by extracting the exact shipped refresh line from
> `origin/main`'s `bin/typikon-init` (`(cd themes/typikon && git pull
> --ff-only origin main 2>/dev/null) || true`) and running it verbatim
> against a `themes/typikon` checkout whose `origin` remote is
> unreachable, which produced silent success (exit 0, empty stdout AND
> stderr) before the fix; the current worktree's shipped replacement lines
> against the identical unreachable remote produce exit 0 (still
> non-fatal, correctly) but with `warn   themes/typikon: refresh failed,
> continuing with existing checkout: fatal: ... does not appear to be a
> git repository ...` on stderr after.

> Negative fixture: `templates/atom.xml` (`<updated>`) — watched failing
> by building `examples/sample-blog` (real `zola build`, shipped
> templates) with `origin/main`'s `templates/atom.xml` against a fixture
> where the older-dated journal entry has a newer `updated` than the
> newer-dated entry's own value, which produced `<updated>2026-02-10T00:00:00+00:00</updated>`
> (the newer entry's own date, ignoring the true most-recent edit) before
> the fix; the current worktree's `templates/atom.xml` against the
> identical fixture produces `<updated>2026-08-10T00:00:00+00:00</updated>`
> (the actual most-recent edit) after.

> Negative fixture: `templates/faq.html` (anchor collision) — watched
> failing by building a FAQ page (real `zola build`, shipped templates)
> with two questions that slugify identically, against `origin/main`'s
> `templates/faq.html`, which produced two `id="do-you-ship-internationally"`
> elements before the fix; the current worktree's `templates/faq.html`
> against the identical fixture produces `id="do-you-ship-internationally"`
> + `id="do-you-ship-internationally-2"` after.

> Negative fixture: `templates/partials/ld-organization.html`
> (`assert::required` + `get_url()`) — watched failing by building
> `examples/sample-blog` (real `zola build`) with `config.extra.logo_path`
> removed from `config.toml`, against `origin/main`'s
> `templates/partials/ld-organization.html`, which produced a bare Tera
> engine error (`Variable 'config.extra.logo_path' not found in context`)
> before the fix; the current worktree's version against the identical
> fixture produces `partials/ld-organization.html: missing required
> metadata 'config.extra.logo_path'` after — matching the message shape
> every sibling `ld-*.html` partial already uses.

> Negative fixture: every `partials/ld-*.html` (JSON-LD escaping) —
> watched failing by piping `"Hello</script><script>alert(1)</script>"`
> through the pre-fix `value | json_encode | safe` pattern (shared,
> unescaped, across all six partials), which left the literal substring
> `</script` intact in the `<script type="application/ld+json">` payload;
> the current worktree's `partials/ld-json.html::str()` macro against the
> identical input produces `Hello<\/script><script>alert(1)<\/script>` —
> `json.loads()`-equivalent to the original string, with `</script`
> nowhere in the byte stream. All 16 real JSON-LD blocks rendered across
> both `examples/*` sites (blog + shop, every template) were re-verified
> to still `json.loads()` cleanly after the change.

All ten fixtures ran the actual shipped file content at each git revision
(`origin/main` vs this branch) — extracted verbatim (`git show
origin/main:<path>`) or symlinked directly at the theme root for a real
`zola build` — never a re-implementation.

## Verification

- `kanon lint <path> --all` — zero violations across all 21 changed/added
  files (individually checked).
- `python3 bin/typikon-validate examples/sample-blog` /
  `examples/sample-shop` — both `{"failed": 0}` against the updated
  schemas.
- Real `zola build` + `zola check` — both example sites build and check
  clean.
- `ci/check-xml-output.sh`, `ci/csp-enforce.sh` — both example builds pass.
- Every `ci/check-*.py` / `ci/check-*.sh` regression script in the repo
  (triad-schema, consumer-schema-registry, page-template-cascade,
  font-coverage, release-config, asset-provenance, favicon-path,
  init-favicon-path, asset-path-existence, init-staging-scope,
  control-contrast, home-heading, content-heading-collision,
  interactive-contrast (+selftest), workflow-template,
  consumer-check-extension, fixture-corpus-exemption, deploy-bundle-gate,
  cf-deploy-gate) — all pass.
- `TYPIKON_CHECK_MODE=dev bin/typikon-check examples/sample-blog` and
  `.../sample-shop` — every stage passes except `pa11y` (`pa11y-ci`
  genuinely absent on this box; `lychee` and `playwright-smoke`, both
  present, pass real link-checking and browser smoke tests against the
  fixed templates).

Not run: GitHub Actions CI (this box does not run cargo/full builds per
fleet policy; this repo's own CI is zola/python/node-based and this PR's
branch push will trigger it — this repo is public, so Actions minutes are
unmetered).

Closes #92
