### PR TITLE
fix(ci): csp-scan hangs at a terminal instead of printing its usage

### DIFF
--- a/ci/check-csp-scan-selftest.py
+++ b/ci/check-csp-scan-selftest.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""csp-scan's three input paths: argv, piped stdin, and a bare invocation at a terminal."""
+
+# WHY a pty is allocated rather than passing an empty stdin: the defect this pins only exists
+# when stdin is a LIVE terminal. Iterating one blocks forever, so csp-scan hung instead of
+# printing its usage. Every cheap way to test it -- closed stdin, /dev/null, an empty pipe --
+# reaches EOF immediately and passes against the broken code, which is why the regression
+# survived a green CI: nothing in CI ever invokes this script from a terminal.
+
+import os
+import pty
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCAN = ROOT / "ci/csp-scan.py"
+TIMEOUT = 10
+
+failures: list[str] = []
+
+
+def fail(msg: str) -> None:
+    failures.append(msg)
+    print(f"FAIL: {msg}", file=sys.stderr)
+
+
+def bare_at_a_terminal() -> None:
+    """No argv, stdin is a real tty: must print usage and exit 2, not block."""
+    primary, secondary = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, str(SCAN)],
+            stdin=secondary,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        os.close(secondary)
+        secondary = -1
+        try:
+            _, err = proc.communicate(timeout=TIMEOUT)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            fail(
+                f"csp-scan.py with no argv at a tty did not exit within {TIMEOUT}s -- it is "
+                "blocking on a stdin read instead of printing usage"
+            )
+            return
+        if proc.returncode != 2:
+            fail(f"expected exit 2 at a tty with no argv, got {proc.returncode}")
+        if "usage:" not in err:
+            fail(f"expected a usage message on stderr at a tty, got: {err!r}")
+    finally:
+        os.close(primary)
+        if secondary != -1:
+            os.close(secondary)
+
+
+def piped_stdin_still_reads() -> None:
+    """A piped path list must still be consumed -- the E2BIG path this gate must not break."""
+    sample = ROOT / "ci/csp-scan.py"
+    proc = subprocess.run(
+        [sys.executable, str(SCAN)],
+        input=f"{sample}\n",
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT,
+    )
+    if proc.returncode == 2 and "usage:" in proc.stderr:
+        fail("a piped path list was ignored -- the isatty gate swallowed the stdin path")
+
+
+def empty_pipe_is_still_a_usage_error() -> None:
+    """Closed/empty stdin must keep reaching the usage error rather than scanning nothing."""
+    proc = subprocess.run(
+        [sys.executable, str(SCAN)], input="", capture_output=True, text=True, timeout=TIMEOUT
+    )
+    if proc.returncode != 2:
+        fail(f"expected exit 2 for an empty pipe, got {proc.returncode}")
+
+
+def main() -> int:
+    if not SCAN.exists():
+        print(f"FAIL: {SCAN} not found", file=sys.stderr)
+        return 1
+    bare_at_a_terminal()
+    piped_stdin_still_reads()
+    empty_pipe_is_still_a_usage_error()
+    if failures:
+        return 1
+    print("check-csp-scan-selftest: ok (tty exits 2, piped stdin reads, empty pipe errors)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/csp-scan.py
+++ b/ci/csp-scan.py
@@ -113,11 +113,15 @@ def scan(path: str) -> list[tuple[int, str]]:
 def main(argv: list[str]) -> int:
     if argv:
         paths = argv
+    elif sys.stdin.isatty():
+        # WHY this gate is load-bearing rather than redundant: iterating a LIVE tty blocks
+        # forever, waiting for input no interactive caller knows to send, so a bare
+        # invocation hangs instead of printing the usage below. Only a closed or piped
+        # stdin reaches EOF and falls through to an empty paths list; a terminal never
+        # does. The stdin path itself stays, because it is what keeps a large file set
+        # from hitting the argv size limit.
+        paths = []
     else:
-        # WHY not sys.stdin.isatty()-gated: an empty/closed stdin (a
-        # direct interactive invocation with no argv) falls through to
-        # an empty paths list either way, hitting the same "no paths"
-        # error below rather than blocking on a read.
         paths = [line.rstrip("\n") for line in sys.stdin if line.strip()]
 
     if not paths:


### PR DESCRIPTION
Fixes a live regression on `main`, found by an independent adversarial review of PR #171 after it merged.

## The defect

`ci/csp-scan.py`'s stdin fallback — added to keep a large file set from hitting the argv size limit — iterates `sys.stdin` whenever `argv` is empty. A closed or piped stdin reaches EOF and falls through to the usage error. A **live terminal never does**, so a bare interactive invocation blocks forever instead of exiting 2.

Reproduced under an allocated pty: no output, still running.

## Why it read as safe

The comment justifying the absence of an `isatty()` gate said an empty or closed stdin "falls through to an empty paths list either way." That is true for closed stdin and false for a tty — the comment's own account of the mechanism was wrong, which is exactly what made the code look correct. It now states what it actually relies on.

The stdin path is unchanged. It stays, because it is the reason this exists.

## Why CI was green on a script that hangs

Nothing in CI ever invokes it from a terminal. Every cheap way to test the empty case — closed stdin, `/dev/null`, an empty pipe — reaches EOF immediately and **passes against the broken code**. So the new `ci/check-csp-scan-selftest.py` allocates a real pty, and pins all three input paths:

- bare at a tty → exit 2 with usage, within a timeout
- piped path list → still consumed (the argv-limit path must not be swallowed by the gate)
- empty pipe → still a usage error

It is discovered automatically by the derived fixture runner from #170; no wiring line.

## Verification

Mutation: disabling the gate (`elif False:`) makes the selftest report `did not exit within 10s -- it is blocking on a stdin read instead of printing usage` and return 1, rather than hanging the suite. Restored, and the selftest returns 0.

## Shape worth noting

This is a fix for an input-handling defect that introduced a new input-handling defect in the same guard path — the "claim does not match runtime behaviour" class that issue #92 was opened to eliminate. Credit to the reviewer who caught it by running the thing under a pty rather than reading the diff.
