### PR TITLE
feat(templates): migrate to Zola 0.23 and Tera 2

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -99,8 +99,8 @@ jobs:
       check_cmd: |
         set -euo pipefail
 
-        ZOLA_VERSION=0.22.1
-        ZOLA_SHA256=0ca09aa40376aaa9ddfb512ff9ad963262ef95edb0d0f2d5ec6961b6f5cf22ef
+        ZOLA_VERSION=0.23.3
+        ZOLA_SHA256=f07c92607e5745268b576bd325ceef3a582aada253bb64db8d92a8a85303d958
         curl -L "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o zola.tar.gz
         echo "${ZOLA_SHA256}  zola.tar.gz" | sha256sum -c
         tar -xzf zola.tar.gz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Typikon is a Zola theme + frontmatter schemas + CI gates for agentic fleet web p
 
 1. [README.md](README.md) — overview, design, usage
 2. [CLAUDE.md](CLAUDE.md) — locked decisions, boundaries
-3. [docs/AGENTIC.md](docs/AGENTIC.md) — agent contract (5 rules)
+3. [docs/AGENTIC.md](docs/AGENTIC.md) — agent contract
 4. [docs/SCHEMAS.md](docs/SCHEMAS.md) — frontmatter field reference
 5. [docs/BOOTSTRAP.md](docs/BOOTSTRAP.md) — scaffolder behavior
 
@@ -53,7 +53,7 @@ Consumer sites use typikon as a git submodule under `themes/typikon/` and scaffo
 
 All decisions are in [CLAUDE.md](CLAUDE.md) under "Locked decisions". Key ones:
 
-- **Static SSG**: Zola 0.22.x. No JavaScript build step in site build path.
+- **Static SSG**: Zola 0.23.x with Tera 2 templates. No JavaScript build step in site build path.
 - **Strict CSP**: no `unsafe-inline` anywhere. CSP-enforce CI gate fails the build on inline script/style/handler.
 - **Self-hosted fonts**: WOFF2 under `static/fonts/`. Zero external CDN at visitor runtime.
 - **Push authority**: `origin` is GitHub; no forge remote is configured. forkwright/kanon#3045 owns the typed authority split.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Web-property-specific standards live alongside as kanon STANDARDS/WEB.md (filed 
 
 ## Locked decisions
 
-- **Static SSG**: Zola 0.22.x. No JavaScript build step, no Node toolchain, no npm in the site build path.
+- **Static SSG**: Zola 0.23.x with Tera 2 templates. No JavaScript build step, no Node toolchain, no npm in the site build path.
 - **Dual-CI migration window**: consumer sites scaffold both `.kanon-ci.toml` and `.github/workflows/deploy.yml`. Forge is primary; GitHub is the executable fallback until menos validates the forge deploy path end-to-end. Both templates target the same Cloudflare Pages project and main/master branch semantics.
 - **Temporary Node deploy-tool exception**: the consumer deploy gates install npm-based `pa11y`, Playwright, and Wrangler so forge and GitHub stay stage-for-stage equivalent during migration. Revisit when forge has native replacements.
 - **Theme distribution**: git submodule under consumer's `themes/typikon/`. (Zola has no theme registry; submodule is current best practice.)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A typikon does not contain the service. It governs how the site enacts the servi
 
 Optimized for agentic operation. Humans should not need to develop here. The substrate ships:
 
-- **Templates** (`templates/`) - Tera templates for base, page, section, journal.
+- **Templates** (`templates/`) - Zola 0.23/Tera 2 templates for base, page, section, journal.
 - **Schemas** (`schemas/`) - JSON Schema for every content type. Frontmatter must validate before commit.
 - **Binaries** (`bin/`) - `typikon-init` (scaffolds a consumer site's content and config inline, no separate template directory), `typikon-validate`, `typikon-check`, `typikon-refresh`, `typikon-migrate-template` (skeleton for schema-migration scripts). Idempotent CLIs with JSONL output where applicable.
 - **CI** (`ci/`) - strict gate: build, CSP enforcement, internal + external link integrity, a11y, smoke. No pass = no deploy.

--- a/_llm/current_state.toml
+++ b/_llm/current_state.toml
@@ -8,9 +8,13 @@ source_docs = [
 ]
 
 [state]
-summary = "Typikon is the active fleet Zola theme, schema, scaffolding, and gate substrate, consumed by ardent-site and ardent-tools-site through the themes/typikon submodule."
-current_phase = "v1 substrate active with consumer adoption through submodules."
-updated = "2026-08-09"
+summary = "Typikon is the active fleet Zola 0.23/Tera 2 theme, schema, scaffolding, and gate substrate, consumed by ardent-site and ardent-tools-site through the themes/typikon submodule."
+current_phase = "v0.5 substrate active; Zola 0.23.3/Tera 2 compatibility is the prerequisite for scoped root-feed work in issue #179."
+updated = "2026-08-19"
+
+[[recent]]
+date = "2026-08-19"
+item = "Migrated the substrate contract from Zola 0.22/Tera 1 to pinned Zola 0.23.3/Tera 2 before issue #179 feed semantics."
 
 [[recent]]
 date = "2026-05-05"

--- a/_llm/decisions.toml
+++ b/_llm/decisions.toml
@@ -15,8 +15,8 @@ id = "D-zola"
 title = "Use Zola as the static-site engine"
 status = "accepted"
 context = "Fleet web properties need static deployment with no JS build path."
-decision = "Use Zola 0.22.x and Tera templates."
-consequences = "Consumer sites avoid Node/npm in the deploy path."
+decision = "Use Zola 0.23.x and Tera 2 templates."
+consequences = "Site generation avoids Node/npm; temporary deployment checks remain a separate CI concern."
 
 [[decision]]
 id = "D-submodule"

--- a/bin/typikon-check
+++ b/bin/typikon-check
@@ -64,7 +64,11 @@
 #     One JSONL line per stage on stdout:
 #         {"stage": "...", "status": "pass|fail|skip|info", "duration_ms": N, "detail": "..."}
 #     `info` lines are coverage receipts (route/check counts), not verdicts.
-#     Detail surface on stderr (each tool's native output).
+#     Failed-stage detail is replayed to stderr through a bounded, JSON-escaped
+#     line protocol; the full native log remains in the reported local temp path.
+#     The wrapper cannot identify credentials in arbitrary child output, so gate
+#     stages must not receive or print secrets. Generated CI runs them without
+#     repository secrets.
 #
 # Exit codes:
 #     0  every implemented stage passed, nothing was skipped
@@ -132,7 +136,19 @@ run_stage() {
     else
         local rc=$?
         local end=$(date +%s%3N)
-        emit "$stage" "fail" "$((end - start))" "exit $rc; see $LOGDIR/$stage.log"
+        local replay_detail
+        if python3 "$TYPIKON_ROOT/ci/replay-stage-log.py" \
+                --stage "$stage" --root "$ROOT" --exit-code "$rc" \
+                "$LOGDIR/$stage.log" >&2; then
+            replay_detail="bounded diagnostics replayed to stderr"
+        else
+            local replay_rc=$?
+            replay_detail="diagnostic replay failed (helper exit $replay_rc)"
+            printf 'typikon-check: failed-stage replay unavailable (helper exit %d); full log retained at %s\n' \
+                "$replay_rc" "$LOGDIR/$stage.log" >&2
+        fi
+        emit "$stage" "fail" "$((end - start))" \
+            "exit $rc; $replay_detail; full log retained at $LOGDIR/$stage.log"
         return 1
     fi
 }

--- a/bin/typikon-defaults.sh
+++ b/bin/typikon-defaults.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # Pinned Zola version. Bump when typikon's Phase-5 gate validates
 # against a new Zola release. Consumer-side workflows pick this up on
 # their next `themes/typikon/bin/typikon-refresh` invocation.
-: "${ZOLA_VERSION:=0.22.1}"
+: "${ZOLA_VERSION:=0.23.3}"
 
 # Pinned wrangler version. An unpinned `npm install -g wrangler` runs inside
 # the deploy step, whose environment already holds CLOUDFLARE_API_TOKEN — so a

--- a/bin/typikon-refresh
+++ b/bin/typikon-refresh
@@ -40,7 +40,7 @@
 # sibling files or operator-authored follow-up commits.
 #
 # Environment:
-#     TYPIKON_ZOLA_VERSION   pinned Zola version (default: 0.22.1, mirroring
+#     TYPIKON_ZOLA_VERSION   pinned Zola version (default: 0.23.3, mirroring
 #                            typikon-init's default)
 #     TYPIKON_PROJECT_NAME   override the auto-derived consumer project
 #                            slug (default: parsed from `git config --get
@@ -64,7 +64,7 @@ re-renders the substituted templates against your consumer config,
 stages the changes, and prints a summary. Does NOT commit.
 
 Environment:
-    TYPIKON_ZOLA_VERSION   pinned Zola version (default: 0.22.1)
+    TYPIKON_ZOLA_VERSION   pinned Zola version (default: 0.23.3)
     TYPIKON_PROJECT_NAME   override consumer project slug
                            (default: derived from git origin URL)
 EOF

--- a/ci/check-content-heading-collision.py
+++ b/ci/check-content-heading-collision.py
@@ -8,7 +8,7 @@ index.html's own version of this guard already has a dedicated fixture
 the same two failure modes for the rest of the family — journal-entry.html,
 faq.html, sizing-guide.html, journal-section.html, page.html, and
 section.html — one authoritative `<h1>` sourced from front matter
-(page.title / section.title), guarded by the shared `assert::no_h1` macro
+(page.title / section.title), guarded by the shared `typikon.assert.no_h1` component
 against a markdown body supplying a competing one:
 
 - page.html and section.html previously rendered NO heading of their own
@@ -90,13 +90,13 @@ H1_RE = re.compile(r"<h1[ >]", re.IGNORECASE)
 
 @dataclass(frozen=True)
 class ContentTemplate:
-    template: str  # exact string this theme's `template` frontmatter field + assert::*(template=...) use
+    template: str  # exact string this theme's `template` frontmatter field + typikon.assert.*(template=...) use
     is_section: bool  # section (_index.md under a subdirectory) vs. leaf page (.md)
-    frontmatter_extra: str  # TOML fragment satisfying this template's own assert::required calls
+    frontmatter_extra: str  # TOML fragment satisfying this template's own typikon.assert.required calls
 
 
 # WHY these minimal shapes and no more: each satisfies exactly the
-# assert::required calls its own template makes (verified by reading
+# typikon.assert.required calls its own template makes (verified by reading
 # templates/*.html directly), so a build failure here can only mean the
 # heading behavior under test, never an unrelated missing field.
 CASES = [

--- a/ci/check-faq-rendering.py
+++ b/ci/check-faq-rendering.py
@@ -104,9 +104,10 @@ def main(argv: list[str]) -> int:
         failures.append("no application/ld+json script block found on the FAQ page")
 
     saw_escaped_breakout = False
+    parsed_blocks = []
     for i, body in enumerate(ldjson_bodies):
         try:
-            json.loads(body)
+            parsed_blocks.append(json.loads(body))
         except json.JSONDecodeError as exc:
             failures.append(
                 f"application/ld+json block {i} is not valid JSON ({exc}) — an "
@@ -125,6 +126,39 @@ def main(argv: list[str]) -> int:
     # block.
     if not saw_escaped_breakout:
         failures.append("escaped '\\/script' not found in any valid JSON-LD block — fixture content missing")
+
+    # A second backslash in the rendered JSON would still leave a textual
+    # ``\\/script`` witness and valid JSON, but json.loads() would preserve a
+    # literal backslash and silently change the FAQ copy. Bind the escape to
+    # its semantic contract: the decoded values must equal the fixture's
+    # original slash-bearing strings exactly.
+    expected_pair = (
+        "What if a question contains </script> ?",
+        "It renders as inert text, both here and inside the FAQPage JSON-LD "
+        "block — </script> must never terminate the ld+json <script> element early.",
+    )
+    faq_pages = [
+        value
+        for value in parsed_blocks
+        if isinstance(value, dict) and value.get("@type") == "FAQPage"
+    ]
+    if len(faq_pages) != 1:
+        failures.append(f"expected one decoded FAQPage object, found {len(faq_pages)}")
+    else:
+        decoded_pairs = [
+            (
+                item.get("name"),
+                item.get("acceptedAnswer", {}).get("text"),
+            )
+            for item in faq_pages[0].get("mainEntity", [])
+            if isinstance(item, dict)
+            and isinstance(item.get("acceptedAnswer"), dict)
+        ]
+        if expected_pair not in decoded_pairs:
+            failures.append(
+                "script-breakout fixture did not round-trip through JSON-LD exactly — "
+                f"expected {expected_pair!r}, decoded {decoded_pairs!r}"
+            )
 
     if failures:
         for line in failures:

--- a/ci/check-faq-rendering.py
+++ b/ci/check-faq-rendering.py
@@ -25,7 +25,7 @@ Usage:
     ci/check-faq-rendering.py <built-sample-shop-public-dir>
 
 NOTE: unlike the standalone checks in this directory, this one needs a
-real Tera render (get_url(), assert::required, and Tera's own macro/
+real Tera render (get_url(), typikon.assert.required, and Tera's component
 scoping rules are all in play) — there is no meaningful way to simulate
 that without invoking zola, so it runs against already-built output
 rather than constructing its own fixture in-process.

--- a/ci/check-faq-rendering.py
+++ b/ci/check-faq-rendering.py
@@ -49,7 +49,32 @@ breakout silently merging/splitting the expected three blocks.
 import json
 import re
 import sys
+from html.parser import HTMLParser
 from pathlib import Path
+
+
+class VisibleTextParser(HTMLParser):
+    """Collect browser-visible text while excluding script/style payloads."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.hidden_depth = 0
+        self.parts: list[str] = []
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        if tag in {"script", "style"}:
+            self.hidden_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style"} and self.hidden_depth:
+            self.hidden_depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if not self.hidden_depth:
+            self.parts.append(data)
 
 
 def main(argv: list[str]) -> int:
@@ -81,13 +106,20 @@ def main(argv: list[str]) -> int:
     if dupes:
         failures.append(f"duplicate element id(s) in rendered FAQ: {dupes}")
 
-    # Script-breakout escaping in visible text. The visible-text rendering
-    # goes through Tera's default HTML autoescaping (item.q is not
-    # `| safe`), so a literal "</script>" reaches the page HTML-entity
-    # encoded (verified against a real zola build: Tera's escaper encodes
-    # "/" as "&#x2F;", not just "<"/">"), not as the literal characters.
-    if "&lt;&#x2F;script&gt;" not in html:
-        failures.append("expected HTML-escaped question text '&lt;&#x2F;script&gt;' not found — fixture content missing")
+    # Script-breakout escaping in visible text. Assert browser semantics,
+    # not one renderer's entity spelling: HTMLParser decodes any safe
+    # equivalent escaping, while a literal </script> parsed as markup cannot
+    # reappear as a visible-text node. Script/style bodies are excluded so the
+    # JSON-LD copy cannot satisfy this witness.
+    visible = VisibleTextParser()
+    visible.feed(html)
+    visible.close()
+    expected_visible_question = "What if a question contains </script> ?"
+    if expected_visible_question not in "".join(visible.parts):
+        failures.append(
+            "script-breakout fixture did not render as browser-visible text — "
+            f"expected {expected_visible_question!r}"
+        )
 
     # The page renders THREE ld+json blocks (Organization, FAQPage,
     # BreadcrumbList) — the fixture content lives in FAQPage's, so every

--- a/ci/check-home-heading.py
+++ b/ci/check-home-heading.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """check-home-heading — regression test for the home-route <h1> assertion in
 ci/smoke/shared.spec.ts (forkwright/typikon#142), and for the build-time
-guard in templates/partials/assert.html's `no_h1` macro (forkwright/typikon#152).
+guard in templates/partials/assert.html's `typikon.assert.no_h1` component
+(forkwright/typikon#152).
 
 Runs the real `zola build` against ISOLATED COPIES of this theme's
 templates/static/sass/theme.toml (never the live checkout in place, so this
@@ -50,7 +51,7 @@ ZOLA = shutil.which("zola")
 # WHY these exact [extra] fields (not a minimal guess): mirrors
 # examples/sample-blog/config.toml, which is the theme's own proof that
 # this shape builds clean — a hand-trimmed config risks passing for the
-# wrong reason (missing an assert::required field this template doesn't
+# wrong reason (missing a typikon.assert.required field this template does not
 # actually reach) rather than proving the heading behavior under test.
 CONFIG_TOML = """title = "Fixture"
 description = "typikon home-heading regression fixture"

--- a/ci/check-tera2-contract.py
+++ b/ci/check-tera2-contract.py
@@ -29,6 +29,7 @@ FORBIDDEN = {
     "positional Tera 2 test argument": re.compile(
         r"\bis\s+(?:matching|starting_with|ending_with)\s*\(\s*[^)=]+\)"
     ),
+    "unsupported Tera 2 date format": re.compile(r'date\(format="%\+"\)'),
 }
 
 PATTERN_WITNESSES = {
@@ -38,6 +39,7 @@ PATTERN_WITNESSES = {
     "removed string filter": "value | escape",
     "renamed trim filter": 'value | trim_end_matches(pat="/")',
     "positional Tera 2 test argument": 'value is ending_with(".svg")',
+    "unsupported Tera 2 date format": 'value | date(format="%+")',
 }
 
 

--- a/ci/check-tera2-contract.py
+++ b/ci/check-tera2-contract.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Keep Typikon's Zola pin and template dialect internally coherent.
+
+Zola 0.23 moved to Tera 2. A version-only bump is not a migration: Tera 1
+macros/imports, namespace calls, several filters, and positional test arguments
+all fail when Zola compiles the theme. This static check catches those known
+incompatibilities before the public GitHub gate downloads Zola and renders the
+fixtures. It does not replace that renderer proof.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_SUFFIXES = {".html", ".xml", ".json", ".txt", ".ics", ".md"}
+
+FORBIDDEN = {
+    "Tera 1 macro/import tag": re.compile(r"\{%[-+]?\s*(?:macro|endmacro|import)\b"),
+    "Tera 1 namespace call": re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*::[A-Za-z_][A-Za-z0-9_]*\s*\("),
+    "removed collection filter": re.compile(r"\|\s*(?:concat|slice|map|filter)\b"),
+    "removed string filter": re.compile(
+        r"\|\s*(?:as_str|addslashes|linebreaksbr|escape)(?![A-Za-z0-9_])"
+    ),
+    "renamed trim filter": re.compile(r"\|\s*trim_(?:start|end)_matches\b"),
+    "positional Tera 2 test argument": re.compile(
+        r"\bis\s+(?:matching|starting_with|ending_with)\s*\(\s*[^)=]+\)"
+    ),
+}
+
+PATTERN_WITNESSES = {
+    "Tera 1 macro/import tag": '{% import "partials/assert.html" as assert %}',
+    "Tera 1 namespace call": "assert::required(ok=true)",
+    "removed collection filter": "items | concat(with=item)",
+    "removed string filter": "value | escape",
+    "renamed trim filter": 'value | trim_end_matches(pat="/")',
+    "positional Tera 2 test argument": 'value is ending_with(".svg")',
+}
+
+
+def first_match(pattern: str, path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(pattern, text, re.MULTILINE)
+    if not match:
+        raise ValueError(f"{path.relative_to(ROOT)}: expected pattern {pattern!r}")
+    return match.group(1)
+
+
+def version_tuple(value: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(part) for part in value.split("."))
+    except ValueError as exc:
+        raise ValueError(f"invalid dotted Zola version {value!r}") from exc
+
+
+def check_pattern_witnesses() -> list[str]:
+    """Prove every static detector observes the old syntax it claims to reject."""
+    failures: list[str] = []
+    for label, pattern in FORBIDDEN.items():
+        witness = PATTERN_WITNESSES[label]
+        if not pattern.search(witness):
+            failures.append(f"internal detector {label!r} missed its witness {witness!r}")
+    return failures
+
+
+def check_pin_coherence() -> list[str]:
+    failures: list[str] = []
+    try:
+        default = first_match(
+            r'ZOLA_VERSION:=([0-9]+\.[0-9]+\.[0-9]+)',
+            ROOT / "bin" / "typikon-defaults.sh",
+        )
+        own_gate = first_match(
+            r"^\s*ZOLA_VERSION=([0-9]+\.[0-9]+\.[0-9]+)$",
+            ROOT / ".github" / "workflows" / "gate-attestation.yml",
+        )
+        minimum = first_match(
+            r'^min_version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"$',
+            ROOT / "theme.toml",
+        )
+    except ValueError as exc:
+        return [str(exc)]
+
+    if version_tuple(default) < (0, 23, 0):
+        failures.append(
+            f"bin/typikon-defaults.sh: Zola {default} predates the Tera 2 runtime"
+        )
+    if own_gate != default:
+        failures.append(
+            f".github/workflows/gate-attestation.yml pins {own_gate}, default is {default}"
+        )
+    if minimum != default:
+        failures.append(f"theme.toml min_version is {minimum}, default is {default}")
+
+    hash_paths = [
+        ROOT / ".github" / "workflows" / "gate-attestation.yml",
+        ROOT / "ci" / "github-workflow.yml.tmpl",
+        ROOT / "ci" / "kanon-ci.toml.tmpl",
+    ]
+    hashes: list[tuple[Path, str]] = []
+    for path in hash_paths:
+        text = path.read_text(encoding="utf-8")
+        match = re.search(r"ZOLA_SHA256(?::|=)\s*([0-9a-f]{64})", text)
+        if not match:
+            failures.append(f"{path.relative_to(ROOT)}: missing 64-hex ZOLA_SHA256")
+            continue
+        hashes.append((path, match.group(1)))
+    if len({value for _, value in hashes}) > 1:
+        detail = ", ".join(f"{path.relative_to(ROOT)}={value}" for path, value in hashes)
+        failures.append(f"Zola artifact hashes disagree: {detail}")
+
+    for path in (ROOT / "ci" / "github-workflow.yml.tmpl", ROOT / "ci" / "kanon-ci.toml.tmpl"):
+        if "{{ ZOLA_VERSION }}" not in path.read_text(encoding="utf-8"):
+            failures.append(f"{path.relative_to(ROOT)}: missing canonical ZOLA_VERSION placeholder")
+
+    return failures
+
+
+def check_template_dialect() -> list[str]:
+    failures: list[str] = []
+    definitions: dict[str, Path] = {}
+    shortcodes = ROOT / "templates" / "shortcodes"
+    if shortcodes.is_dir() and any(path.is_file() for path in shortcodes.rglob("*")):
+        failures.append(
+            "templates/shortcodes: Zola 0.23 removed shortcodes; migrate them to Tera 2 components"
+        )
+
+    for path in sorted((ROOT / "templates").rglob("*")):
+        if not path.is_file() or path.suffix not in TEMPLATE_SUFFIXES:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for label, pattern in FORBIDDEN.items():
+            for match in pattern.finditer(text):
+                line = text.count("\n", 0, match.start()) + 1
+                failures.append(f"{path.relative_to(ROOT)}:{line}: {label}: {match.group(0)!r}")
+        for match in re.finditer(r"\{%[-+]?\s*component\s+([A-Za-z_][A-Za-z0-9_.]*)", text):
+            name = match.group(1)
+            line = text.count("\n", 0, match.start()) + 1
+            if not name.startswith("typikon."):
+                failures.append(
+                    f"{path.relative_to(ROOT)}:{line}: component {name!r} lacks typikon namespace"
+                )
+            if name in definitions:
+                failures.append(
+                    f"{path.relative_to(ROOT)}:{line}: duplicate component {name!r}; first in "
+                    f"{definitions[name].relative_to(ROOT)}"
+                )
+            else:
+                definitions[name] = path
+        for match in re.finditer(r"\{\{[-+]?\s*<([A-Za-z_][A-Za-z0-9_.]*)", text):
+            name = match.group(1)
+            if not name.startswith("typikon."):
+                line = text.count("\n", 0, match.start()) + 1
+                failures.append(
+                    f"{path.relative_to(ROOT)}:{line}: component call {name!r} lacks typikon namespace"
+                )
+    return failures
+
+
+def main() -> int:
+    failures = [
+        *check_pattern_witnesses(),
+        *check_pin_coherence(),
+        *check_template_dialect(),
+    ]
+    if failures:
+        for failure in failures:
+            print(f"check-tera2-contract: {failure}", file=sys.stderr)
+        return 1
+    print("check-tera2-contract: ok (pin/hash coherence and Tera 2 source dialect)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check-tera2-contract.py
+++ b/ci/check-tera2-contract.py
@@ -121,6 +121,18 @@ def check_pin_coherence() -> list[str]:
     return failures
 
 
+def check_xml_preamble() -> list[str]:
+    """Keep the XML declaration at the first byte of the Atom template source."""
+    atom = ROOT / "templates" / "atom.xml"
+    declaration = b'<?xml version="1.0" encoding="UTF-8"?>'
+    if not atom.read_bytes().startswith(declaration):
+        return [
+            "templates/atom.xml: XML declaration must begin at byte zero; "
+            "leading template whitespace renders an invalid feed"
+        ]
+    return []
+
+
 def check_template_dialect() -> list[str]:
     failures: list[str] = []
     definitions: dict[str, Path] = {}
@@ -166,6 +178,7 @@ def main() -> int:
     failures = [
         *check_pattern_witnesses(),
         *check_pin_coherence(),
+        *check_xml_preamble(),
         *check_template_dialect(),
     ]
     if failures:

--- a/ci/check-tera2-rendering.py
+++ b/ci/check-tera2-rendering.py
@@ -7,6 +7,8 @@ but only a real render can establish the migrated runtime semantics:
 
 - missing ``[extra.author]`` falls back to the site title/base URL in Atom and
   to the site title in Article JSON-LD;
+- Atom timestamps use Jiff-compatible RFC 3339 output and an absent page
+  ``updated`` value falls back to its publication date;
 - a component receives no ambient ``lang``, so the breadcrumb component must
   carry the translated page's language into every ``get_section`` lookup;
 - the array-spread replacement for Tera 1's ``concat`` retains ``rel="me"``
@@ -198,6 +200,13 @@ def check_atom_author(public: Path, failures: list[str]) -> None:
         failures.append(f"author-less Atom name: expected site title, got {name!r}")
     if uri != "https://renderer-fixture.example.com":
         failures.append(f"author-less Atom URI: expected base URL, got {uri!r}")
+    expected_timestamp = "2026-08-19T00:00:00+00:00"
+    feed_updated = atom.findtext("atom:updated", namespaces=namespace)
+    if feed_updated != expected_timestamp:
+        failures.append(
+            "Atom feed updated: expected Jiff-compatible RFC 3339 publication fallback "
+            f"{expected_timestamp!r}, got {feed_updated!r}"
+        )
     entries = atom.findall("atom:entry", namespace)
     if len(entries) != 1:
         failures.append(f"author-less Atom entries: expected exactly 1, got {len(entries)}")
@@ -206,6 +215,13 @@ def check_atom_author(public: Path, failures: list[str]) -> None:
         if entry_author != "Renderer Fixture":
             failures.append(
                 f"author-less Atom entry name: expected site title, got {entry_author!r}"
+            )
+        published = entries[0].findtext("atom:published", namespaces=namespace)
+        updated = entries[0].findtext("atom:updated", namespaces=namespace)
+        if published != expected_timestamp or updated != expected_timestamp:
+            failures.append(
+                "Atom entry timestamps: expected publication and null-updated fallback to "
+                f"{expected_timestamp!r}, got published={published!r}, updated={updated!r}"
             )
 
 

--- a/ci/check-tera2-rendering.py
+++ b/ci/check-tera2-rendering.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Exercise the Tera 2 migration paths that static syntax checks cannot prove.
+
+Zola 0.23 moved Typikon from Tera 1 macros to globally registered, isolated-
+context Tera 2 components. ``check-tera2-contract.py`` rejects the old dialect,
+but only a real render can establish the migrated runtime semantics:
+
+- missing ``[extra.author]`` falls back to the site title/base URL in Atom and
+  to the site title in Article JSON-LD;
+- a component receives no ambient ``lang``, so the breadcrumb component must
+  carry the translated page's language into every ``get_section`` lookup;
+- the array-spread replacement for Tera 1's ``concat`` retains ``rel="me"``
+  links in Organization ``sameAs``.
+
+The public GitHub gate installs the pinned Zola binary before auto-discovering
+this no-argument fixture. The fixture builds only an isolated temporary site;
+it never writes generated output into the checkout.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+
+
+THEME_ROOT = Path(__file__).resolve().parent.parent
+ZOLA = shutil.which("zola")
+
+CONFIG_TOML = '''title = "Renderer Fixture"
+description = "Default-language renderer fixture."
+base_url = "https://renderer-fixture.example.com"
+default_language = "en"
+output_dir = "public"
+theme = "typikon"
+generate_feeds = true
+feed_filenames = ["atom.xml"]
+
+[languages.fr]
+title = "Matrice française"
+description = "Fixture de rendu en français."
+generate_feeds = true
+feed_filenames = ["atom.xml"]
+
+[extra]
+brand_name = "Renderer Fixture"
+brand_greek = "Δοκιμή"
+logo_path = "img/logo.svg"
+theme_color = "#FBF7EC"
+og_locale = "en_US"
+founding_date = "2026"
+footer_links = [
+  { url = "https://profile.example.com/first", label = "First profile", rel = "me" },
+  { url = "/contact/", label = "Contact" },
+  { url = "https://profile.example.com/second", label = "Second profile", rel = "me" },
+]
+'''
+
+ROOT_EN = '''+++
+title = "English Home"
+description = "Default-language home."
+template = "section.html"
++++
+'''
+
+ROOT_FR = '''+++
+title = "Accueil français"
+description = "Accueil traduit."
+template = "section.html"
++++
+'''
+
+SECTION_EN = '''+++
+title = "English Journal"
+description = "Default-language journal."
+sort_by = "date"
+template = "journal-section.html"
+page_template = "journal-entry.html"
++++
+'''
+
+SECTION_FR = '''+++
+title = "Journal français"
+description = "Journal traduit."
+sort_by = "date"
+template = "journal-section.html"
+page_template = "journal-entry.html"
++++
+'''
+
+ENTRY_EN = '''+++
+title = "English Entry"
+description = "Default-language entry."
+date = 2026-08-19
+
+[extra]
+audience = "renderer fixture readers"
+components = "Tera 2 · defaults · breadcrumbs"
++++
+
+Default-language body.
+'''
+
+ENTRY_FR = '''+++
+title = "Entrée française"
+description = "Entrée traduite."
+date = 2026-08-19
+
+[extra]
+audience = "lecteurs de la fixture"
+components = "Tera 2 · langue · fil d’Ariane"
++++
+
+Corps traduit.
+'''
+
+
+class JsonLdParser(HTMLParser):
+    """Collect JSON values from ``application/ld+json`` script elements."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self._chunks: list[str] | None = None
+        self.payloads: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "script" and dict(attrs).get("type") == "application/ld+json":
+            self._chunks = []
+
+    def handle_data(self, data: str) -> None:
+        if self._chunks is not None:
+            self._chunks.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "script" and self._chunks is not None:
+            self.payloads.append("".join(self._chunks))
+            self._chunks = None
+
+
+def copy_theme(dest: Path) -> None:
+    for item in ("templates", "static", "sass", "theme.toml"):
+        source = THEME_ROOT / item
+        if not source.exists():
+            continue
+        if source.is_dir():
+            shutil.copytree(source, dest / item)
+        else:
+            shutil.copy2(source, dest / item)
+
+
+def make_site(root: Path, theme_dir: Path) -> Path:
+    site = root / "site"
+    journal = site / "content" / "journal"
+    journal.mkdir(parents=True)
+    (site / "themes").mkdir()
+    (site / "themes" / "typikon").symlink_to(theme_dir, target_is_directory=True)
+
+    files = {
+        site / "config.toml": CONFIG_TOML,
+        site / "content" / "_index.md": ROOT_EN,
+        site / "content" / "_index.fr.md": ROOT_FR,
+        journal / "_index.md": SECTION_EN,
+        journal / "_index.fr.md": SECTION_FR,
+        journal / "entry.md": ENTRY_EN,
+        journal / "entry.fr.md": ENTRY_FR,
+    }
+    for path, content in files.items():
+        path.write_text(content, encoding="utf-8")
+    return site
+
+
+def json_ld_objects(path: Path) -> list[dict[str, Any]]:
+    parser = JsonLdParser()
+    parser.feed(path.read_text(encoding="utf-8"))
+    values = [json.loads(payload) for payload in parser.payloads]
+    return [value for value in values if isinstance(value, dict)]
+
+
+def object_of_type(objects: list[dict[str, Any]], kind: str) -> dict[str, Any]:
+    matches = [value for value in objects if value.get("@type") == kind]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {kind} JSON-LD object, found {len(matches)}")
+    return matches[0]
+
+
+def check_atom_author(public: Path, failures: list[str]) -> None:
+    atom = ET.parse(public / "atom.xml").getroot()
+    namespace = {"atom": "http://www.w3.org/2005/Atom"}
+    name = atom.findtext("atom:author/atom:name", namespaces=namespace)
+    uri = atom.findtext("atom:author/atom:uri", namespaces=namespace)
+    if name != "Renderer Fixture":
+        failures.append(f"author-less Atom name: expected site title, got {name!r}")
+    if uri != "https://renderer-fixture.example.com":
+        failures.append(f"author-less Atom URI: expected base URL, got {uri!r}")
+    entries = atom.findall("atom:entry", namespace)
+    if len(entries) != 1:
+        failures.append(f"author-less Atom entries: expected exactly 1, got {len(entries)}")
+    else:
+        entry_author = entries[0].findtext("atom:author/atom:name", namespaces=namespace)
+        if entry_author != "Renderer Fixture":
+            failures.append(
+                f"author-less Atom entry name: expected site title, got {entry_author!r}"
+            )
+
+
+def check_structured_data(public: Path, failures: list[str]) -> None:
+    english = json_ld_objects(public / "journal" / "entry" / "index.html")
+    article = object_of_type(english, "Article")
+    article_author = article.get("author", {}).get("name")
+    if article_author != "Renderer Fixture":
+        failures.append(
+            f"author-less Article name: expected site title, got {article_author!r}"
+        )
+
+    organization = object_of_type(english, "Organization")
+    expected_same_as = [
+        "https://profile.example.com/first",
+        "https://profile.example.com/second",
+    ]
+    if organization.get("sameAs") != expected_same_as:
+        failures.append(
+            "Organization sameAs: expected only the two ordered rel=me URLs after Tera 2 array "
+            f"spread, got {organization.get('sameAs')!r}"
+        )
+
+    french = json_ld_objects(public / "fr" / "journal" / "entry" / "index.html")
+    breadcrumb = object_of_type(french, "BreadcrumbList")
+    breadcrumb_items = [
+        (item.get("position"), item.get("name"), item.get("item"))
+        for item in breadcrumb.get("itemListElement", [])
+    ]
+    expected_items = [
+        (1, "Matrice française", "https://renderer-fixture.example.com"),
+        (2, "Accueil français", "https://renderer-fixture.example.com/fr/"),
+        (3, "Journal français", "https://renderer-fixture.example.com/fr/journal/"),
+        (4, "Entrée française", "https://renderer-fixture.example.com/fr/journal/entry/"),
+    ]
+    if breadcrumb_items != expected_items:
+        failures.append(
+            "translated breadcrumb: expected ordered French ancestors and canonical URLs "
+            f"{expected_items!r}, got {breadcrumb_items!r}"
+        )
+
+
+def main() -> int:
+    if ZOLA is None:
+        print(
+            "check-tera2-rendering: FAIL — zola not on PATH "
+            "(see gate-attestation.yml's install step)",
+            file=sys.stderr,
+        )
+        return 1
+
+    failures: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="typikon-tera2-rendering-") as tmp:
+        root = Path(tmp)
+        theme = root / "theme"
+        copy_theme(theme)
+        site = make_site(root, theme)
+        try:
+            version = subprocess.run(
+                [ZOLA, "--version"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=15,
+            )
+            version_text = f"{version.stdout}\n{version.stderr}".strip()
+            if version.returncode != 0 or version_text != "zola 0.23.3":
+                failures.append(
+                    "renderer authority: expected zola 0.23.3, got "
+                    f"exit {version.returncode} and output {version_text!r}"
+                )
+
+            result = subprocess.run(
+                [ZOLA, "build"],
+                cwd=site,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=120,
+            )
+            if result.returncode != 0:
+                failures.append(
+                    f"pinned Zola/Tera renderer exited {result.returncode}:\n"
+                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+                )
+            else:
+                public = site / "public"
+                try:
+                    check_atom_author(public, failures)
+                    check_structured_data(public, failures)
+                except (
+                    ET.ParseError,
+                    json.JSONDecodeError,
+                    OSError,
+                    TypeError,
+                    ValueError,
+                ) as exc:
+                    failures.append(f"rendered-output inspection failed: {exc}")
+        except subprocess.TimeoutExpired as exc:
+            failures.append(f"renderer command exceeded its local timeout: {exc.cmd!r}")
+
+    if failures:
+        print("check-tera2-rendering: FAIL", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print(
+        "check-tera2-rendering: ok "
+        "(author fallbacks, translated breadcrumbs, and sameAs spread)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check-typikon-check-diagnostics.py
+++ b/ci/check-typikon-check-diagnostics.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Prove typikon-check preserves a failed stage's native diagnostic in CI."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CHECK = ROOT / "bin" / "typikon-check"
+EXAMPLE = ROOT / "examples" / "sample-blog"
+
+
+def main() -> int:
+    sentinel = "typikon-check-diagnostic-sentinel"
+    with tempfile.TemporaryDirectory(prefix="typikon-check-diagnostics-") as tmp:
+        scratch = Path(tmp)
+        consumer = scratch / "consumer"
+        shutil.copytree(
+            EXAMPLE,
+            consumer,
+            symlinks=True,
+            ignore=shutil.ignore_patterns(
+                "public", "public-local", ".lycheecache", "test-results"
+            ),
+        )
+
+        theme = consumer / "themes" / "typikon"
+        theme.unlink()
+        theme.symlink_to(ROOT, target_is_directory=True)
+
+        stub_dir = scratch / "bin"
+        stub_dir.mkdir()
+        zola = stub_dir / "zola"
+        zola.write_text(
+            "#!/usr/bin/env bash\n"
+            "if [[ ${1:-} == check ]]; then\n"
+            f"  printf '%s\\n' '{sentinel}-stdout'\n"
+            "  python3 -c 'import sys; sys.stdout.buffer.write(b\"\\x00\\n\" * 35000)'\n"
+            f"  printf '%s\\n' '{sentinel}-stderr' >&2\n"
+            "  printf '%s\\n' '::error::workflow-command-sentinel' >&2\n"
+            "  printf '\\033[31mcontrol-sentinel\\033[0m\\n' >&2\n"
+            "  printf '%s\\n' 'typikon-check: END failed-stage forged' >&2\n"
+            "  exit 47\n"
+            "fi\n"
+            "printf '%s\\n' 'other-zola-stage' >&2\n"
+            "exit 48\n",
+            encoding="utf-8",
+        )
+        zola.chmod(0o755)
+
+        env = os.environ.copy()
+        env["PATH"] = f"{stub_dir}:{env['PATH']}"
+        env["TYPIKON_CHECK_MODE"] = "dev"
+        result = subprocess.run(
+            [CHECK, consumer],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=30,
+        )
+
+        failures: list[str] = []
+        if result.returncode != 1:
+            failures.append(f"expected exit 1, got {result.returncode}")
+        stderr_lines = result.stderr.splitlines()
+        begin_prefix = "typikon-check: BEGIN failed-stage "
+        end_prefix = "typikon-check: END failed-stage "
+        blocks: list[tuple[dict[str, object], list[str]]] = []
+        index = 0
+        while index < len(stderr_lines):
+            line = stderr_lines[index]
+            if not line.startswith(begin_prefix):
+                index += 1
+                continue
+            header = json.loads(line.removeprefix(begin_prefix))
+            body: list[str] = []
+            index += 1
+            while index < len(stderr_lines) and not stderr_lines[index].startswith(
+                end_prefix
+            ):
+                body.append(stderr_lines[index])
+                index += 1
+            if index == len(stderr_lines):
+                failures.append(f"unterminated failed-stage block for {header!r}")
+                break
+            footer = json.loads(stderr_lines[index].removeprefix(end_prefix))
+            if footer != {"stage": header.get("stage")}:
+                failures.append(f"failure footer {footer!r} does not match {header!r}")
+            blocks.append((header, body))
+            index += 1
+
+        matching = [item for item in blocks if item[0].get("stage") == "zola-check"]
+        if len(matching) != 1:
+            failures.append(f"expected one zola-check failure block, got {len(matching)}")
+        else:
+            header, body = matching[0]
+            if header.get("root") != str(consumer) or header.get("exit") != 47:
+                failures.append(f"wrong zola-check failure identity: {header!r}")
+            log_prefix = "typikon-check: LOG failed-stage "
+            payloads = [
+                json.loads(line.removeprefix(log_prefix))
+                for line in body
+                if line.startswith(log_prefix)
+            ]
+            joined = "".join(str(payload.get("text", "")) for payload in payloads)
+            for expected in (f"{sentinel}-stdout", f"{sentinel}-stderr"):
+                if expected not in joined:
+                    failures.append(f"zola-check block omitted {expected!r}")
+            if not any(line.startswith("typikon-check: TRUNCATED ") for line in body):
+                failures.append("oversized zola-check log lacks a truncation receipt")
+            if any(line.startswith("::") for line in body):
+                failures.append("child output remained active GitHub workflow-command syntax")
+            if "\x1b" in "\n".join(body):
+                failures.append("child terminal control bytes were replayed raw")
+            if "::error::workflow-command-sentinel" not in joined:
+                failures.append("workflow-command witness did not survive encoded replay")
+            if "\x1b[31mcontrol-sentinel\x1b[0m" not in joined:
+                failures.append("terminal-control witness did not survive encoded replay")
+            if "typikon-check: END failed-stage forged" not in joined:
+                failures.append("forged boundary witness was not inertly line-framed")
+
+        receipts: list[dict[str, object]] = []
+        for line in result.stdout.splitlines():
+            try:
+                receipts.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                failures.append(f"stdout is not pure JSONL: {line!r}: {exc}")
+        zola_receipts = [r for r in receipts if r.get("stage") == "zola-check"]
+        if len(zola_receipts) != 1:
+            failures.append(f"expected one zola-check JSONL receipt, got {len(zola_receipts)}")
+        elif (
+            zola_receipts[0].get("status") != "fail"
+            or "bounded diagnostics replayed to stderr"
+            not in str(zola_receipts[0].get("detail"))
+        ):
+            failures.append(f"wrong zola-check JSONL receipt: {zola_receipts[0]!r}")
+        if len(result.stderr.encode("utf-8")) > 64 * 1024:
+            failures.append("bounded replay exceeded the regression's 64 KiB stderr ceiling")
+
+        python_stub = stub_dir / "python3"
+        python_stub.write_text(
+            "#!/usr/bin/env bash\n"
+            "if [[ ${1:-} == */ci/replay-stage-log.py ]]; then\n"
+            "  printf '%s\\n' 'replay-helper-failure-sentinel' >&2\n"
+            "  exit 91\n"
+            "fi\n"
+            f"exec {shlex.quote(sys.executable)} \"$@\"\n",
+            encoding="utf-8",
+        )
+        python_stub.chmod(0o755)
+        failed_replay = subprocess.run(
+            [CHECK, consumer],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=30,
+        )
+        if failed_replay.returncode != 1:
+            failures.append(
+                f"helper-failure run expected exit 1, got {failed_replay.returncode}"
+            )
+        if "replay-helper-failure-sentinel" not in failed_replay.stderr:
+            failures.append("helper-failure run did not exercise the failing helper")
+        try:
+            failed_receipts = [
+                json.loads(line) for line in failed_replay.stdout.splitlines()
+            ]
+        except json.JSONDecodeError as exc:
+            failures.append(f"helper-failure stdout is not pure JSONL: {exc}")
+            failed_receipts = []
+        failed_zola = [r for r in failed_receipts if r.get("stage") == "zola-check"]
+        if len(failed_zola) != 1 or "diagnostic replay failed (helper exit 91)" not in str(
+            failed_zola[0].get("detail") if failed_zola else ""
+        ):
+            failures.append(f"helper failure was reported untruthfully: {failed_zola!r}")
+        if "bounded diagnostics replayed to stderr" in failed_replay.stdout:
+            failures.append("helper-failure run falsely claimed diagnostics were replayed")
+
+        if failures:
+            print("check-typikon-check-diagnostics: FAIL")
+            for failure in failures:
+                print(f"  - {failure}")
+            print(f"stdout:\n{result.stdout}")
+            print(f"stderr:\n{result.stderr}")
+            return 1
+
+    print("check-typikon-check-diagnostics: ok (failed-stage detail survives CI capture)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -59,7 +59,7 @@ jobs:
         env:
           # Pinned per typikon Stage 2a. Refresh when ZOLA_VERSION bumps via:
           #   curl -sL https://github.com/getzola/zola/releases/download/v<X>/zola-v<X>-x86_64-unknown-linux-gnu.tar.gz | sha256sum
-          ZOLA_SHA256: 0ca09aa40376aaa9ddfb512ff9ad963262ef95edb0d0f2d5ec6961b6f5cf22ef
+          ZOLA_SHA256: f07c92607e5745268b576bd325ceef3a582aada253bb64db8d92a8a85303d958
         run: |
           curl -L --proto '=https' --tlsv1.2 "https://github.com/getzola/zola/releases/download/v{{ ZOLA_VERSION }}/zola-v{{ ZOLA_VERSION }}-x86_64-unknown-linux-gnu.tar.gz" \
             -o zola.tar.gz

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -37,7 +37,7 @@ stages = [
 [stages.install-zola]
 cmd = """
 set -euo pipefail
-ZOLA_SHA256=0ca09aa40376aaa9ddfb512ff9ad963262ef95edb0d0f2d5ec6961b6f5cf22ef
+ZOLA_SHA256=f07c92607e5745268b576bd325ceef3a582aada253bb64db8d92a8a85303d958
 curl -L --proto '=https' --tlsv1.2 "https://github.com/getzola/zola/releases/download/v{{ ZOLA_VERSION }}/zola-v{{ ZOLA_VERSION }}-x86_64-unknown-linux-gnu.tar.gz" -o zola.tar.gz
 echo "${ZOLA_SHA256}  zola.tar.gz" | sha256sum -c
 tar -xzf zola.tar.gz

--- a/ci/replay-stage-log.py
+++ b/ci/replay-stage-log.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Replay a failed typikon-check stage without trusting its output as CI syntax.
+
+Child output is arbitrary consumer/tool text. Framing retained head/tail chunks
+as JSON strings prevents GitHub workflow commands, terminal controls, and
+forged boundaries from becoming active protocol. Both input reads and encoded
+output are bounded; the complete native log remains on disk for local runs.
+This helper cannot identify credentials, so callers must not give gate stages
+secrets to print.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+
+
+OUTPUT_LIMIT_BYTES = 60 * 1024
+HEAD_BYTES = 4 * 1024
+TAIL_BYTES = 4 * 1024
+READ_LIMIT_BYTES = HEAD_BYTES + TAIL_BYTES
+
+
+def frame(prefix: str, payload: object) -> bytes:
+    encoded = json.dumps(payload, ensure_ascii=True, sort_keys=True)
+    return f"{prefix}{encoded}\n".encode("utf-8")
+
+
+def read_chunks(path: Path) -> tuple[int, list[tuple[str, bytes]]]:
+    with path.open("rb") as handle:
+        size = os.fstat(handle.fileno()).st_size
+        if size <= READ_LIMIT_BYTES:
+            return size, [("full", handle.read(READ_LIMIT_BYTES))]
+
+        head = handle.read(HEAD_BYTES)
+        handle.seek(max(size - TAIL_BYTES, 0))
+        tail = handle.read(TAIL_BYTES)
+        return size, [("head", head), ("tail", tail)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage", required=True)
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--exit-code", required=True, type=int)
+    parser.add_argument("log", type=Path)
+    args = parser.parse_args()
+
+    log_bytes, chunks = read_chunks(args.log)
+    retained_bytes = sum(len(data) for _, data in chunks)
+    header = {
+        "stage": args.stage,
+        "root": args.root,
+        "exit": args.exit_code,
+        "log_bytes": log_bytes,
+        "retained_bytes": retained_bytes,
+        "output_limit_bytes": OUTPUT_LIMIT_BYTES,
+    }
+    output = [frame("typikon-check: BEGIN failed-stage ", header)]
+    for label, data in chunks:
+        output.append(
+            frame(
+                "typikon-check: LOG failed-stage ",
+                {
+                    "label": label,
+                    "text": data.decode("utf-8", errors="backslashreplace"),
+                },
+            )
+        )
+    if log_bytes > retained_bytes:
+        truncation = {
+            "omitted_bytes": log_bytes - retained_bytes,
+            "retained_head_bytes": len(chunks[0][1]),
+            "retained_tail_bytes": len(chunks[-1][1]),
+        }
+        output.append(frame("typikon-check: TRUNCATED ", truncation))
+    output.append(
+        frame("typikon-check: END failed-stage ", {"stage": args.stage})
+    )
+
+    encoded = b"".join(output)
+    if len(encoded) > OUTPUT_LIMIT_BYTES:
+        print(
+            "replay-stage-log: encoded failure record exceeds "
+            f"{OUTPUT_LIMIT_BYTES}-byte output limit ({len(encoded)} bytes)",
+            file=sys.stderr,
+        )
+        return 2
+    sys.stdout.buffer.write(encoded)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -170,6 +170,35 @@ For a structural change (template, schema, primitive):
 7. on merge: run migration against each consumer, open consumer-side PRs
 ```
 
+### Zola and Tera compatibility boundary
+
+Typikon pins Zola 0.23.3 in `bin/typikon-defaults.sh`; `theme.toml` declares the
+same minimum and the generated CI templates install the matching, hash-verified
+release artifact. Zola 0.23 moved the renderer to Tera 2, so consumer template
+overrides must migrate with the submodule instead of treating the update as an
+isolated version change.
+
+- Define reusable template behavior with a collision-resistant dotted name such
+  as `{% component typikon.assert.required(...) %}` and call it with
+  `{{ <typikon.assert.required ... /> }}`. Components are global and a consumer
+  template can otherwise replace a theme component of the same name silently.
+  Tera 1 `{% macro %}`, `{% import %}`, and `name::call()` syntax is invalid.
+- A component receives only its declared arguments (plus registered functions and
+  filters). Pass `config`, `page`, `section`, or any narrower value explicitly when
+  the component needs it. Do not rely on the caller's ambient template context.
+- Zola 0.23 removed shortcodes. Convert consumer shortcodes to Tera 2 components and
+  update every content call before raising the Zola pin.
+- Replace removed Tera 1 collection filters with Tera 2 expressions such as array
+  spread or slicing, and pass test arguments by keyword (`is matching(pat="...")`).
+
+`ci/check-tera2-contract.py` rejects the known old dialect and proves that the
+theme minimum, Typikon's own gate, generated consumer gates, and artifact hashes
+remain coherent. `ci/check-tera2-rendering.py` builds isolated multilingual and
+author-less fixtures to prove component context, fallbacks, and array-spread
+behavior. The public GitHub fixture gate is still the renderer authority: the
+static check cannot establish that a template compiles or that rendered bytes
+preserve their contract.
+
 ## Starting a new typikon-consuming site
 
 When a new fleet site enters the family, do not fork or copy. Consume the substrate.
@@ -199,9 +228,9 @@ The substrate is design-family neutral. Brand-specific values go in `config.toml
 | `[extra.author]`            | atom feed `<author>` + JSON-LD Article author |
 | `consumer_css`              | list of stylesheet paths, each `<link>`ed after core's own `style.css`, in order (`templates/base.html`'s Consumer stylesheet hook) |
 
-If a brand needs a *visual* override beyond the table above (different scale ratio, different color palette, different type pairing), declare it via `consumer_css` and redeclare the relevant `:root` custom properties in that file. Core's own interactive-state CSS (nav hover, buttons, the home triad mark, FAQ anchors, ...) never hard-codes a hue — it resolves through four semantic tokens, `--accent-1` through `--accent-4`, which default to a neutral `--text-mid` and exist solely for a skin to redeclare. `static/css/skins/leather.css` is the first-party example: it maps those four tokens to Ardent Leatherworks' dye palette and carries that brand's own content-authoring classes (`.dye-entry-*`, `.swatch-*`, `.dye-marks`) — copy its shape, not its colors, for a new skin. **Do not edit typikon's `static/css/style.css`** for one-off site needs — that's a fork by mutation.
+If a brand needs a *visual* override beyond the table above (different scale ratio, different color palette, different type pairing), declare it via `consumer_css` and redeclare the relevant `:root` custom properties in that file. Core's own interactive-state CSS never hard-codes a hue. Nav hover, buttons, the home triad mark, FAQ anchors, and similar surfaces resolve through four semantic tokens: `--accent-1` through `--accent-4`. Those tokens default to a neutral `--text-mid` and exist solely for a skin to redeclare. `static/css/skins/leather.css` is the first-party example: it maps those four tokens to Ardent Leatherworks' dye palette and carries that brand's own content-authoring classes (`.dye-entry-*`, `.swatch-*`, `.dye-marks`) — copy its shape, not its colors, for a new skin. **Do not edit typikon's `static/css/style.css`** for one-off site needs — that's a fork by mutation.
 
-Beyond styles, `templates/base.html`'s own header comment documents the full design/extension surface (forkwright/typikon#55): a `{% block %}` for head metadata, nav, footer, structured data (JSON-LD), scripts, and page composition, each with a sane default a consumer only overrides when it needs to. A consumer template extends `base.html` and overrides just the block(s) it needs — it does not need to copy the whole file to add a stylesheet, a nav item, or a JSON-LD field.
+Beyond styles, `templates/base.html`'s own header comment documents the full design/extension surface (forkwright/typikon#55). It provides a `{% block %}` for head metadata, nav, footer, structured data (JSON-LD), scripts, and page composition. Each has a sane default that a consumer overrides only when needed. A consumer template extends `base.html` and overrides just the block(s) it needs — it does not need to copy the whole file to add a stylesheet, a nav item, or a JSON-LD field.
 
 ### 3. When to extend typikon vs. override locally
 

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -51,7 +51,7 @@
        the feed valid. #}
     {%- set feed_updated = last_updated | default(value=now(), boolean=true) -%}
     {%- endif -%}
-    <updated>{{ feed_updated | date(format="%+") }}</updated>
+    <updated>{{ feed_updated | date(format="%Y-%m-%dT%H:%M:%S%:z") }}</updated>
     <id>{{ feed_url | safe }}</id>
     <author>
         <name>{{ author_name }}</name>
@@ -60,8 +60,8 @@
     {%- for page in pages %}
     <entry xml:lang="{{ page.lang | default(value=lang) }}">
         <title>{{ page.title }}</title>
-        <published>{{ page.date | date(format="%+") }}</published>
-        <updated>{{ page.updated | default(value=page.date, boolean=true) | date(format="%+") }}</updated>
+        <published>{{ page.date | date(format="%Y-%m-%dT%H:%M:%S%:z") }}</published>
+        <updated>{{ page.updated | default(value=page.date, boolean=true) | date(format="%Y-%m-%dT%H:%M:%S%:z") }}</updated>
         <author>
             <name>{{ page.extra.author | default(value=author_name) }}</name>
         </author>

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -7,14 +7,14 @@
      config.extra.author.uri  — optional author URL
      page.extra.author        — per-entry override (becomes Person)
 #}
-{%- set author_name = config.extra.author.name | default(value=config.title) -%}
-{%- set author_uri = config.extra.author.uri | default(value=config.base_url) -%}
-{# Section feeds get section.pages; the global feed already receives
-   Zola's site-wide `pages` in context, so leave it untouched here. #}
-{%- if section %}{% set pages = section.pages %}{% endif -%}
+{%- set author_name = config.extra.author?.name | default(value=config.title) -%}
+{%- set author_uri = config.extra.author?.uri | default(value=config.base_url) -%}
+{# Zola supplies `pages` for global, section, and taxonomy feeds after
+   applying its date/render/hidden/include_in_feeds filter, deterministic
+   feed ordering, and feed_limit. Never replace that engine-owned set here. #}
 <?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom"{% if lang %} xml:lang="{{ lang }}"{% endif %}>
-    <title>{{ config.title }}{% if term %} - {{ term.name }}{% elif section.title %} - {{ section.title }}{% endif %}</title>
+    <title>{{ config.title }}{% if term %} - {{ term.name }}{% elif section and section.title %} - {{ section.title }}{% endif %}</title>
     {%- if config.description %}
     <subtitle>{{ config.description }}</subtitle>
     {%- endif %}

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 {# Atom 1.0 feed override. Zola's default emits <author><name>Unknown</name>;
    typikon reads the brand author from config.extra.author so feed
    subscribers see a real attribution.
@@ -12,7 +13,6 @@
 {# Zola supplies `pages` for global, section, and taxonomy feeds after
    applying its date/render/hidden/include_in_feeds filter, deterministic
    feed ordering, and feed_limit. Never replace that engine-owned set here. #}
-<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom"{% if lang %} xml:lang="{{ lang }}"{% endif %}>
     <title>{{ config.title }}{% if term %} - {{ term.name }}{% elif section and section.title %} - {{ section.title }}{% endif %}</title>
     {%- if config.description %}

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -32,11 +32,13 @@
        set) is required so an assignment inside the for loop survives
        past that iteration; date(format="%s") | int turns each value
        into an epoch integer because Tera's `>` only compares numbers,
-       never date/string values directly. #}
+       never date/string values directly. Zola serializes an unset
+       `updated` as null, so Tera 2's default filter needs boolean=true
+       to select the dated fallback for that falsey value. #}
     {%- set_global feed_updated_ts = 0 -%}
     {%- set_global feed_updated = "" -%}
     {%- for p in pages -%}
-    {%- set p_updated = p.updated | default(value=p.date) -%}
+    {%- set p_updated = p.updated | default(value=p.date, boolean=true) -%}
     {%- set p_ts = p_updated | date(format="%s") | int -%}
     {%- if p_ts > feed_updated_ts -%}
     {%- set_global feed_updated_ts = p_ts -%}
@@ -47,7 +49,7 @@
     {# No dated entries to derive updated from (e.g. a shop with no
        journal) — fall back to Zola's last_updated, then now(), to keep
        the feed valid. #}
-    {%- set feed_updated = last_updated | default(value=now()) -%}
+    {%- set feed_updated = last_updated | default(value=now(), boolean=true) -%}
     {%- endif -%}
     <updated>{{ feed_updated | date(format="%+") }}</updated>
     <id>{{ feed_url | safe }}</id>
@@ -59,7 +61,7 @@
     <entry xml:lang="{{ page.lang | default(value=lang) }}">
         <title>{{ page.title }}</title>
         <published>{{ page.date | date(format="%+") }}</published>
-        <updated>{{ page.updated | default(value=page.date) | date(format="%+") }}</updated>
+        <updated>{{ page.updated | default(value=page.date, boolean=true) | date(format="%+") }}</updated>
         <author>
             <name>{{ page.extra.author | default(value=author_name) }}</name>
         </author>

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,26 +21,11 @@
    keeps rendering the default. See index.html for an example that overrides
    several at once.
 
-   WHY the assert import below (forkwright/typikon#92): Tera resolves a
-   macro namespace by which TEMPLATE an include tag is textually written
-   in, not by the included partial's own imports, once that block is
-   reached via extends plus a child's super() call (verified: a flat
-   include honors the partial's own import; the identical include inside
-   an inherited block that a child renders via super() does not — Tera
-   attributes it to base.html regardless of which child called super()).
-   partials/ld-organization.html is included directly in the ld_json
-   block below and calls assert::required; every child template's own
-   super() call would otherwise fail exactly the way an unimported macro
-   namespace does.
-
-   WARNING: this file tolerates only ONE leading comment block before its
-   import statements — Tera's parser rejects a second, separate leading
-   comment block ahead of an import with a parse error naming the import
-   line (verified), so any addition here must stay inside this single
-   comment, never a new one placed above the imports.
+   Tera 2 components are registered globally when templates load. The
+   included structured-data partials therefore call the shared typikon.assert.*,
+   typikon.crumb.*, and typikon.ldjson.* components directly; no macro imports or
+   inheritance-sensitive namespace setup remains here.
 #}
-{% import "partials/ld-breadcrumb.html" as crumb %}
-{% import "partials/assert.html" as assert %}
 <!DOCTYPE html>
 <html lang="{{ lang | default(value="en") }}">
 <head>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -5,18 +5,17 @@
    Schema: schemas/faq.schema.json
 #}
 {% extends "page.html" %}
-{% import "partials/assert.html" as assert %}
 
 {% block ld_json %}
   {%- include "partials/ld-organization.html" -%}
   {%- include "partials/ld-faq.html" -%}
-  {{ crumb::breadcrumb(title=page.title, permalink=page.permalink, ancestors=page.ancestors) }}
+  {{ <typikon.crumb.breadcrumb config={config} lang={page.lang} title={page.title} permalink={page.permalink} ancestors={page.ancestors} /> }}
 {% endblock ld_json %}
 
 {% block content %}
-{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="faq.html") }}
-{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="faq.html") }}
-{{ assert::required(ok=page.extra.questions is defined and page.extra.questions | length > 0, field="page.extra.questions", template="faq.html") }}
+{{ <typikon.assert.required ok={page.title is defined and page.title} field="page.title" template="faq.html" /> }}
+{{ <typikon.assert.required ok={page.extra.audience is defined and page.extra.audience} field="page.extra.audience" template="faq.html" /> }}
+{{ <typikon.assert.required ok={page.extra.questions is defined and page.extra.questions | length > 0} field="page.extra.questions" template="faq.html" /> }}
 <article class="faq-page">
   <header class="page-header">
     <h1>{{ page.title }}</h1>
@@ -32,7 +31,7 @@
      convention, colliding with the one in page-header above -- same
      posture as index.html (forkwright/typikon#152), the fail-closed
      precedent this mirrors. -#}
-  {{ assert::no_h1(content=page.content, template="faq.html") }}
+  {{ <typikon.assert.no_h1 content={page.content} template="faq.html" /> }}
   {%- if page.content %}
   <div class="faq-intro">
     {{ page.content | safe }}
@@ -43,8 +42,8 @@
     {#- WHY the seen-anchor dedup: two questions (explicit anchor or
        slugify(item.q)) that resolve to the same string previously
        produced two elements with the identical `id`, which is invalid
-       HTML and makes the SECOND element the only one any fragment link
-       to that id can ever reach (forkwright/typikon#92). set_global is
+       HTML and leaves every later element with that id unreachable by a
+       fragment link (forkwright/typikon#92). set_global is
        required for `faq_seen_anchors` to survive across loop
        iterations — a plain `set` re-initializes on every pass. #}
     {%- set_global faq_seen_anchors = [] -%}
@@ -55,7 +54,7 @@
     {%- else -%}
     {%- set anchor = base_anchor -%}
     {%- endif -%}
-    {%- set_global faq_seen_anchors = faq_seen_anchors | concat(with=anchor) -%}
+    {%- set_global faq_seen_anchors = [...faq_seen_anchors, anchor] -%}
     <div class="faq-item" id="{{ anchor }}">
       <dt class="faq-question">
         <a href="#{{ anchor }}" class="faq-anchor">{{ item.q }}</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,10 +20,9 @@
      +++
 #}
 {% extends "base.html" %}
-{% import "partials/assert.html" as assert %}
 
-{% block title %}{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="index.html") }}{{ section.extra.seo_title | default(value=section.title) }}{% endblock title %}
-{% block og_title %}{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="index.html") }}{{ section.extra.seo_title | default(value=section.title) }}{% endblock og_title %}
+{% block title %}{{ <typikon.assert.required ok={section.title is defined and section.title} field="section.title" template="index.html" /> }}{{ section.extra.seo_title | default(value=section.title) }}{% endblock title %}
+{% block og_title %}{{ <typikon.assert.required ok={section.title is defined and section.title} field="section.title" template="index.html" /> }}{{ section.extra.seo_title | default(value=section.title) }}{% endblock og_title %}
 
 {% block description %}{{ section.description | default(value=config.description | default(value="")) }}{% endblock description %}
 {% block og_description %}{{ section.description | default(value=config.description | default(value="")) }}{% endblock og_description %}
@@ -42,7 +41,7 @@
   {# Preload the home logo so it can race with the rest of the head fetches.
      Stage 3c — only matters on the home route, but this template is only
      used for the home so the conditional is the visit-class itself. #}
-  {%- if section.extra.home_logo is ending_with(".svg") %}
+  {%- if section.extra.home_logo is ending_with(pat=".svg") %}
   <link rel="preload" href="/{{ section.extra.home_logo | safe }}" as="image" type="image/svg+xml">
   {%- else %}
   <link rel="preload" href="/{{ section.extra.home_logo | safe }}" as="image">
@@ -99,7 +98,7 @@
    markdown `# ` line gets a second <h1> from Zola's own leading-heading
    convention, colliding with the sr-only one above -- this fails the
    build loudly instead of shipping a silently-broken heading structure. -#}
-{{ assert::no_h1(content=section.content, template="index.html") }}
+{{ <typikon.assert.no_h1 content={section.content} template="index.html" /> }}
 {{ section.content | safe }}
 {% endblock content %}
 

--- a/templates/journal-entry.html
+++ b/templates/journal-entry.html
@@ -22,14 +22,13 @@
    rendered body on every build. It counts the rendered body's words
    (headings, emphasis, inline code, link text AND link targets, image
    alt text AND src) but EXCLUDES fenced code block content entirely --
-   verified against zola 0.22.1. page.extra.words overrides it when a
+   verified against Zola 0.23.3. page.extra.words overrides it when a
    consumer needs a custom string (a translated unit, a deliberate count
    that excludes something page.word_count includes); setting it requires
    page.extra.words_source alongside it. See
    schemas/journal-entry.schema.json.
 #}
 {% extends "page.html" %}
-{% import "partials/assert.html" as assert %}
 
 {# NOTE: no og_type block override here (forkwright/typikon#92) — a prior
    hardcoded `{% block og_type %}article{% endblock %}` silently discarded
@@ -41,17 +40,17 @@
 {% block ld_json %}
   {%- include "partials/ld-organization.html" -%}
   {%- include "partials/ld-article.html" -%}
-  {{ crumb::breadcrumb(title=page.title, permalink=page.permalink, ancestors=page.ancestors) }}
+  {{ <typikon.crumb.breadcrumb config={config} lang={page.lang} title={page.title} permalink={page.permalink} ancestors={page.ancestors} /> }}
 {% endblock ld_json %}
 
 {% block content %}
-{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="journal-entry.html") }}
-{{ assert::required(ok=page.description is defined and page.description, field="page.description", template="journal-entry.html") }}
-{{ assert::required(ok=page.date is defined and page.date, field="page.date", template="journal-entry.html") }}
-{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="journal-entry.html") }}
-{{ assert::required(ok=page.extra.components is defined and page.extra.components, field="page.extra.components", template="journal-entry.html") }}
+{{ <typikon.assert.required ok={page.title is defined and page.title} field="page.title" template="journal-entry.html" /> }}
+{{ <typikon.assert.required ok={page.description is defined and page.description} field="page.description" template="journal-entry.html" /> }}
+{{ <typikon.assert.required ok={page.date is defined and page.date} field="page.date" template="journal-entry.html" /> }}
+{{ <typikon.assert.required ok={page.extra.audience is defined and page.extra.audience} field="page.extra.audience" template="journal-entry.html" /> }}
+{{ <typikon.assert.required ok={page.extra.components is defined and page.extra.components} field="page.extra.components" template="journal-entry.html" /> }}
 {%- if page.extra.words %}
-{{ assert::required(ok=page.extra.words_source is defined and page.extra.words_source, field="page.extra.words_source", template="journal-entry.html") }}
+{{ <typikon.assert.required ok={page.extra.words_source is defined and page.extra.words_source} field="page.extra.words_source" template="journal-entry.html" /> }}
 {%- endif %}
 <article class="journal-entry-page">
   <header class="entry-header">
@@ -72,7 +71,7 @@
      colliding with the one in entry-header above -- same posture as
      index.html (forkwright/typikon#152), the fail-closed precedent this
      mirrors. -#}
-  {{ assert::no_h1(content=page.content, template="journal-entry.html") }}
+  {{ <typikon.assert.no_h1 content={page.content} template="journal-entry.html" /> }}
   {{ page.content | safe }}
 
   <p class="specs">{{ page.extra.words | default(value=page.word_count ~ " words") }}</p>

--- a/templates/journal-section.html
+++ b/templates/journal-section.html
@@ -18,10 +18,9 @@
    entry.extra.words overrides it. See schemas/journal-entry.schema.json.
 #}
 {% extends "base.html" %}
-{% import "partials/assert.html" as assert %}
 
-{% block title %}{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="journal-section.html") }}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock title %}
-{% block og_title %}{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="journal-section.html") }}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock og_title %}
+{% block title %}{{ <typikon.assert.required ok={section.title is defined and section.title} field="section.title" template="journal-section.html" /> }}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock title %}
+{% block og_title %}{{ <typikon.assert.required ok={section.title is defined and section.title} field="section.title" template="journal-section.html" /> }}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock og_title %}
 
 {% block description %}{{ section.description | default(value=config.description | default(value="")) }}{% endblock description %}
 {% block og_description %}{{ section.description | default(value=config.description | default(value="")) }}{% endblock og_description %}
@@ -30,11 +29,11 @@
 
 {% block ld_json %}
   {{ super() }}
-  {{ crumb::breadcrumb(title=section.title, permalink=section.permalink, ancestors=section.ancestors) }}
+  {{ <typikon.crumb.breadcrumb config={config} lang={section.lang} title={section.title} permalink={section.permalink} ancestors={section.ancestors} /> }}
 {% endblock ld_json %}
 
 {% block content %}
-{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="journal-section.html") }}
+{{ <typikon.assert.required ok={section.title is defined and section.title} field="section.title" template="journal-section.html" /> }}
 {%- if section.extra.greek %}
 <h1 data-greek="{{ section.extra.greek }}"><span>{{ section.title }}</span></h1>
 {%- else %}
@@ -47,7 +46,7 @@
    colliding with the one rendered above -- the same fail-closed guard
    journal-entry.html and faq.html carry, applied here so the class does
    not survive in the one content template #157 did not name. -#}
-{{ assert::no_h1(content=section.content, template="journal-section.html") }}
+{{ <typikon.assert.no_h1 content={section.content} template="journal-section.html" /> }}
 {{ section.content | safe }}
 
 <ul class="journal-list">

--- a/templates/page.html
+++ b/templates/page.html
@@ -2,10 +2,9 @@
    shared base shell. Consumers can override per-page via frontmatter
    `template = "..."` or per-section by shipping `<section>/page.html`. #}
 {% extends "base.html" %}
-{% import "partials/assert.html" as assert %}
 
-{% block title %}{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="page.html") }}{{ page.extra.seo_title | default(value=page.title) }} - {{ config.title }}{% endblock title %}
-{% block og_title %}{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="page.html") }}{{ page.extra.seo_title | default(value=page.title) }} - {{ config.title }}{% endblock og_title %}
+{% block title %}{{ <typikon.assert.required ok={page.title is defined and page.title} field="page.title" template="page.html" /> }}{{ page.extra.seo_title | default(value=page.title) }} - {{ config.title }}{% endblock title %}
+{% block og_title %}{{ <typikon.assert.required ok={page.title is defined and page.title} field="page.title" template="page.html" /> }}{{ page.extra.seo_title | default(value=page.title) }} - {{ config.title }}{% endblock og_title %}
 
 {% block description %}{{ page.description | default(value=config.description | default(value="")) }}{% endblock description %}
 {% block og_description %}{{ page.description | default(value=config.description | default(value="")) }}{% endblock og_description %}
@@ -25,14 +24,14 @@
   {{ super() }}
   {# Product JSON-LD when frontmatter is product-shaped (per schema). #}
   {%- if page.extra.price or page.extra.stripe_url or page.extra.price_source -%}
-  {{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="page.html") }}
-  {{ assert::required(ok=page.extra.price is defined and page.extra.price, field="page.extra.price", template="page.html") }}
-  {{ assert::required(ok=page.extra.price_source is defined and page.extra.price_source, field="page.extra.price_source", template="page.html") }}
-  {{ assert::required(ok=page.extra.stripe_url is defined and page.extra.stripe_url, field="page.extra.stripe_url", template="page.html") }}
+  {{ <typikon.assert.required ok={page.extra.audience is defined and page.extra.audience} field="page.extra.audience" template="page.html" /> }}
+  {{ <typikon.assert.required ok={page.extra.price is defined and page.extra.price} field="page.extra.price" template="page.html" /> }}
+  {{ <typikon.assert.required ok={page.extra.price_source is defined and page.extra.price_source} field="page.extra.price_source" template="page.html" /> }}
+  {{ <typikon.assert.required ok={page.extra.stripe_url is defined and page.extra.stripe_url} field="page.extra.stripe_url" template="page.html" /> }}
   {%- include "partials/ld-product.html" -%}
   {%- endif -%}
   {# BreadcrumbList for non-home pages. #}
-  {{ crumb::breadcrumb(title=page.title, permalink=page.permalink, ancestors=page.ancestors) }}
+  {{ <typikon.crumb.breadcrumb config={config} lang={page.lang} title={page.title} permalink={page.permalink} ancestors={page.ancestors} /> }}
 {% endblock ld_json %}
 
 {% block content %}
@@ -43,7 +42,7 @@
    built with zero headings at any level. page.title is already required
    (asserted in the title/og_title blocks above), so sourcing the heading
    from it is a guarantee, not a convention. -#}
-{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="page.html") }}
+{{ <typikon.assert.required ok={page.title is defined and page.title} field="page.title" template="page.html" /> }}
 <h1>{{ page.title }}</h1>
 {# Product gallery renders before page content when extra.images is set —
    the operator drops the placeholder <div class="product-images"> from
@@ -60,7 +59,7 @@
    with it exactly as #157 found in journal-entry.html/faq.html. Adding
    the heading above without this guard would have reproduced the very
    defect class #149 exists to close, in a template #157 never named. -#}
-{{ assert::no_h1(content=page.content, template="page.html") }}
+{{ <typikon.assert.no_h1 content={page.content} template="page.html" /> }}
 {{ page.content | safe }}
 {# Process video renders after page content when extra.video is set. #}
 {%- include "partials/video.html" -%}

--- a/templates/partials/assert.html
+++ b/templates/partials/assert.html
@@ -1,11 +1,11 @@
 {# Template assertions for metadata that must exist before rendering.
    Schema validation should catch these first; throw keeps custom-template
    builds from silently rendering incomplete context. #}
-{% macro required(ok, field, template) -%}
+{% component typikon.assert.required(ok, field, template) -%}
 {%- if not ok -%}
 {{ throw(message=template ~ ": missing required metadata `" ~ field ~ "`") }}
 {%- endif -%}
-{%- endmacro required %}
+{%- endcomponent %}
 
 {# WHY (forkwright/typikon#152): a template that renders both a required
    heading element AND a consumer's markdown content unconditionally can be
@@ -16,8 +16,8 @@
    not frontmatter), so the only fail-closed point is here, at render time.
    Same posture as `required` above: a loud build failure that names the
    collision, never a silently-shipped duplicate heading. #}
-{% macro no_h1(content, template) -%}
-{%- if content is matching("(?i)<h1[ >]") -%}
+{% component typikon.assert.no_h1(content, template) -%}
+{%- if content is matching(pat="(?i)<h1[ >]") -%}
 {{ throw(message=template ~ ": content contains its own <h1> element (a markdown body starting with a single `# ` line), which collides with this page's required heading. Demote it to `##` or lower.") }}
 {%- endif -%}
-{%- endmacro no_h1 %}
+{%- endcomponent %}

--- a/templates/partials/ld-article.html
+++ b/templates/partials/ld-article.html
@@ -10,13 +10,11 @@
      config.extra.author.name — fallback brand author
      config.title       — publisher name
 #}
-{% import "partials/assert.html" as assert %}
-{% import "partials/ld-json.html" as ldjson %}
-{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="partials/ld-article.html") }}
-{{ assert::required(ok=page.description is defined and page.description, field="page.description", template="partials/ld-article.html") }}
-{{ assert::required(ok=page.date is defined and page.date, field="page.date", template="partials/ld-article.html") }}
-{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="partials/ld-article.html") }}
-{%- set author_name = page.extra.author | default(value=config.extra.author.name) | default(value=config.title) -%}
+{{ <typikon.assert.required ok={page.title is defined and page.title} field="page.title" template="partials/ld-article.html" /> }}
+{{ <typikon.assert.required ok={page.description is defined and page.description} field="page.description" template="partials/ld-article.html" /> }}
+{{ <typikon.assert.required ok={page.date is defined and page.date} field="page.date" template="partials/ld-article.html" /> }}
+{{ <typikon.assert.required ok={page.extra.audience is defined and page.extra.audience} field="page.extra.audience" template="partials/ld-article.html" /> }}
+{%- set author_name = page.extra.author | default(value=config.extra.author?.name) | default(value=config.title) -%}
 {%- set image_url = "" -%}
 {%- if page.extra.og_image -%}
   {#- get_url(), not hand string-concatenation (forkwright/typikon#92):
@@ -31,23 +29,23 @@
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "headline": {{ ldjson::str(value=page.title) }},
-  "description": {{ ldjson::str(value=page.description) }},
-  "url": {{ ldjson::str(value=page.permalink) }},
-  "datePublished": {{ ldjson::str(value=page.date) }},
+  "headline": {{ <typikon.ldjson.str value={page.title} /> }},
+  "description": {{ <typikon.ldjson.str value={page.description} /> }},
+  "url": {{ <typikon.ldjson.str value={page.permalink} /> }},
+  "datePublished": {{ <typikon.ldjson.str value={page.date} /> }},
   "author": {
     "@type": "Person",
-    "name": {{ ldjson::str(value=author_name) }}
+    "name": {{ <typikon.ldjson.str value={author_name} /> }}
   },
   "publisher": {
     "@type": "Organization",
-    "name": {{ ldjson::str(value=config.title) }}
+    "name": {{ <typikon.ldjson.str value={config.title} /> }}
   }
   {%- if page.updated -%},
-  "dateModified": {{ ldjson::str(value=page.updated) }}
+  "dateModified": {{ <typikon.ldjson.str value={page.updated} /> }}
   {%- endif -%}
   {%- if image_url -%},
-  "image": {{ ldjson::str(value=image_url) }}
+  "image": {{ <typikon.ldjson.str value={image_url} /> }}
   {%- endif %}
 }
 </script>

--- a/templates/partials/ld-breadcrumb.html
+++ b/templates/partials/ld-breadcrumb.html
@@ -1,21 +1,19 @@
-{# Schema.org/BreadcrumbList JSON-LD as a Tera macro. Both page and section
+{# Schema.org/BreadcrumbList JSON-LD as a Tera 2 component. Both page and section
    contexts call it with their own title/permalink/ancestors.
 
    Usage from page.html / section.html / journal-*.html:
-     {% import "partials/ld-breadcrumb.html" as crumb %}
-     {{ crumb::breadcrumb(title=page.title, permalink=page.permalink, ancestors=page.ancestors) }}
+     {{ <typikon.crumb.breadcrumb config={config} lang={page.lang} title={page.title} permalink={page.permalink} ancestors={page.ancestors} /> }}
 
    Skips emitting any JSON-LD when ancestors is empty (e.g. home page).
 #}
-{% import "partials/ld-json.html" as ldjson %}
-{% macro breadcrumb(title, permalink, ancestors) %}
+{% component typikon.crumb.breadcrumb(config, lang, title, permalink, ancestors) %}
 {%- if ancestors and ancestors | length > 0 %}
 {#- WHY: trailing-slash spelling varies (config.base_url is user-entered,
    ancestor/page permalinks come from Zola); strip the trailing slash before
    comparing so the root is deduplicated regardless of spelling, instead of
    comparing one unnormalized slash form. #}
-{%- set base_key = config.base_url | trim_end_matches(pat="/") -%}
-{%- set page_key = permalink | trim_end_matches(pat="/") -%}
+{%- set base_key = config.base_url | trim_end(pat="/") -%}
+{%- set page_key = permalink | trim_end(pat="/") -%}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -24,35 +22,35 @@
     {
       "@type": "ListItem",
       "position": 1,
-      "name": {{ ldjson::str(value=config.title) }},
-      "item": {{ ldjson::str(value=config.base_url) }}
+      "name": {{ <typikon.ldjson.str value={config.title} /> }},
+      "item": {{ <typikon.ldjson.str value={config.base_url} /> }}
     }
     {%- set position = 2 -%}
     {%- set_global seen = [base_key] -%}
     {%- for ancestor_path in ancestors -%}
-      {%- set ancestor = get_section(path=ancestor_path) -%}
+      {%- set ancestor = get_section(path=ancestor_path, lang=lang) -%}
       {%- if ancestor.title and ancestor.permalink -%}
-        {%- set ancestor_key = ancestor.permalink | trim_end_matches(pat="/") -%}
+        {%- set ancestor_key = ancestor.permalink | trim_end(pat="/") -%}
         {%- if not ancestor_key in seen and ancestor_key != page_key -%},
     {
       "@type": "ListItem",
       "position": {{ position }},
-      "name": {{ ldjson::str(value=ancestor.title) }},
-      "item": {{ ldjson::str(value=ancestor.permalink) }}
+      "name": {{ <typikon.ldjson.str value={ancestor.title} /> }},
+      "item": {{ <typikon.ldjson.str value={ancestor.permalink} /> }}
     }
         {%- set_global position = position + 1 -%}
-        {%- set_global seen = seen | concat(with=ancestor_key) -%}
+        {%- set_global seen = [...seen, ancestor_key] -%}
         {%- endif -%}
       {%- endif -%}
     {%- endfor -%},
     {
       "@type": "ListItem",
       "position": {{ position }},
-      "name": {{ ldjson::str(value=title) }},
-      "item": {{ ldjson::str(value=permalink) }}
+      "name": {{ <typikon.ldjson.str value={title} /> }},
+      "item": {{ <typikon.ldjson.str value={permalink} /> }}
     }
   ]
 }
 </script>
 {%- endif %}
-{% endmacro breadcrumb %}
+{% endcomponent %}

--- a/templates/partials/ld-faq.html
+++ b/templates/partials/ld-faq.html
@@ -5,11 +5,9 @@
    Inputs:
      page.extra.questions — array of {q, a, anchor?} per faq schema
 #}
-{% import "partials/assert.html" as assert %}
-{% import "partials/ld-json.html" as ldjson %}
-{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="partials/ld-faq.html") }}
-{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="partials/ld-faq.html") }}
-{{ assert::required(ok=page.extra.questions is defined and page.extra.questions | length > 0, field="page.extra.questions", template="partials/ld-faq.html") }}
+{{ <typikon.assert.required ok={page.title is defined and page.title} field="page.title" template="partials/ld-faq.html" /> }}
+{{ <typikon.assert.required ok={page.extra.audience is defined and page.extra.audience} field="page.extra.audience" template="partials/ld-faq.html" /> }}
+{{ <typikon.assert.required ok={page.extra.questions is defined and page.extra.questions | length > 0} field="page.extra.questions" template="partials/ld-faq.html" /> }}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -18,10 +16,10 @@
     {%- for item in page.extra.questions -%}
     {
       "@type": "Question",
-      "name": {{ ldjson::str(value=item.q) }},
+      "name": {{ <typikon.ldjson.str value={item.q} /> }},
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": {{ ldjson::str(value=item.a) }}
+        "text": {{ <typikon.ldjson.str value={item.a} /> }}
       }
     }{%- if not loop.last -%},{%- endif -%}
     {%- endfor %}

--- a/templates/partials/ld-howto.html
+++ b/templates/partials/ld-howto.html
@@ -16,28 +16,26 @@
 
    Schema reference: https://schema.org/HowTo
 #}
-{% import "partials/assert.html" as assert %}
-{% import "partials/ld-json.html" as ldjson %}
-{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="partials/ld-howto.html") }}
-{{ assert::required(ok=page.extra.product_type is defined and page.extra.product_type, field="page.extra.product_type", template="partials/ld-howto.html") }}
-{{ assert::required(ok=page.extra.measurement_source is defined and page.extra.measurement_source, field="page.extra.measurement_source", template="partials/ld-howto.html") }}
-{{ assert::required(ok=page.extra.decision_tree is defined and page.extra.decision_tree | length > 0, field="page.extra.decision_tree", template="partials/ld-howto.html") }}
+{{ <typikon.assert.required ok={page.extra.audience is defined and page.extra.audience} field="page.extra.audience" template="partials/ld-howto.html" /> }}
+{{ <typikon.assert.required ok={page.extra.product_type is defined and page.extra.product_type} field="page.extra.product_type" template="partials/ld-howto.html" /> }}
+{{ <typikon.assert.required ok={page.extra.measurement_source is defined and page.extra.measurement_source} field="page.extra.measurement_source" template="partials/ld-howto.html" /> }}
+{{ <typikon.assert.required ok={page.extra.decision_tree is defined and page.extra.decision_tree | length > 0} field="page.extra.decision_tree" template="partials/ld-howto.html" /> }}
 {%- set howto_name = "How to choose your " ~ page.extra.product_type ~ " size" -%}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "HowTo",
-  "name": {{ ldjson::str(value=howto_name) }},
-  "description": {{ ldjson::str(value=page.description) }},
+  "name": {{ <typikon.ldjson.str value={howto_name} /> }},
+  "description": {{ <typikon.ldjson.str value={page.description} /> }},
   {%- if page.extra.duration is defined and page.extra.duration %}
-  "totalTime": {{ ldjson::str(value=page.extra.duration) }},
+  "totalTime": {{ <typikon.ldjson.str value={page.extra.duration} /> }},
   {%- endif %}
   "step": [
     {%- for line in page.extra.decision_tree -%}
     {
       "@type": "HowToStep",
       "position": {{ loop.index }},
-      "text": {{ ldjson::str(value=line) }}
+      "text": {{ <typikon.ldjson.str value={line} /> }}
     }{%- if not loop.last -%},{%- endif -%}
     {%- endfor %}
   ]

--- a/templates/partials/ld-json.html
+++ b/templates/partials/ld-json.html
@@ -22,5 +22,5 @@
    this component instead of calling json_encode directly, so no future
    ld-*.html addition can reintroduce the gap by omission. #}
 {% component typikon.ldjson.str(value) -%}
-{{- value | json_encode | replace(from="/", to="\/") | safe -}}
+{{- value | json_encode | replace(from="/", to="\\/") | safe -}}
 {%- endcomponent %}

--- a/templates/partials/ld-json.html
+++ b/templates/partials/ld-json.html
@@ -19,8 +19,8 @@
 
    Every partials/ld-*.html routes every field value (string, number, or
    array alike -- replace() is a no-op on a value with no "/") through
-   this macro instead of calling json_encode directly, so no future
+   this component instead of calling json_encode directly, so no future
    ld-*.html addition can reintroduce the gap by omission. #}
-{% macro str(value) -%}
+{% component typikon.ldjson.str(value) -%}
 {{- value | json_encode | replace(from="/", to="\/") | safe -}}
-{%- endmacro str %}
+{%- endcomponent %}

--- a/templates/partials/ld-organization.html
+++ b/templates/partials/ld-organization.html
@@ -10,20 +10,18 @@
      config.extra.founding_date — optional ISO 8601 year (e.g. "2024")
      config.extra.footer_links — list of {url, rel}; entries with rel="me" emit as sameAs
 #}
-{% import "partials/assert.html" as assert %}
-{% import "partials/ld-json.html" as ldjson %}
 {#- WHY this guard (forkwright/typikon#92): every sibling partials/ld-*.html
-   imports partials/assert.html and asserts its own documented required
-   inputs; this file did neither. config.extra.logo_path feeds logo_url
+   uses the shared typikon.assert.required component for its documented
+   inputs; this file previously did neither. config.extra.logo_path feeds logo_url
    below UNCONDITIONALLY — there is no `{% if %}` around it the way
    brand_greek/founding_date/footer_links each get — so an absent value
    still failed the build (Tera's `~` concatenation errors on an undefined
    variable), but with a bare "Variable `config.extra.logo_path` not found
    in context" engine error naming neither the missing field's role nor
    which template needs it — verified against a zola build. Every sibling
-   partial instead names both, via the same assert::required this file now
-   also uses. -#}
-{{ assert::required(ok=config.extra.logo_path is defined and config.extra.logo_path, field="config.extra.logo_path", template="partials/ld-organization.html") }}
+   partial instead names both, via the same typikon.assert.required
+   component this file now also uses. -#}
+{{ <typikon.assert.required ok={config.extra.logo_path is defined and config.extra.logo_path} field="config.extra.logo_path" template="partials/ld-organization.html" /> }}
 {#- get_url(), not hand string-concatenation (forkwright/typikon#92): the
    visible <link rel="icon"> in base.html resolves config.extra.favicon_path
    the same way, and get_url() normalizes base_url/path joining (a
@@ -36,26 +34,26 @@
 {
   "@context": "https://schema.org",
   "@type": "Organization",
-  "name": {{ ldjson::str(value=config.title) }},
-  "description": {{ ldjson::str(value=config.description) }},
-  "url": {{ ldjson::str(value=config.base_url) }},
-  "logo": {{ ldjson::str(value=logo_url) }}
+  "name": {{ <typikon.ldjson.str value={config.title} /> }},
+  "description": {{ <typikon.ldjson.str value={config.description} /> }},
+  "url": {{ <typikon.ldjson.str value={config.base_url} /> }},
+  "logo": {{ <typikon.ldjson.str value={logo_url} /> }}
   {%- if config.extra.brand_greek -%},
-  "alternateName": {{ ldjson::str(value=config.extra.brand_greek) }}
+  "alternateName": {{ <typikon.ldjson.str value={config.extra.brand_greek} /> }}
   {%- endif -%}
   {%- if config.extra.founding_date -%},
-  "foundingDate": {{ ldjson::str(value=config.extra.founding_date) }}
+  "foundingDate": {{ <typikon.ldjson.str value={config.extra.founding_date} /> }}
   {%- endif -%}
   {%- if config.extra.footer_links -%}
     {%- set sameas = [] -%}
     {%- for link in config.extra.footer_links -%}
       {%- set rel_val = link.rel | default(value="") -%}
       {%- if rel_val == "me" -%}
-        {%- set_global sameas = sameas | concat(with=link.url) -%}
+        {%- set_global sameas = [...sameas, link.url] -%}
       {%- endif -%}
     {%- endfor -%}
     {%- if sameas | length > 0 -%},
-  "sameAs": {{ ldjson::str(value=sameas) }}
+  "sameAs": {{ <typikon.ldjson.str value={sameas} /> }}
     {%- endif -%}
   {%- endif %}
 }

--- a/templates/partials/ld-product.html
+++ b/templates/partials/ld-product.html
@@ -16,15 +16,13 @@
    and page.extra.availability_source are set — never defaulted, since an
    unverified stock claim in structured data misleads search engines.
 #}
-{% import "partials/assert.html" as assert %}
-{% import "partials/ld-json.html" as ldjson %}
-{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="partials/ld-product.html") }}
-{{ assert::required(ok=page.description is defined and page.description, field="page.description", template="partials/ld-product.html") }}
-{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="partials/ld-product.html") }}
-{{ assert::required(ok=page.extra.price is defined and page.extra.price, field="page.extra.price", template="partials/ld-product.html") }}
-{{ assert::required(ok=page.extra.price_source is defined and page.extra.price_source, field="page.extra.price_source", template="partials/ld-product.html") }}
-{{ assert::required(ok=page.extra.stripe_url is defined and page.extra.stripe_url, field="page.extra.stripe_url", template="partials/ld-product.html") }}
-{%- set price_numeric = page.extra.price | trim_start_matches(pat="$") -%}
+{{ <typikon.assert.required ok={page.title is defined and page.title} field="page.title" template="partials/ld-product.html" /> }}
+{{ <typikon.assert.required ok={page.description is defined and page.description} field="page.description" template="partials/ld-product.html" /> }}
+{{ <typikon.assert.required ok={page.extra.audience is defined and page.extra.audience} field="page.extra.audience" template="partials/ld-product.html" /> }}
+{{ <typikon.assert.required ok={page.extra.price is defined and page.extra.price} field="page.extra.price" template="partials/ld-product.html" /> }}
+{{ <typikon.assert.required ok={page.extra.price_source is defined and page.extra.price_source} field="page.extra.price_source" template="partials/ld-product.html" /> }}
+{{ <typikon.assert.required ok={page.extra.stripe_url is defined and page.extra.stripe_url} field="page.extra.stripe_url" template="partials/ld-product.html" /> }}
+{%- set price_numeric = page.extra.price | trim_start(pat="$") -%}
 {%- set image_url = "" -%}
 {%- if page.extra.og_image -%}
   {#- get_url(), not hand string-concatenation — same rationale as
@@ -35,27 +33,27 @@
 {
   "@context": "https://schema.org",
   "@type": "Product",
-  "name": {{ ldjson::str(value=page.title) }},
-  "description": {{ ldjson::str(value=page.description) }},
-  "url": {{ ldjson::str(value=page.permalink) }},
+  "name": {{ <typikon.ldjson.str value={page.title} /> }},
+  "description": {{ <typikon.ldjson.str value={page.description} /> }},
+  "url": {{ <typikon.ldjson.str value={page.permalink} /> }},
   "brand": {
     "@type": "Organization",
-    "name": {{ ldjson::str(value=config.title) }}
+    "name": {{ <typikon.ldjson.str value={config.title} /> }}
   },
   "offers": {
     "@type": "Offer",
-    "price": {{ ldjson::str(value=price_numeric) }},
+    "price": {{ <typikon.ldjson.str value={price_numeric} /> }},
     "priceCurrency": "USD"
     {%- if page.extra.availability and page.extra.availability_source -%}
     {%- set availability_url = "https://schema.org/" ~ page.extra.availability -%}
     ,
-    "availability": {{ ldjson::str(value=availability_url) }}
+    "availability": {{ <typikon.ldjson.str value={availability_url} /> }}
     {%- endif -%}
     ,
-    "url": {{ ldjson::str(value=page.extra.stripe_url) }}
+    "url": {{ <typikon.ldjson.str value={page.extra.stripe_url} /> }}
   }
   {%- if image_url -%},
-  "image": {{ ldjson::str(value=image_url) }}
+  "image": {{ <typikon.ldjson.str value={image_url} /> }}
   {%- endif %}
 }
 </script>

--- a/templates/section.html
+++ b/templates/section.html
@@ -1,9 +1,8 @@
 {# Default section template. Renders the section index's markdown content. #}
 {% extends "base.html" %}
-{% import "partials/assert.html" as assert %}
 
-{% block title %}{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="section.html") }}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock title %}
-{% block og_title %}{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="section.html") }}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock og_title %}
+{% block title %}{{ <typikon.assert.required ok={section.title is defined and section.title} field="section.title" template="section.html" /> }}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock title %}
+{% block og_title %}{{ <typikon.assert.required ok={section.title is defined and section.title} field="section.title" template="section.html" /> }}{{ section.extra.seo_title | default(value=section.title) }} - {{ config.title }}{% endblock og_title %}
 
 {% block description %}{{ section.description | default(value=config.description | default(value="")) }}{% endblock description %}
 {% block og_description %}{{ section.description | default(value=config.description | default(value="")) }}{% endblock og_description %}
@@ -19,7 +18,7 @@
 
 {% block ld_json %}
   {{ super() }}
-  {{ crumb::breadcrumb(title=section.title, permalink=section.permalink, ancestors=section.ancestors) }}
+  {{ <typikon.crumb.breadcrumb config={config} lang={section.lang} title={section.title} permalink={section.permalink} ancestors={section.ancestors} /> }}
 {% endblock ld_json %}
 
 {% block content %}
@@ -32,7 +31,7 @@
    section.title is already required (asserted in the title/og_title
    blocks above), so sourcing the heading from it is a guarantee, not a
    convention. -#}
-{{ assert::required(ok=section.title is defined and section.title, field="section.title", template="section.html") }}
+{{ <typikon.assert.required ok={section.title is defined and section.title} field="section.title" template="section.html" /> }}
 <h1>{{ section.title }}</h1>
 {#- WHY this guard (forkwright/typikon#157 class): now that this template
    renders its own <h1> above, section.content is unconditional
@@ -41,7 +40,7 @@
    journal-entry.html/faq.html. Adding the heading above without this
    guard would have reproduced the very defect class #149 exists to
    close, in a template #157 never named. -#}
-{{ assert::no_h1(content=section.content, template="section.html") }}
+{{ <typikon.assert.no_h1 content={section.content} template="section.html" /> }}
 {{ section.content | safe }}
 
 {# NOTE: default child-page listing (e.g. content/products/_index.md).

--- a/templates/sizing-guide.html
+++ b/templates/sizing-guide.html
@@ -5,7 +5,6 @@
    Schema: schemas/sizing-guide.schema.json
 #}
 {% extends "page.html" %}
-{% import "partials/assert.html" as assert %}
 
 {% block ld_json %}
   {{ super() }}
@@ -18,11 +17,11 @@
 {% endblock ld_json %}
 
 {% block content %}
-{{ assert::required(ok=page.title is defined and page.title, field="page.title", template="sizing-guide.html") }}
-{{ assert::required(ok=page.extra.audience is defined and page.extra.audience, field="page.extra.audience", template="sizing-guide.html") }}
-{{ assert::required(ok=page.extra.product_type is defined and page.extra.product_type, field="page.extra.product_type", template="sizing-guide.html") }}
-{{ assert::required(ok=page.extra.measurement_source is defined and page.extra.measurement_source, field="page.extra.measurement_source", template="sizing-guide.html") }}
-{{ assert::required(ok=page.extra.size_table is defined and page.extra.size_table | length > 0, field="page.extra.size_table", template="sizing-guide.html") }}
+{{ <typikon.assert.required ok={page.title is defined and page.title} field="page.title" template="sizing-guide.html" /> }}
+{{ <typikon.assert.required ok={page.extra.audience is defined and page.extra.audience} field="page.extra.audience" template="sizing-guide.html" /> }}
+{{ <typikon.assert.required ok={page.extra.product_type is defined and page.extra.product_type} field="page.extra.product_type" template="sizing-guide.html" /> }}
+{{ <typikon.assert.required ok={page.extra.measurement_source is defined and page.extra.measurement_source} field="page.extra.measurement_source" template="sizing-guide.html" /> }}
+{{ <typikon.assert.required ok={page.extra.size_table is defined and page.extra.size_table | length > 0} field="page.extra.size_table" template="sizing-guide.html" /> }}
 <article class="sizing-guide">
   <header class="page-header">
     <h1>{{ page.title }}</h1>
@@ -38,7 +37,7 @@
      above -- the same fail-closed guard journal-entry.html and faq.html
      carry, applied here so the class does not survive in the one content
      template #157 did not name. -#}
-  {{ assert::no_h1(content=page.content, template="sizing-guide.html") }}
+  {{ <typikon.assert.no_h1 content={page.content} template="sizing-guide.html" /> }}
   {%- if page.content %}
   <div class="sizing-intro">
     {{ page.content | safe }}

--- a/theme.toml
+++ b/theme.toml
@@ -4,7 +4,7 @@ name = "typikon"
 description = "Fleet web-property substrate — Zola theme, frontmatter schemas, agentic scaffolding, strict CI gates"
 license = "AGPL-3.0-or-later"
 homepage = "https://github.com/forkwright/typikon"
-min_version = "0.22.0"
+min_version = "0.23.3"
 
 [author]
 name = "Cody Kickertz"


### PR DESCRIPTION
## Summary

- pin Typikon and both generated consumer gates to the official Zola 0.23.3 Linux artifact;
- migrate the theme from removed Tera 1 macro/filter syntax to collision-resistant `typikon.*` Tera 2 components;
- preserve Zola's engine-owned feed page set, including `include_in_feeds`, ordering, and limit behavior;
- add static contracts, a real multilingual renderer fixture, and durable bounded failure diagnostics.

This is the separately gated renderer prerequisite for #179. It intentionally does not implement or close the scoped-root-feed issue, and it changes no consumer repository.

## Why this is separate

Zola 0.22.1 does not expose the `include_in_feeds` page field required by #179 acceptance item 4. Zola 0.23 does, but also moves rendering to Tera 2. A version-only bump would break Typikon's macro imports, namespace calls, removed collection/string filters, positional test arguments, and consumer shortcodes.

## Compatibility contract

- `theme.toml` requires and `bin/typikon-defaults.sh` defaults to Zola 0.23.3. Typikon's gate pins that version directly, and both consumer gate templates receive it when rendered. Those three download surfaces pin SHA-256 `f07c92607e5745268b576bd325ceef3a582aada253bb64db8d92a8a85303d958`.
- Components use a `typikon.*` namespace because Tera 2 registers components globally.
- Components receive only declared arguments; breadcrumb callers pass both `config` and the current language explicitly.
- Consumer template overrides and removed Zola shortcodes must migrate before a consumer raises its pin.

## Exact-head proof

GitHub Gate Attestation run [32387018419](https://github.com/forkwright/typikon/actions/runs/32387018419) completed successfully for head `7545041b93576b0abca62d3d6a4890abda3b14d3` and synthetic merge commit `48120c02548432a31815ad86cf5401358ecee770` / tree `65bcba0d695a0d63f127c405abf61e37bfb0be56`.

The hosted gate proved:

- Zola 0.23.3 parses and renders both consumer fixtures;
- the multilingual Tera 2 fixture preserves author fallbacks, translated breadcrumbs, and ordered `sameAs` values;
- both sample sites pass CSP enforcement;
- hostile FAQ text remains visible while JSON-LD escapes script termination and round-trips to the exact question and answer;
- failed-stage details survive CI capture through bounded, JSON-framed replay;
- Atom outputs are well-formed and begin at the XML declaration;
- all remaining full-gate checks pass.

Kanon MCP lint reports 0 violations with 6 existing suppressions. `git diff --check`, the static Tera contract, Python AST checks, schema validation, and fixture discovery also pass.

No Zola build was run locally; the exact GitHub-hosted build is the renderer authority. Runs 32322479432, 32323223834, 32378738973, 32380347712, 32383486818, and 32385620561 successively exposed null `updated`, Jiff-incompatible formatting, XML declaration displacement, an unreplayed CSP failure log, the FAQ JSON-LD breakout, and a stale entity-spelling assertion; each now has a static or rendered regression.

## Next boundary

After this prerequisite lands, #179 still needs its own scoped-root-feed implementation and consumer migrations. Those changes are outside this PR.

Refs #179
