### PR TITLE
feat(templates,schemas): render audience, derive the journal word count from Zola

### DIFF
--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -145,23 +145,23 @@ list_caption = "Newest at top."
 
 Pages under `content/journal/` (excluding `_index.md`), OR any page whose effective `template` — explicit or resolved through the `page_template` cascade (see the routing table above) — is `journal-entry.html`, regardless of its path. Stricter than page: requires `description`, `date`, and the entry-level extras so the auto-generated journal listing renders cleanly.
 
-**Required:** `title`, `description`, `date`, `extra.audience`, `extra.components`, `extra.words`, `extra.words_source`.
+**Required:** `title`, `description`, `date`, `extra.audience`, `extra.components`.
 
-**Optional `[extra]`:** `seo_title`, `body_class`, `og_image`, `og_type`, `author`, `skip_sitemap`, `figure`, `figure_alt`, `tier`.
+**Optional `[extra]`:** `words`, `words_source`, `seo_title`, `body_class`, `og_image`, `og_type`, `author`, `skip_sitemap`, `figure`, `figure_alt`, `tier`.
 
 **Constraints:**
 - description: 20–200 chars
 - date: ISO 8601
-- extra.audience: 3–120 chars
+- extra.audience: 3–120 chars. Rendered in the entry header, alongside `extra.components` — reader-orienting context for who the piece is for
 - extra.components: 5–120 chars (the conceptual-tags line)
-- extra.words: matches `^~?\d+( words)?$`
-- extra.words_source: 3–200 chars. Source for the rendered word-count claim
+- extra.words: matches `^~?\d+( words)?$`. **Optional override** — `journal-entry.html`/`journal-section.html` render Zola's own `page.word_count`/`entry.word_count` by default (the rendered body's word count, excluding fenced code blocks — see `templates/journal-entry.html`), so the figure cannot drift from the body it describes. Set this only to force a custom string
+- extra.words_source: 3–200 chars. **Required alongside `extra.words`, forbidden without it** (`dependentRequired`, both directions — same pattern as `product.schema.json`'s `availability`/`availability_source`). Not needed for the default derived count, which carries no separate provenance claim
 - extra.og_image: ends in `.svg|.png|.jpg|.webp`
 - extra.figure: ends in `.svg|.png|.jpg|.webp`. Not consumed by typikon's own stock `journal-entry.html` — a consumer shadow template renders it as furniture above the entry body (forkwright/typikon#163)
 - extra.figure_alt: 5–500 chars. **Required whenever `extra.figure` is set** (enforced via `dependentRequired`, not just documented)
 - extra.tier: one of `notes | research`. Not consumed by typikon's own stock `journal-section.html` — a consumer shadow template that groups its listing by tier reads it (forkwright/typikon#163)
 
-**Example:**
+**Example — explicit `words` override:**
 
 ```toml
 +++
@@ -174,6 +174,20 @@ audience = "readers following the workbench journal"
 components = "ἀπορία · productive uncertainty · the green"
 words = "~430 words"
 words_source = "manual count"
++++
+```
+
+**Example — derived `words`:** omitting `words`/`words_source` renders `page.word_count` instead:
+
+```toml
++++
+title = "ἀπορία"
+description = "On the green dye and the tensions it holds. Why the color that can't decide is the one I keep thinking about."
+date = 2026-01-20
+
+[extra]
+audience = "readers following the workbench journal"
+components = "ἀπορία · productive uncertainty · the green"
 +++
 ```
 

--- a/examples/sample-blog/content/journal/first-entry.md
+++ b/examples/sample-blog/content/journal/first-entry.md
@@ -12,6 +12,6 @@ words_source = "fixture hand count"
 
 The first journal entry exists to prove that `journal-entry.schema.json` validates a real file with all required fields populated.
 
-The frontmatter declares its `date`, `description`, and the entry-extras (`components`, `words`). The template renders the date through `<time datetime="...">`, the title as `<h1>`, the body inside `<article class="journal-entry-page">`, and the prev/next nav at the bottom (with no targets in a one-entry corpus).
+The frontmatter declares its own `words`/`words_source`, overriding the derived `page.word_count` the template renders by default (see `second-entry.md` for the derived count actually rendering). The template renders `audience` and `components` in the entry header, the date through `<time datetime="...">`, the title as `<h1>`, the body inside `<article class="journal-entry-page">`, and the prev/next nav at the bottom (with no targets in a one-entry corpus).
 
 When this fixture grows past one entry, the prev/next links should appear and follow the older=prev, newer=next convention.

--- a/examples/sample-blog/content/journal/second-entry.md
+++ b/examples/sample-blog/content/journal/second-entry.md
@@ -6,10 +6,10 @@ date = 2026-02-10
 [extra]
 audience = "typikon fixture readers"
 components = "πρᾶξις · iteration · the second pass"
-words = "~90 words"
-words_source = "fixture hand count"
 +++
 
 The second journal entry. With this entry plus `first-entry.md`, the section renders as a list of two and each entry has one prev/next sibling.
 
 In a DESC-by-date sort, this entry comes first in the listing (newer); `first-entry.md` comes second. From this entry, "next" (newer) is undefined and "prev" (older) is `first-entry.md`. From `first-entry.md`, "prev" is undefined and "next" is this entry.
+
+This entry sets neither `extra.words` nor `extra.words_source` — the specs line below renders Zola's own `page.word_count`, derived from this body, instead of a hand-written claim.

--- a/schemas/journal-entry.schema.json
+++ b/schemas/journal-entry.schema.json
@@ -21,7 +21,7 @@
     "draft": { "type": "boolean" },
     "extra": {
       "type": "object",
-      "required": ["audience", "components", "words", "words_source"],
+      "required": ["audience", "components"],
       "additionalProperties": false,
       "properties": {
         "audience": {
@@ -39,13 +39,13 @@
         "words": {
           "type": "string",
           "pattern": "^~?\\d+( words)?$",
-          "description": "Approximate word count, e.g. '~480' or '~480 words'."
+          "description": "Optional override for the rendered word-count line. journal-entry.html/journal-section.html render Zola's own page.word_count/entry.word_count by default (counted from the rendered body, excluding fenced code blocks) so the figure cannot drift from the body. Set this only to force a custom string; requires words_source alongside it."
         },
         "words_source": {
           "type": "string",
           "minLength": 3,
           "maxLength": 200,
-          "description": "Source for the rendered word-count claim, e.g. 'manual count' or the counting tool used."
+          "description": "Required alongside words: where the overriding word-count claim came from. Not needed for the default derived count, which is self-sourced (Zola's own page.word_count) and carries no separate provenance claim to trace."
         },
         "seo_title": { "type": "string", "maxLength": 80 },
         "body_class": { "type": "string", "pattern": "^[a-z][a-z0-9 -]*$" },
@@ -71,7 +71,9 @@
         }
       },
       "dependentRequired": {
-        "figure": ["figure_alt"]
+        "figure": ["figure_alt"],
+        "words": ["words_source"],
+        "words_source": ["words"]
       }
     }
   }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -860,13 +860,22 @@ footer p {
   margin-bottom: var(--space-xs);
 }
 
-.entry-header .entry-components {
+.entry-header .entry-components,
+.entry-header .entry-audience {
   font-family: var(--font-mono);
   font-size: var(--step--2);
   color: var(--text-light);
   letter-spacing: 0.05em;
   margin: 0;
   flex: none;
+}
+
+/* WHY: entry-components carries no top margin of its own -- it sits
+   flush under entry-date's margin-bottom. entry-audience, when it
+   follows entry-components (both required, both always rendered), needs
+   its own small gap or the two lines touch. */
+.entry-header .entry-components + .entry-audience {
+  margin-top: var(--space-3xs);
 }
 
 /* === LEXICON === */

--- a/templates/journal-entry.html
+++ b/templates/journal-entry.html
@@ -8,7 +8,25 @@
 
    The template assumes journal entries have:
      page.title, page.description, page.date (ISO), page.extra.components,
-     page.extra.words. See schemas/journal-entry.schema.json.
+     page.extra.audience.
+
+   page.extra.audience is rendered in entry-header, alongside components:
+   it is reader-orienting context ("who this piece is for"), so it belongs
+   where a reader decides whether to keep reading, not buried past the
+   body -- the same reasoning that puts entry-components (what it's about)
+   there rather than in the closing .specs line.
+
+   The `.specs` word-count line renders Zola's own page.word_count by
+   default -- a hand-written count can drift from the body it claims to
+   describe; page.word_count cannot, because Zola recomputes it from the
+   rendered body on every build. It counts the rendered body's words
+   (headings, emphasis, inline code, link text AND link targets, image
+   alt text AND src) but EXCLUDES fenced code block content entirely --
+   verified against zola 0.22.1. page.extra.words overrides it when a
+   consumer needs a custom string (a translated unit, a deliberate count
+   that excludes something page.word_count includes); setting it requires
+   page.extra.words_source alongside it. See
+   schemas/journal-entry.schema.json.
 #}
 {% extends "page.html" %}
 {% import "partials/assert.html" as assert %}
@@ -32,14 +50,18 @@
 {{ assert::required(ok=page.date is defined and page.date, field="page.date", template="journal-entry.html") }}
 {{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="journal-entry.html") }}
 {{ assert::required(ok=page.extra.components is defined and page.extra.components, field="page.extra.components", template="journal-entry.html") }}
-{{ assert::required(ok=page.extra.words is defined and page.extra.words, field="page.extra.words", template="journal-entry.html") }}
+{%- if page.extra.words %}
 {{ assert::required(ok=page.extra.words_source is defined and page.extra.words_source, field="page.extra.words_source", template="journal-entry.html") }}
+{%- endif %}
 <article class="journal-entry-page">
   <header class="entry-header">
     <h1>{{ page.title }}</h1>
     <p class="entry-date"><time datetime="{{ page.date }}">{{ page.date | date(format="%Y-%m-%d") }}</time></p>
     {%- if page.extra.components %}
     <p class="entry-components">{{ page.extra.components }}</p>
+    {%- endif %}
+    {%- if page.extra.audience %}
+    <p class="entry-audience">{{ page.extra.audience }}</p>
     {%- endif %}
   </header>
 
@@ -53,9 +75,7 @@
   {{ assert::no_h1(content=page.content, template="journal-entry.html") }}
   {{ page.content | safe }}
 
-  {%- if page.extra.words %}
-  <p class="specs">{{ page.extra.words }}</p>
-  {%- endif %}
+  <p class="specs">{{ page.extra.words | default(value=page.word_count ~ " words") }}</p>
 
   {%- if page.lower or page.higher %}
   <nav class="entry-nav" aria-label="Journal navigation">

--- a/templates/journal-section.html
+++ b/templates/journal-section.html
@@ -13,8 +13,9 @@
      - date (ISO 8601)
      - title
      - extra.components (string, e.g. "ardere · presence · the question")
-     - extra.words      (string, e.g. "~480 words")
-   See schemas/journal-entry.schema.json.
+   The `.entry-words` figure renders Zola's own entry.word_count by
+   default (see templates/journal-entry.html for what it counts and why);
+   entry.extra.words overrides it. See schemas/journal-entry.schema.json.
 #}
 {% extends "base.html" %}
 {% import "partials/assert.html" as assert %}
@@ -60,9 +61,7 @@
       {%- if entry.extra.components %}
       <span class="entry-components">{{ entry.extra.components }}</span>
       {%- endif %}
-      {%- if entry.extra.words %}
-      <span class="entry-words">{{ entry.extra.words }}</span>
-      {%- endif %}
+      <span class="entry-words">{{ entry.extra.words | default(value=entry.word_count ~ " words") }}</span>
     </a>
   </li>
 {%- endfor %}


### PR DESCRIPTION
Two fixes that unblock a consumer, plus a design correction that removed a third. The PR pivoted mid-flight; this body describes what it **is**, not what it was.

## 1. The journal word count is derived, not declared

`schemas/journal-entry.schema.json` no longer *requires* `extra.words` / `extra.words_source`. `journal-entry.html` and `journal-section.html` render Zola's own `page.word_count`. An explicit `extra.words` still wins as an override, and `words_source` is required only alongside it (the `dependentRequired` pattern `product.schema.json` already uses for `availability`).

**Why:** the count was a hand-written claim that drifts. Measured against a consumer's 8 essays, three were materially wrong — `~1050` for 1263 words, `~1150` for 944, `~1120` for 1264. Written once, never updated as the essays were edited. A derived count cannot drift.

**What `page.word_count` actually counts** — verified against real builds with isolated per-variable fixtures, not assumed:

| Included | Excluded |
|---|---|
| headings, emphasis/bold inner text | **fenced code block content, entirely** |
| inline code span content | |
| link visible text **and the link URL** | |
| image alt text **and the image `src` path** | |

Worth stating in the docs, because a reader of the rendered number deserves to know what it measures — particularly on essays containing code fences.

Demonstrated: `second-entry` (no `extra.words`) renders `93 words`; appending a 23-word sentence renders `133` — hand-checked exact delta. `first-entry` keeps its `~120 words` override.

## 2. `audience` is rendered, so requiring it is honest

`extra.audience` now renders in the entry header beside `components`, and stays required.

Its schema rationale claimed it was *"required so rendered deliverables carry audience assumptions explicitly."* Nothing rendered it — no template in this repo, no consumer template, no script. Outside the schema definitions it appeared only in test fixtures that existed to satisfy the requirement. A requirement justified by an effect that does not occur is the defect; the choice was to make the claim true rather than drop the field.

## 3. What was dropped, and why that is the interesting part

This branch first added an `extra` cascade, so a section could set `audience` once for all its pages.

**Zola has no such mechanism.** A bare `[cascade]` table is a hard `unknown field` error at 0.22.1 — verified directly, and confirmed absent through 0.23.3 release notes:

```
unknown field `cascade`, expected one of `title`, `description`, `sort_by`, `weight`,
`draft`, `template`, ... `page_template`, `aliases`, `generate_feeds`, `extra`
```

So the cascade was **validator-only**: it satisfied `typikon-validate` and told the renderer nothing. A page relying on it passed validation and then failed `zola build` against the render-time assert — reproduced before it was removed. That is a validate-passes/build-fails trap, and shipping one to fix a metadata gap would have been a bad trade.

Rendering `audience` moots it entirely: a rendered value must reach Zola, so it must live in the page's own frontmatter. `ci/check-extra-cascade.py`, the `section.core.schema.json` change, and the validator's cascade functions are all gone, and the two asserts removed while chasing it are restored — correct again, since they now guard a value that is genuinely rendered.

## Verification

- `bash ci/run-fixtures.sh` (with `~/.npm-global/bin` on PATH so `pa11y-ci` resolves) → **exit 0**, every stage pass.
- `bin/typikon-check examples/sample-blog` and `examples/sample-shop` → **exit 0** each.
- Rendered output confirmed in built HTML: `<p class="entry-audience">…</p>` and `<p class="specs">93 words</p>` on the fixture with no override.
