### PR TITLE
fix(release): separate candidate proof from publication

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -115,7 +115,7 @@ jobs:
         # through it, and without it check-font-coverage.py fails at import with
         # 'No module named brotli' — which passed locally, where it was already
         # installed, and failed only in CI.
-        python3 -m pip install --user jsonschema==4.23.0 fonttools==4.62.1 Brotli==1.2.0
+        python3 -m pip install --user jsonschema==4.23.0 fonttools==4.62.1 Brotli==1.2.0 PyYAML==6.0.3
 
         LYCHEE_VERSION=0.24.2
         LYCHEE_SHA256=1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,124 @@
+name: Release Candidate # kanon:ignore CI/release-yml-missing-attestation -- split signer job; Kanon 2558
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: typikon-release-candidate
+  cancel-in-progress: false
+
+jobs:
+  freeze-candidate:
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect a pure Release Please squash commit
+        id: detect
+        run: python3 ci/build-release-candidate.py detect --github-output "$GITHUB_OUTPUT"
+
+      - name: Prepare candidate staging directory
+        if: steps.detect.outputs.candidate == 'true'
+        run: |
+          candidate_dir="$RUNNER_TEMP/typikon-release-candidate"
+          mkdir -p "$candidate_dir"
+          echo "CANDIDATE_DIR=$candidate_dir" >> "$GITHUB_ENV"
+
+      - name: Generate the inventory-backed CycloneDX SBOM
+        if: steps.detect.outputs.candidate == 'true'
+        run: python3 ci/build-release-candidate.py seed-sbom --output-dir "$CANDIDATE_DIR"
+
+      - name: Freeze exact archive and candidate manifest
+        if: steps.detect.outputs.candidate == 'true'
+        run: python3 ci/build-release-candidate.py freeze --output-dir "$CANDIDATE_DIR"
+
+      - name: Validate the CycloneDX schema
+        if: steps.detect.outputs.candidate == 'true'
+        env:
+          CYCLONEDX_CLI_SHA256: bfc8b2538da86fe239bc53658bbb63c1c8c510a293c1e6891aa5bea5d3c58746
+        run: |
+          cli="$RUNNER_TEMP/cyclonedx-linux-x64"
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --connect-timeout 10 --max-time 240 --retry 3 --retry-all-errors \
+            --output "$cli" \
+            https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.33.1/cyclonedx-linux-x64
+          printf '%s  %s\n' "$CYCLONEDX_CLI_SHA256" "$cli" | sha256sum --check --strict
+          chmod 0755 "$cli"
+          "$cli" validate \
+            --input-format json \
+            --input-file "$CANDIDATE_DIR/typikon-${{ steps.detect.outputs.tag }}.tar.gz.cdx.json" \
+            --fail-on-errors
+
+      - name: Attest the frozen source archive
+        if: steps.detect.outputs.candidate == 'true'
+        id: provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: ${{ env.CANDIDATE_DIR }}/typikon-${{ steps.detect.outputs.tag }}.tar.gz
+
+      - name: Attest the frozen CycloneDX SBOM
+        if: steps.detect.outputs.candidate == 'true'
+        id: sbom_attestation
+        uses: actions/attest-sbom@5026d3663739160db546203eeaffa6aa1c51a4d6 # v1
+        with:
+          subject-path: ${{ env.CANDIDATE_DIR }}/typikon-${{ steps.detect.outputs.tag }}.tar.gz
+          sbom-path: ${{ env.CANDIDATE_DIR }}/typikon-${{ steps.detect.outputs.tag }}.tar.gz.cdx.json
+
+      - name: Freeze the offline attestation bundles
+        if: steps.detect.outputs.candidate == 'true'
+        run: |
+          python3 ci/build-release-candidate.py attach-attestations \
+            --output-dir "$CANDIDATE_DIR" \
+            --provenance-bundle "${{ steps.provenance.outputs.bundle-path }}" \
+            --sbom-bundle "${{ steps.sbom_attestation.outputs.bundle-path }}"
+
+      - name: Verify both frozen offline attestation bundles
+        if: steps.detect.outputs.candidate == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          archive="$CANDIDATE_DIR/typikon-${{ steps.detect.outputs.tag }}.tar.gz"
+          signer="$GITHUB_REPOSITORY/.github/workflows/release-candidate.yml"
+          gh attestation verify "$archive" \
+            --bundle "$archive.provenance.intoto.jsonl" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$signer" \
+            --source-digest "$GITHUB_SHA" \
+            --predicate-type https://slsa.dev/provenance/v1
+          gh attestation verify "$archive" \
+            --bundle "$archive.sbom.intoto.jsonl" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$signer" \
+            --source-digest "$GITHUB_SHA" \
+            --predicate-type https://cyclonedx.org/bom
+
+      - name: Upload immutable candidate bundle
+        if: steps.detect.outputs.candidate == 'true'
+        id: candidate_artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: typikon-${{ steps.detect.outputs.tag }}-candidate
+          path: ${{ env.CANDIDATE_DIR }}/*
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Record candidate artifact identity
+        if: steps.detect.outputs.candidate == 'true'
+        run: |
+          {
+            echo "### Frozen untagged release candidate"
+            echo "- commit: ${{ steps.detect.outputs.candidate_commit }}"
+            echo "- tree: ${{ steps.detect.outputs.candidate_tree }}"
+            echo "- artifact id: ${{ steps.candidate_artifact.outputs.artifact-id }}"
+            echo "- artifact digest: ${{ steps.candidate_artifact.outputs.artifact-digest }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,102 +1,287 @@
-name: Release Please
+name: Release Please # kanon:ignore CI/release-yml-missing-attestation -- publishes candidate attestations; Kanon 2558/3556
 
-# WHY this exists: release-please-config.json and .release-please-manifest.json
-# declare intent only — without a workflow that runs them, the manifest can
-# assert a version that no tag, GitHub release, or CHANGELOG entry backs
-# (forkwright/typikon#73).
-
+# Main pushes may prepare a release PR only while the manifest version already
+# has an exact published release. Publication is a separate, manually
+# dispatched, compatibility-locked state machine that always targets the
+# frozen untagged squash commit.
 on:
   push:
     branches: [main]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      lock_path:
+        description: Tracked compatibility lock to verify before publication
+        required: true
+        default: release/compatibility/v0.6.0.json
+        type: string
+      acknowledge_private_consumer_metadata:
+        description: Publish the lock and receipt identifiers for the private Leather repository
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: typikon-release-main
   cancel-in-progress: false
 
-# WHY attestations/id-token are here despite this repo shipping no binaries: the
-# attested subject is the release SOURCE ARCHIVE, not a build output. Consumers pin
-# this theme by submodule SHA, so the source tree IS the artifact they take.
-permissions:
-  attestations: write
-  contents: write
-  id-token: write
-  pull-requests: write
+permissions: {}
 
 jobs:
-  release-please:
+  prepare-release-pr:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created || steps.release_retry.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name || steps.release_retry.outputs.tag_name }}
-    steps:
-      # WHY pinned to a SHA: a mutable tag lets the action's behaviour change under
-      # an already-reviewed workflow. Same pin as forkwright/kanon.
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
-        id: release
-        continue-on-error: true
-        with:
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
-
-      # NOTE: GitHub's release-create API creates the tag inline when it does not
-      # yet exist, and can 422 with "Published releases must have a valid tag" while
-      # that tag is still propagating server-side. It is a GitHub-side race, not
-      # manifest drift. One retry clears it; a genuine failure still fails the job.
-      # This retry belongs in a shared reusable workflow, not duplicated per-repo
-      # (see kanon#2436).
-      - name: Wait for tag propagation before retry
-        if: steps.release.outcome == 'failure'
-        run: sleep 15
-
-      - name: Retry release-please after transient tag-validation race
-        if: steps.release.outcome == 'failure'
-        id: release_retry
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
-        with:
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
-
-  # WHY a second job rather than more steps: it must run only when a release was
-  # actually cut, and the attested archive has to be checked out AT THE TAG — the
-  # first job's tree is whatever main was when it started.
-  attest-release:
-    needs: [release-please]
-    # WARNING: GH-native attestations cannot be persisted for user-owned PRIVATE
-    # repositories; the job 422s there on every cut. typikon is public, so this is
-    # live — the guard keeps it a non-fatal skip if visibility ever flips.
-    if: needs.release-please.outputs.release_created == 'true' && !github.event.repository.private
-    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ needs.release-please.outputs.tag_name }}
 
-      - name: Stage source archive
-        id: source
+      - name: Determine whether the manifest version is already published
+        id: state
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          archive="typikon-${{ needs.release-please.outputs.tag_name }}.tar.gz"
-          git archive --format=tar.gz --output "$archive" HEAD
-          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+          version=$(python3 - <<'PY'
+          import json
+          print(json.load(open(".release-please-manifest.json", encoding="utf-8"))["."])
+          PY
+          )
+          if python3 -I ci/verify-published-release.py --version "$version"; then
+            echo "prepare=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prepare=false" >> "$GITHUB_OUTPUT"
+            echo "Manifest version $version is not an exact published release; release PR preparation is parked."
+          fi
 
-      - name: Generate CycloneDX SBOM
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0
+      - name: Prepare or refresh the release pull request only
+        if: steps.state.outputs.prepare == 'true'
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
-          artifact-name: ${{ steps.source.outputs.archive }}.cdx.json
-          format: cyclonedx-json
-          output-file: ${{ steps.source.outputs.archive }}.cdx.json
-          upload-artifact: false
-          upload-release-assets: false
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-release: true
 
-      - name: Attest source provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
-        with:
-          subject-path: ${{ steps.source.outputs.archive }}
+  verify-locked-release:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    outputs:
+      candidate_commit: ${{ steps.verify.outputs.candidate_commit }}
+      candidate_tree: ${{ steps.verify.outputs.candidate_tree }}
+      evidence_commit: ${{ github.sha }}
+      lock_sha256: ${{ steps.verify.outputs.lock_sha256 }}
+      release_pr: ${{ steps.verify.outputs.release_pr }}
+      staging_artifact_digest: ${{ steps.staging.outputs.artifact-digest }}
+      staging_artifact_id: ${{ steps.staging.outputs.artifact-id }}
+      staging_run_attempt: ${{ github.run_attempt }}
+      staging_run_id: ${{ github.run_id }}
+      tag: ${{ steps.verify.outputs.tag }}
+    steps:
+      - name: Require explicit public-evidence privacy acknowledgment
+        env:
+          PRIVACY_ACKNOWLEDGED: ${{ inputs.acknowledge_private_consumer_metadata }}
+        run: |
+          test "$PRIVACY_ACKNOWLEDGED" = true
+          echo "Operator acknowledged publication of private-consumer receipt metadata." >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Attest CycloneDX SBOM
-        uses: actions/attest-sbom@5026d3663739160db546203eeaffa6aa1c51a4d6 # v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          subject-path: ${{ steps.source.outputs.archive }}
-          sbom-path: ${{ steps.source.outputs.archive }}.cdx.json
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Prove dispatch is on the current default-branch head
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq .default_branch)
+          test "$default_branch" = main
+          test "$GITHUB_REF" = refs/heads/main
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          live_head=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq .object.sha)
+          test "$live_head" = "$GITHUB_SHA"
+
+      - name: Resolve the tracked lock path
+        id: lock
+        env:
+          REQUESTED_LOCK: ${{ inputs.lock_path }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os
+          from pathlib import Path
+
+          root = Path.cwd().resolve()
+          lock = (root / os.environ["REQUESTED_LOCK"]).resolve()
+          expected = root / "release" / "compatibility"
+          if expected not in lock.parents or lock.suffix != ".json" or not lock.is_file():
+              raise SystemExit(f"lock path is not a tracked compatibility JSON: {lock}")
+          print(f"path={lock.relative_to(root)}")
+          PY
+
+      - name: Replay candidate, artifact, consumer, workflow, and PR evidence
+        id: verify
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TOOLS_RECEIPT_TOKEN: ${{ secrets.TOOLS_RECEIPT_TOKEN }}
+          LEATHER_RECEIPT_TOKEN: ${{ secrets.LEATHER_RECEIPT_TOKEN }}
+        run: |
+          python3 -I ci/verify-release-lock.py \
+            --lock "${{ steps.lock.outputs.path }}" \
+            --materialize-candidate "$RUNNER_TEMP/verified-candidate" \
+            --emit-github-output "$GITHUB_OUTPUT"
+
+      - name: Stage the exact release evidence set
+        run: |
+          publish_dir="$RUNNER_TEMP/publish"
+          mkdir -p "$publish_dir"
+          cp "$RUNNER_TEMP/verified-candidate/candidate.json" "$publish_dir/"
+          cp "$RUNNER_TEMP/verified-candidate/typikon-${{ steps.verify.outputs.tag }}.tar.gz" "$publish_dir/"
+          cp "$RUNNER_TEMP/verified-candidate/typikon-${{ steps.verify.outputs.tag }}.tar.gz.sha256" "$publish_dir/"
+          cp "$RUNNER_TEMP/verified-candidate/typikon-${{ steps.verify.outputs.tag }}.tar.gz.cdx.json" "$publish_dir/"
+          cp "$RUNNER_TEMP/verified-candidate/typikon-${{ steps.verify.outputs.tag }}.tar.gz.provenance.intoto.jsonl" "$publish_dir/"
+          cp "$RUNNER_TEMP/verified-candidate/typikon-${{ steps.verify.outputs.tag }}.tar.gz.sbom.intoto.jsonl" "$publish_dir/"
+          cp "${{ steps.lock.outputs.path }}" "$publish_dir/typikon-${{ steps.verify.outputs.tag }}-compatibility-lock.json"
+          cp release/compatibility/receipts/tools.json "$publish_dir/typikon-${{ steps.verify.outputs.tag }}-tools-receipt.json"
+          cp release/compatibility/receipts/leather.json "$publish_dir/typikon-${{ steps.verify.outputs.tag }}-leather-receipt.json"
+          echo "PUBLISH_DIR=$publish_dir" >> "$GITHUB_ENV"
+
+      - name: Revalidate live evidence before sealing the handoff
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TOOLS_RECEIPT_TOKEN: ${{ secrets.TOOLS_RECEIPT_TOKEN }}
+          LEATHER_RECEIPT_TOKEN: ${{ secrets.LEATHER_RECEIPT_TOKEN }}
+        run: |
+          python3 -I ci/verify-release-lock.py \
+            --lock "${{ steps.lock.outputs.path }}" \
+            --materialize-candidate "$RUNNER_TEMP/reverified-candidate"
+          reverified="$RUNNER_TEMP/reverified-publish"
+          mkdir -p "$reverified"
+          cp "$RUNNER_TEMP/reverified-candidate/candidate.json" "$reverified/"
+          cp "$RUNNER_TEMP/reverified-candidate/typikon-${{ steps.verify.outputs.tag }}.tar.gz" "$reverified/"
+          cp "$RUNNER_TEMP/reverified-candidate/typikon-${{ steps.verify.outputs.tag }}.tar.gz.sha256" "$reverified/"
+          cp "$RUNNER_TEMP/reverified-candidate/typikon-${{ steps.verify.outputs.tag }}.tar.gz.cdx.json" "$reverified/"
+          cp "$RUNNER_TEMP/reverified-candidate/typikon-${{ steps.verify.outputs.tag }}.tar.gz.provenance.intoto.jsonl" "$reverified/"
+          cp "$RUNNER_TEMP/reverified-candidate/typikon-${{ steps.verify.outputs.tag }}.tar.gz.sbom.intoto.jsonl" "$reverified/"
+          cp "${{ steps.lock.outputs.path }}" "$reverified/typikon-${{ steps.verify.outputs.tag }}-compatibility-lock.json"
+          cp release/compatibility/receipts/tools.json "$reverified/typikon-${{ steps.verify.outputs.tag }}-tools-receipt.json"
+          cp release/compatibility/receipts/leather.json "$reverified/typikon-${{ steps.verify.outputs.tag }}-leather-receipt.json"
+          diff -qr "$PUBLISH_DIR" "$reverified"
+          live_head=$(python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          request = urllib.request.Request(
+              f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}/git/ref/heads/main",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              print(json.load(response)["object"]["sha"])
+          PY
+          )
+          test "$live_head" = "$GITHUB_SHA"
+          rm -rf "$PUBLISH_DIR"
+          mv "$reverified" "$PUBLISH_DIR"
+
+      - name: Seal the verified publication handoff
+        id: staging
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: typikon-${{ steps.verify.outputs.tag }}-verified-publication-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.PUBLISH_DIR }}/*
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-locked-release:
+    needs: verify-locked-release
+    if: needs.verify-locked-release.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.verify-locked-release.outputs.evidence_commit }}
+
+      - name: Prove the verified evidence commit is still current main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          test "$GITHUB_REF" = refs/heads/main
+          test "$(git rev-parse HEAD)" = "${{ needs.verify-locked-release.outputs.evidence_commit }}"
+          test "$(gh api "repos/$GITHUB_REPOSITORY" --jq .default_branch)" = main
+          live_head=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq .object.sha)
+          test "$live_head" = "${{ needs.verify-locked-release.outputs.evidence_commit }}"
+
+      - name: Materialize the raw digest-bound publication handoff
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          test "$GITHUB_RUN_ID" = "${{ needs.verify-locked-release.outputs.staging_run_id }}"
+          if test "$GITHUB_RUN_ATTEMPT" != "${{ needs.verify-locked-release.outputs.staging_run_attempt }}"; then
+            echo "Publisher-only retries are stale; rerun the complete workflow so live evidence is replayed." >&2
+            exit 1
+          fi
+          python3 -I ci/materialize-release-handoff.py \
+            --artifact-id "${{ needs.verify-locked-release.outputs.staging_artifact_id }}" \
+            --artifact-digest "${{ needs.verify-locked-release.outputs.staging_artifact_digest }}" \
+            --run-id "${{ needs.verify-locked-release.outputs.staging_run_id }}" \
+            --run-attempt "${{ needs.verify-locked-release.outputs.staging_run_attempt }}" \
+            --tag "${{ needs.verify-locked-release.outputs.tag }}" \
+            --output "$RUNNER_TEMP/publish"
+          echo "PUBLISH_DIR=$RUNNER_TEMP/publish" >> "$GITHUB_ENV"
+
+      - name: Inspect any exact interrupted publication state
+        id: publication
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 -I ci/publish-locked-release.py inspect \
+            --tag "${{ needs.verify-locked-release.outputs.tag }}" \
+            --candidate "${{ needs.verify-locked-release.outputs.candidate_commit }}" \
+            --evidence-commit "${{ needs.verify-locked-release.outputs.evidence_commit }}" \
+            --lock-sha256 "${{ needs.verify-locked-release.outputs.lock_sha256 }}" \
+            --tracked-lock "${{ inputs.lock_path }}" \
+            --assets-dir "$PUBLISH_DIR" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Publish or resume the exact locked release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 -I ci/publish-locked-release.py publish \
+            --tag "${{ steps.publication.outputs.tag }}" \
+            --candidate "${{ steps.publication.outputs.candidate_commit }}" \
+            --evidence-commit "${{ needs.verify-locked-release.outputs.evidence_commit }}" \
+            --lock-sha256 "${{ steps.publication.outputs.lock_sha256 }}" \
+            --tracked-lock "${{ inputs.lock_path }}" \
+            --assets-dir "$PUBLISH_DIR"
+
+      - name: Reconcile Release Please bookkeeping
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr="${{ steps.publication.outputs.release_pr }}"
+          printf '%s\n' '{"labels":["autorelease: tagged"]}' > "$RUNNER_TEMP/tagged-label.json"
+          gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$pr/labels" \
+            --input "$RUNNER_TEMP/tagged-label.json" >/dev/null
+          if gh api "repos/$GITHUB_REPOSITORY/issues/$pr/labels" \
+            --jq '.[].name' | grep -Fxq 'autorelease: pending'; then
+            gh api --method DELETE \
+              "repos/$GITHUB_REPOSITORY/issues/$pr/labels/autorelease%3A%20pending" \
+              >/dev/null
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Typikon is a Zola theme + frontmatter schemas + CI gates for agentic fleet web p
 3. [docs/AGENTIC.md](docs/AGENTIC.md) — agent contract
 4. [docs/SCHEMAS.md](docs/SCHEMAS.md) — frontmatter field reference
 5. [docs/BOOTSTRAP.md](docs/BOOTSTRAP.md) — scaffolder behavior
+6. [docs/RELEASING.md](docs/RELEASING.md) — exact candidate and consumer-lock protocol
 
 ## Key binaries
 
@@ -60,6 +61,7 @@ All decisions are in [CLAUDE.md](CLAUDE.md) under "Locked decisions". Key ones:
 - **Fail-closed checkout**: a catalog price does not imply readiness. Checkout and Offer URLs require sourced purchasable availability; shipping copy requires paired provenance.
 - **Push authority**: `origin` is GitHub; no forge remote is configured. forkwright/kanon#3045 owns the typed authority split.
 - **License**: PolyForm Noncommercial 1.0.0 (`LicenseRef-PolyForm-Noncommercial-1.0.0`). `LICENSE` is authoritative.
+- **Two-phase releases**: the SemVer tag targets the frozen one-parent release commit, not the later evidence commit. Tools and Leather must pass that exact gitlink; the typed lock records both promotion and per-consumer rollback subjects.
 
 ## Boundaries
 
@@ -69,6 +71,7 @@ All decisions are in [CLAUDE.md](CLAUDE.md) under "Locked decisions". Key ones:
 - **Schema changes are migrations.** Ship a `bin/` migration for incompatible transformations that can preserve truth. A newly required provenance value is the explicit exception: name every blocked consumer, then author the source or intentionally remove the gated fact in a consumer PR; never synthesize provenance.
 - **Schemas and primitives change in typikon, not in consumers.** When two consumer sites disagree on a primitive, parameterize the schema here; do not fork the theme.
 - **Owned headings carry qualified metadata.** Default page and section H1s consume typed `extra.greek`; consumers do not hand-author a replacement H1 to attach that metadata.
+- **Do not publish from a provisional tree.** Keep the Release Please PR untagged until both consumer receipts and the evidence-only lock pass `ci/verify-release-lock.py`. Credential installation and the final manual dispatch remain operator-owned actions.
 
 ## Dispatch entry points
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ typikon/
 ├── scaffolds/              # reserved, currently empty — typikon-init scaffolds content inline
 ├── bin/                    # typikon-init, typikon-validate, typikon-check, typikon-refresh, typikon-migrate-template
 ├── ci/                     # strict gate config (lychee, pa11y, playwright, csp-enforce, asset-provenance)
-├── docs/                   # AGENTIC.md, SCHEMAS.md, BOOTSTRAP.md
+├── docs/                   # AGENTIC.md, SCHEMAS.md, BOOTSTRAP.md, RELEASING.md
+├── release/                # strict two-consumer compatibility-lock schema and evidence
 ├── _headers.tmpl           # Cloudflare Pages strict-CSP
 ├── _redirects.tmpl         # Cloudflare Pages redirects
 ├── theme.toml              # Zola theme manifest
@@ -53,6 +54,7 @@ Web-property-specific standards live alongside as kanon STANDARDS/WEB.md (filed 
 - **Fail-closed checkout**: product price is catalog data. Checkout and Offer URLs require sourced purchasable availability, and shipping text requires its own source.
 - **Push authority**: `origin` is GitHub (`forkwright/typikon`); no forge remote is configured. The typed forge/GitHub authority split is unresolved — forkwright/kanon#3045 owns it.
 - **License**: PolyForm Noncommercial 1.0.0 (`LicenseRef-PolyForm-Noncommercial-1.0.0`). `LICENSE` is authoritative.
+- **Two-phase releases**: Release Please prepares the PR but does not tag. The release squash is frozen as exact candidate `R`; Tools and Leather gate `R`; a later evidence-only commit records typed promotion and rollback; manual publication creates the annotated SemVer tag at `R` only after replaying the lock.
 - **Consumer schema registry**: a consumer site's custom-templated content types register in `schemas/registry.toml` and validate against their own schema, composed from typikon's open `page.core.schema.json`/`section.core.schema.json` building blocks and closed with `unevaluatedProperties: false`. A custom `template` with no registry entry fails validation naming the missing registration rather than falling back to `page`'s shape. See `docs/SCHEMAS.md#consumer-schema-registry`. <!-- kanon:ignore STANDARDS/citation-must-be-resolvable -- anchor exists at docs/SCHEMAS.md:26. Resolver drops the docs/ prefix and checks the wrong directory. Filed kanon (forge) issue #10073. -->
 
 ## How an agent operates here
@@ -70,6 +72,7 @@ Web-property-specific standards live alongside as kanon STANDARDS/WEB.md (filed 
 - **Push to `origin`.** It is GitHub; there is no mirror step. Verify with `git remote -v` rather than assuming.
 - **Never bypass the CI gate.** No `--no-verify`, no `[skip ci]`, no commit on green failure.
 - **Schema changes are migrations.** Ship a `bin/` migration for incompatible transformations that can preserve truth. A newly required provenance value is the explicit exception: name every blocked consumer, then author the source or intentionally remove the gated fact in a consumer PR; never synthesize provenance.
+- **Release credentials are operator-owned.** The two cross-repository receipt tokens are read-only and scoped to one consumer each. Never create, widen, or install them without explicit operator direction. See `docs/RELEASING.md`.
 
 <!-- kanon:auto-start -->
 ## Generated kanon context

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Optimized for agentic operation. Humans should not need to develop here. The sub
 - **Fail-closed commerce** - catalog prices may render without readiness. Checkout and Offer URLs require sourced purchasable availability, and shipping claims require their own source.
 - **Binaries** (`bin/`) - `typikon-init` (scaffolds a consumer site's content and config inline, no separate template directory), `typikon-validate`, `typikon-check`, `typikon-refresh`, `typikon-migrate-template` (skeleton for schema-migration scripts). Idempotent CLIs with JSONL output where applicable.
 - **CI** (`ci/`) - strict gate: build, CSP enforcement, internal + external link integrity, a11y, smoke. No pass = no deploy.
+- **Release control** (`release/`, `docs/RELEASING.md`) - freezes one untagged candidate, binds Tools and Leather to that exact commit, records per-consumer rollback pins, and publishes only through a reviewed compatibility lock.
 - **Headers** (`_headers.tmpl`, `_redirects.tmpl`) - Cloudflare Pages strict-CSP + redirect templates.
 
 ## Visitor runtime
@@ -69,7 +70,7 @@ and taxonomy feeds remain Zola-owned.
 Set `include_in_feeds = false` to exclude an individual page. Missing or empty
 configured sources fail the build.
 
-See `docs/AGENTIC.md` for the agent contract, `docs/SCHEMAS.md` for the frontmatter reference, `docs/BOOTSTRAP.md` for the scaffolder behavior.
+See `docs/AGENTIC.md` for the agent contract, `docs/SCHEMAS.md` for the frontmatter reference, `docs/BOOTSTRAP.md` for the scaffolder behavior, and `docs/RELEASING.md` for the two-phase release protocol.
 
 ## License
 

--- a/_llm/apis.toml
+++ b/_llm/apis.toml
@@ -36,3 +36,11 @@ purpose = "Apply template/schema migrations for consumers."
 [[cli_commands]]
 name = "bin/typikon-refresh"
 purpose = "Re-render consumer-side templates after an upstream bump."
+
+[[cli_commands]]
+name = "ci/verify-release-lock.py"
+purpose = "Replay a typed two-consumer compatibility lock against exact Git and GitHub evidence."
+
+[[cli_commands]]
+name = "ci/publish-locked-release.py"
+purpose = "Inspect, resume, or publish the exact annotated tag and locked release assets."

--- a/_llm/architecture.toml
+++ b/_llm/architecture.toml
@@ -17,6 +17,7 @@ layers = [
   "scaffolds",
   "bin",
   "ci",
+  "release-control",
   "static-assets",
   "docs",
 ]
@@ -46,6 +47,11 @@ name = "ci"
 path = "ci"
 role = "Strict web-property gate configuration."
 
+[[architecture.crates]]
+name = "release-control"
+path = "release"
+role = "Typed exact-candidate consumer promotion and rollback evidence."
+
 [[interfaces]]
 name = "typikon CLI tools"
 kind = "cli"
@@ -55,3 +61,8 @@ path = "bin"
 name = "Zola theme"
 kind = "static-web"
 path = "theme.toml"
+
+[[interfaces]]
+name = "release compatibility verifier"
+kind = "cli"
+path = "ci/verify-release-lock.py"

--- a/_llm/current_state.toml
+++ b/_llm/current_state.toml
@@ -9,8 +9,12 @@ source_docs = [
 
 [state]
 summary = "Typikon is the active fleet Zola 0.23/Tera 2 theme, schema, scaffolding, and gate substrate, consumed by ardent-site and ardent-tools-site through the themes/typikon submodule."
-current_phase = "Zola 0.23.3/Tera 2 substrate active; feeds, sale readiness, and qualified headings are bound to typed source contracts."
+current_phase = "Zola 0.23.3/Tera 2 substrate active; exact-candidate two-consumer release control is under review before v0.6.0."
 updated = "2026-08-20"
+
+[[recent]]
+date = "2026-08-20"
+item = "Separated release preparation from publication and added an exact-candidate compatibility lock with per-consumer rollback subjects."
 
 [[recent]]
 date = "2026-08-20"
@@ -36,3 +40,8 @@ item = "Typikon repo established as fleet web-property substrate."
 name = "Consumer migrations"
 issue = 183
 status = "Ardent Leatherworks must author sources or intentionally remove three products' shipping/readiness facts before bumping; Ardent Tools validates unchanged. A script may remove claims safely but cannot synthesize their provenance."
+
+[[open_threads]]
+name = "Release compatibility program"
+issue = 70
+status = "The v0.6 change implements the first typed Tools+Leather promotion and rollback receipt. Generalized bundles, provider adapters, and automatic merge refusal remain open. Publication also requires two operator-installed read-only receipt tokens."

--- a/_llm/decisions.toml
+++ b/_llm/decisions.toml
@@ -72,3 +72,11 @@ status = "accepted"
 context = "A stored checkout URL and recorded price do not establish current availability or fulfillment readiness."
 decision = "Render checkout and Offer URLs only for sourced purchasable availability. Render shipping text only with paired provenance."
 consequences = "Unknown or negative readiness keeps the product legible as a catalog record without inviting a transaction."
+
+[[decision]]
+id = "D-two-phase-release"
+title = "Separate release content from compatibility evidence"
+status = "accepted"
+context = "Squash-only publication changes the commit identity, while both consumers must test the exact commit and source archive later tagged as the release."
+decision = "Freeze the one-parent release squash as candidate R, gate both consumer gitlinks at R, commit only the lock and receipts afterward, and publish an annotated tag at R through a replayed evidence lock."
+consequences = "The evidence commit never becomes release content; promotion and distinct per-consumer rollback subjects are typed, and publication credentials stay outside PR gates."

--- a/ci/build-release-candidate.py
+++ b/ci/build-release-candidate.py
@@ -1,0 +1,655 @@
+#!/usr/bin/env python3
+"""Detect and freeze an untagged Release Please merge commit."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ".release-please-manifest.json"
+SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+RELEASE_COMMIT = re.compile(r"\(#(?P<pr>[1-9][0-9]*)\)\s*$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+ROOT_PURL = "pkg:github/forkwright/typikon"
+ROOT_LICENSE = "LicenseRef-PolyForm-Noncommercial-1.0.0"
+EMBEDDED_COMPONENT_GLOBS = ("static/fonts/*.woff2",)
+
+
+class CandidateError(RuntimeError):
+    pass
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise CandidateError(result.stderr.strip() or f"git {' '.join(args)} failed")
+    return result.stdout.strip()
+
+
+def git_succeeds(*args: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "-C", str(ROOT), *args],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def manifest_at(revision: str) -> str:
+    raw = json.loads(git("show", f"{revision}:{MANIFEST}"))
+    if set(raw) != {"."} or not isinstance(raw["."], str):
+        raise CandidateError(f"{MANIFEST} must contain exactly the root package version")
+    version = raw["."]
+    if not SEMVER.fullmatch(version):
+        raise CandidateError(f"invalid release version {version!r}")
+    return version
+
+
+def release_identity() -> dict[str, object] | None:
+    parents = git("rev-list", "--parents", "-n", "1", "HEAD").split()[1:]
+    if len(parents) != 1:
+        changed_from_first_parent = (
+            set(git("diff", "--name-only", parents[0], "HEAD").splitlines())
+            if parents
+            else set()
+        )
+        if MANIFEST in changed_from_first_parent:
+            raise CandidateError("a release candidate must be a one-parent squash commit")
+        return None
+    try:
+        parent = parents[0]
+    except CandidateError:
+        return None
+    changed = set(git("diff", "--name-only", "HEAD^", "HEAD").splitlines())
+    if MANIFEST not in changed:
+        return None
+    if changed != {MANIFEST, "CHANGELOG.md"}:
+        raise CandidateError(
+            "a release-candidate commit may change only CHANGELOG.md and "
+            f"{MANIFEST}; found {sorted(changed)}"
+        )
+    previous = manifest_at("HEAD^")
+    version = manifest_at("HEAD")
+    if tuple(map(int, version.split("."))) <= tuple(map(int, previous.split("."))):
+        raise CandidateError(f"release version {version} does not advance {previous}")
+    tag = f"v{version}"
+    if git_succeeds("show-ref", "--verify", "--quiet", f"refs/tags/{tag}"):
+        raise CandidateError(f"release candidate {tag} is already tagged")
+    subject = git("show", "-s", "--format=%s", "HEAD")
+    match = RELEASE_COMMIT.search(subject)
+    if match is None:
+        raise CandidateError("release-candidate commit subject must end in '(#PR)' provenance")
+    return {
+        "version": version,
+        "tag": tag,
+        "release_pr": int(match.group("pr")),
+        "candidate_commit": git("rev-parse", "HEAD"),
+        "candidate_tree": git("rev-parse", "HEAD^{tree}"),
+        "parent_commit": parent,
+    }
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def release_notes(version: str) -> str:
+    try:
+        text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CandidateError(f"cannot read CHANGELOG.md: {exc}") from exc
+    header = re.compile(rf"^## \[{re.escape(version)}\].*$", re.MULTILINE)
+    matches = list(header.finditer(text))
+    if len(matches) != 1:
+        raise CandidateError(
+            f"CHANGELOG.md must contain exactly one release heading for {version}"
+        )
+    start = matches[0].end()
+    following = re.search(r"^## ", text[start:], re.MULTILINE)
+    end = start + following.start() if following else len(text)
+    notes = text[start:end].strip()
+    if not notes:
+        raise CandidateError(f"CHANGELOG.md release section {version} is empty")
+    return notes
+
+
+def validated_component_inventory() -> list[dict[str, object]]:
+    inventory_path = ROOT / "release" / "components.json"
+    try:
+        value = json.loads(inventory_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CandidateError(f"cannot read release component inventory: {exc}") from exc
+    if not isinstance(value, dict) or set(value) != {"schema_version", "components"}:
+        raise CandidateError("release component inventory has unexpected fields")
+    if value["schema_version"] != 1:
+        raise CandidateError("release component inventory schema_version must be 1")
+    raw_components = value["components"]
+    if not isinstance(raw_components, list) or not raw_components:
+        raise CandidateError("release component inventory is empty")
+
+    embedded: set[str] = set()
+    for pattern in EMBEDDED_COMPONENT_GLOBS:
+        embedded.update(
+            path.relative_to(ROOT).as_posix()
+            for path in ROOT.glob(pattern)
+            if path.is_file()
+        )
+
+    repository_files: set[str] = set()
+    external_distributions = 0
+    purls: set[str] = set()
+    result: list[dict[str, object]] = []
+    for index, raw in enumerate(raw_components):
+        label = f"release component {index}"
+        if not isinstance(raw, dict) or set(raw) != {
+            "name",
+            "version",
+            "purl",
+            "scope",
+            "license",
+            "hash",
+        }:
+            raise CandidateError(f"{label} has unexpected fields")
+        for field in ("name", "version", "purl", "scope", "license"):
+            if not isinstance(raw[field], str) or not raw[field]:
+                raise CandidateError(f"{label} has invalid {field}")
+        if raw["scope"] not in {"required", "optional", "excluded"}:
+            raise CandidateError(f"{label} has invalid scope")
+        purl = str(raw["purl"])
+        if purl in purls:
+            raise CandidateError(f"duplicate release component purl: {purl}")
+        purls.add(purl)
+        hash_source = raw["hash"]
+        if not isinstance(hash_source, dict) or "kind" not in hash_source:
+            raise CandidateError(f"{label} has invalid hash source")
+        kind = hash_source["kind"]
+        if kind == "repository-file":
+            if set(hash_source) != {"kind", "path"}:
+                raise CandidateError(f"{label} repository hash source is invalid")
+            relative = hash_source["path"]
+            if not isinstance(relative, str) or not relative:
+                raise CandidateError(f"{label} repository path is invalid")
+            path = (ROOT / relative).resolve()
+            if ROOT not in path.parents or not path.is_file():
+                raise CandidateError(f"{label} repository path is unsafe or missing")
+            normalized = path.relative_to(ROOT).as_posix()
+            if normalized != relative:
+                raise CandidateError(f"{label} repository path is not normalized")
+            repository_files.add(relative)
+            digest = sha256(path)
+            component_type = "file"
+        elif kind == "external-distribution":
+            if set(hash_source) != {"kind", "sha256", "url"}:
+                raise CandidateError(f"{label} external hash source is invalid")
+            digest = hash_source["sha256"]
+            if not isinstance(digest, str) or SHA256.fullmatch(digest) is None:
+                raise CandidateError(f"{label} external SHA-256 is invalid")
+            distribution_url = hash_source["url"]
+            if not isinstance(distribution_url, str) or not distribution_url.startswith(
+                "https://"
+            ):
+                raise CandidateError(f"{label} external distribution URL is invalid")
+            component_type = "application"
+            external_distributions += 1
+        else:
+            raise CandidateError(f"{label} has unknown hash source {kind!r}")
+        component = {
+                "type": component_type,
+                "bom-ref": purl,
+                "name": raw["name"],
+                "version": raw["version"],
+                "scope": raw["scope"],
+                "purl": purl,
+                "licenses": [{"expression": raw["license"]}],
+                "hashes": [{"alg": "SHA-256", "content": digest}],
+            }
+        if kind == "external-distribution":
+            component["externalReferences"] = [
+                {
+                    "type": "distribution",
+                    "url": distribution_url,
+                    "hashes": [{"alg": "SHA-256", "content": digest}],
+                }
+            ]
+        result.append(component)
+    if repository_files != embedded:
+        raise CandidateError(
+            "release component inventory does not exactly cover embedded files: "
+            f"inventory={sorted(repository_files)}, discovered={sorted(embedded)}"
+        )
+    if external_distributions == 0:
+        raise CandidateError("release component inventory has no external distribution")
+    return result
+
+
+def component_inventory() -> list[dict[str, object]]:
+    validated_component_inventory()
+    raise CandidateError(
+        "release SBOM dependency graph is incomplete; forkwright/typikon#58 "
+        "must lock every shipped CLI, gate, and deploy dependency before publication"
+    )
+
+
+def iter_components(items: object):
+    if not isinstance(items, list):
+        return
+    for component in items:
+        if not isinstance(component, dict):
+            raise CandidateError("CycloneDX components must be objects")
+        yield component
+        yield from iter_components(component.get("components", []))
+
+
+def component_has_license(component: dict[str, object]) -> bool:
+    licenses = component.get("licenses")
+    if not isinstance(licenses, list) or not licenses:
+        return False
+    for item in licenses:
+        if not isinstance(item, dict):
+            return False
+        expression = item.get("expression")
+        license_value = item.get("license")
+        if isinstance(expression, str) and expression:
+            continue
+        if isinstance(license_value, dict) and any(
+            isinstance(license_value.get(key), str) and license_value.get(key)
+            for key in ("id", "name")
+        ):
+            continue
+        return False
+    return True
+
+
+def component_has_sha256(component: dict[str, object]) -> bool:
+    hashes = component.get("hashes")
+    return isinstance(hashes, list) and any(
+        isinstance(item, dict)
+        and item.get("alg") == "SHA-256"
+        and isinstance(item.get("content"), str)
+        and SHA256.fullmatch(item["content"]) is not None
+        for item in hashes
+    )
+
+
+def normalize_and_validate_sbom(
+    document: dict[str, object], identity: dict[str, object], archive: Path
+) -> None:
+    if document.get("bomFormat") != "CycloneDX":
+        raise CandidateError("SBOM is not a CycloneDX document")
+    spec = document.get("specVersion")
+    try:
+        major, minor = (int(part) for part in str(spec).split(".", 1))
+    except (TypeError, ValueError) as exc:
+        raise CandidateError("CycloneDX specVersion is not numeric") from exc
+    if (major, minor) < (1, 5):
+        raise CandidateError("CycloneDX specVersion must be 1.5 or newer")
+
+    version = str(identity["version"])
+    archive_digest = sha256(archive)
+    purl = f"{ROOT_PURL}@{version}"
+    expected_serial = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"https://github.com/forkwright/typikon/commit/{identity['candidate_commit']}",
+        )
+    )
+    if document.get("serialNumber") != f"urn:uuid:{expected_serial}":
+        raise CandidateError("CycloneDX serialNumber does not bind the candidate commit")
+    metadata = document.setdefault("metadata", {})
+    if not isinstance(metadata, dict):
+        raise CandidateError("CycloneDX metadata must be an object")
+    metadata["component"] = {
+        "type": "library",
+        "bom-ref": purl,
+        "name": "typikon",
+        "version": version,
+        "scope": "required",
+        "purl": purl,
+        "licenses": [{"expression": ROOT_LICENSE}],
+        "hashes": [{"alg": "SHA-256", "content": archive_digest}],
+    }
+
+    inventory = component_inventory()
+    inventory_purls = {str(item["purl"]) for item in inventory}
+    existing = document.get("components", [])
+    if not isinstance(existing, list):
+        raise CandidateError("CycloneDX components must be an array")
+    if any(
+        component.get("purl") in inventory_purls
+        for component in iter_components(existing)
+    ):
+        raise CandidateError("generated SBOM duplicates an authoritative component purl")
+    document["components"] = [*existing, *inventory]
+    document["dependencies"] = [
+        {"ref": purl, "dependsOn": sorted(inventory_purls)},
+        *[
+            {"ref": item["purl"], "dependsOn": []}
+            for item in sorted(inventory, key=lambda value: str(value["purl"]))
+        ],
+    ]
+
+    for component in iter_components(document.get("components", [])):
+        missing = [
+            field
+            for field in ("name", "version", "purl", "scope")
+            if not isinstance(component.get(field), str) or not component.get(field)
+        ]
+        if missing:
+            raise CandidateError(
+                f"CycloneDX component lacks required fields {missing}: {component.get('name')!r}"
+            )
+        if component["scope"] not in {"required", "optional", "excluded"}:
+            raise CandidateError(
+                f"CycloneDX component has invalid scope: {component.get('name')!r}"
+            )
+        if not component_has_license(component):
+            raise CandidateError(
+                f"CycloneDX component lacks a license: {component.get('name')!r}"
+            )
+        if not component_has_sha256(component):
+            raise CandidateError(
+                f"CycloneDX component lacks a SHA-256 hash: {component.get('name')!r}"
+            )
+
+    expected_dependency_refs = {purl, *inventory_purls}
+    dependency_rows = document.get("dependencies")
+    if not isinstance(dependency_rows, list) or {
+        row.get("ref") for row in dependency_rows if isinstance(row, dict)
+    } != expected_dependency_refs:
+        raise CandidateError("CycloneDX dependency graph does not cover every component")
+
+
+def read_bundle(
+    path: Path,
+    label: str,
+    archive_name: str,
+    archive_sha256: str,
+) -> bytes:
+    payload = path.read_bytes()
+    lines = [line for line in payload.splitlines() if line.strip()]
+    if len(lines) != 1:
+        raise CandidateError(f"{label} attestation bundle must contain exactly one JSONL record")
+    try:
+        value = json.loads(lines[0])
+    except json.JSONDecodeError as exc:
+        raise CandidateError(f"{label} attestation bundle is invalid JSONL: {exc}") from exc
+    if not isinstance(value, dict):
+        raise CandidateError(f"{label} attestation bundle record must be an object")
+    media_type = value.get("mediaType")
+    if not isinstance(media_type, str) or not media_type.startswith(
+        "application/vnd.dev.sigstore.bundle"
+    ):
+        raise CandidateError(f"{label} attestation bundle has no Sigstore media type")
+    verification = value.get("verificationMaterial")
+    envelope = value.get("dsseEnvelope")
+    if not isinstance(verification, dict) or not verification:
+        raise CandidateError(f"{label} attestation bundle has no verification material")
+    if not isinstance(envelope, dict):
+        raise CandidateError(f"{label} attestation bundle has no DSSE envelope")
+    if envelope.get("payloadType") != "application/vnd.in-toto+json":
+        raise CandidateError(f"{label} attestation bundle has the wrong payload type")
+    signatures = envelope.get("signatures")
+    if not isinstance(signatures, list) or not signatures:
+        raise CandidateError(f"{label} attestation bundle has no signature")
+    try:
+        statement = json.loads(
+            base64.b64decode(envelope.get("payload", ""), validate=True)
+        )
+    except (ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise CandidateError(f"{label} attestation payload is invalid") from exc
+    expected_predicate = {
+        "provenance": "https://slsa.dev/provenance/v1",
+        "sbom": "https://cyclonedx.org/bom",
+    }[label]
+    if (
+        not isinstance(statement, dict)
+        or statement.get("_type") != "https://in-toto.io/Statement/v1"
+        or statement.get("predicateType") != expected_predicate
+    ):
+        raise CandidateError(f"{label} attestation statement type is wrong")
+    subjects = statement.get("subject")
+    if not isinstance(subjects, list) or len(subjects) != 1:
+        raise CandidateError(f"{label} attestation must name exactly one subject")
+    subject = subjects[0]
+    if (
+        not isinstance(subject, dict)
+        or Path(str(subject.get("name", ""))).name != archive_name
+        or subject.get("digest", {}).get("sha256") != archive_sha256
+    ):
+        raise CandidateError(f"{label} attestation subject differs from the archive")
+    return payload
+
+
+def attach_attestations(output_dir: Path, provenance: Path, sbom_bundle: Path) -> Path:
+    manifest_path = output_dir / "candidate.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CandidateError(f"candidate manifest cannot be read: {exc}") from exc
+    if set(manifest) != {
+        "schema_version",
+        "release",
+        "workflow",
+        "archive",
+        "checksum",
+        "sbom",
+        "notes",
+    }:
+        raise CandidateError("candidate manifest is not awaiting attestation finalization")
+    archive_name = manifest.get("archive", {}).get("name")
+    if not isinstance(archive_name, str):
+        raise CandidateError("candidate manifest has no archive name")
+    archive_sha256 = manifest.get("archive", {}).get("sha256")
+    if not isinstance(archive_sha256, str) or SHA256.fullmatch(archive_sha256) is None:
+        raise CandidateError("candidate manifest has no archive SHA-256")
+    sources = {"provenance": provenance, "sbom": sbom_bundle}
+    attestations: dict[str, dict[str, object]] = {}
+    for kind, source in sources.items():
+        payload = read_bundle(source, kind, archive_name, archive_sha256)
+        destination = output_dir / f"{archive_name}.{kind}.intoto.jsonl"
+        destination.unlink(missing_ok=True)
+        with source.open("rb") as input_handle, destination.open("xb") as output_handle:
+            shutil.copyfileobj(input_handle, output_handle)
+        attestations[kind] = {
+            "name": destination.name,
+            "sha256": sha256(destination),
+            "size": destination.stat().st_size,
+        }
+        if destination.read_bytes() != payload:
+            raise CandidateError(f"{kind} attestation bundle copy changed bytes")
+    manifest["attestations"] = attestations
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return manifest_path
+
+
+def write_github_output(identity: dict[str, object] | None, output: Path) -> None:
+    lines = [f"candidate={'true' if identity else 'false'}"]
+    if identity:
+        for key in (
+            "version",
+            "tag",
+            "release_pr",
+            "candidate_commit",
+            "candidate_tree",
+        ):
+            lines.append(f"{key}={identity[key]}")
+    with output.open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+def seed_sbom(output_dir: Path) -> Path:
+    identity = release_identity()
+    if identity is None:
+        raise CandidateError("HEAD is not a release-candidate commit")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    archive_name = f"typikon-{identity['tag']}.tar.gz"
+    destination = output_dir / f"{archive_name}.cdx.json"
+    destination.unlink(missing_ok=True)
+    serial = uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        f"https://github.com/forkwright/typikon/commit/{identity['candidate_commit']}",
+    )
+    document = {
+        "bomFormat": "CycloneDX",
+        "serialNumber": f"urn:uuid:{serial}",
+        "specVersion": "1.6",
+        "version": 1,
+        "metadata": {
+            "timestamp": git("show", "-s", "--format=%cI", "HEAD"),
+            "tools": {
+                "components": [
+                    {
+                        "type": "application",
+                        "name": "typikon release candidate builder",
+                        "version": str(identity["candidate_commit"]),
+                    }
+                ]
+            },
+        },
+        "components": [],
+        "dependencies": [],
+    }
+    destination.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return destination
+
+
+def freeze(output_dir: Path) -> Path:
+    identity = release_identity()
+    if identity is None:
+        raise CandidateError("HEAD is not a release-candidate commit")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    archive_name = f"typikon-{identity['tag']}.tar.gz"
+    archive = output_dir / archive_name
+    checksum = output_dir / f"{archive_name}.sha256"
+    sbom = output_dir / f"{archive_name}.cdx.json"
+    # The freezer owns the archive bytes. Never bless a stale caller-supplied
+    # file merely because its name is plausible.
+    archive.unlink(missing_ok=True)
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), "archive", "--format=tar.gz", "--output", str(archive), "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise CandidateError(result.stderr.strip() or "git archive failed")
+    if not sbom.is_file():
+        raise CandidateError(f"pinned SBOM step produced no {sbom}")
+    try:
+        sbom_doc = json.loads(sbom.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CandidateError(f"{sbom} is not JSON: {exc}") from exc
+    if not isinstance(sbom_doc, dict):
+        raise CandidateError(f"{sbom} is not a JSON object")
+    normalize_and_validate_sbom(sbom_doc, identity, archive)
+    sbom.write_text(json.dumps(sbom_doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    checksum.write_text(
+        f"{sha256(archive)}  {archive.name}\n",
+        encoding="utf-8",
+    )
+    notes = release_notes(str(identity["version"]))
+    notes_bytes = notes.encode("utf-8")
+    manifest = {
+        "schema_version": 1,
+        "release": identity,
+        "workflow": {
+            "repository": os.environ.get("GITHUB_REPOSITORY", ""),
+            "run_id": int(os.environ.get("GITHUB_RUN_ID", "0")),
+            "run_attempt": int(os.environ.get("GITHUB_RUN_ATTEMPT", "0")),
+        },
+        "archive": {
+            "name": archive.name,
+            "sha256": sha256(archive),
+            "size": archive.stat().st_size,
+        },
+        "checksum": {
+            "name": checksum.name,
+            "sha256": sha256(checksum),
+            "size": checksum.stat().st_size,
+        },
+        "sbom": {
+            "name": sbom.name,
+            "sha256": sha256(sbom),
+            "size": sbom.stat().st_size,
+        },
+        "notes": {
+            "body": notes,
+            "sha256": sha256_bytes(notes_bytes),
+            "size": len(notes_bytes),
+        },
+    }
+    destination = output_dir / "candidate.json"
+    destination.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return destination
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    detect = sub.add_parser("detect")
+    detect.add_argument("--github-output", type=Path)
+    seed = sub.add_parser("seed-sbom")
+    seed.add_argument("--output-dir", required=True, type=Path)
+    finish = sub.add_parser("freeze")
+    finish.add_argument("--output-dir", required=True, type=Path)
+    attest = sub.add_parser("attach-attestations")
+    attest.add_argument("--output-dir", required=True, type=Path)
+    attest.add_argument("--provenance-bundle", required=True, type=Path)
+    attest.add_argument("--sbom-bundle", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        if args.command == "detect":
+            identity = release_identity()
+            if args.github_output:
+                write_github_output(identity, args.github_output)
+            print(json.dumps({"candidate": identity is not None, "release": identity}))
+        elif args.command == "seed-sbom":
+            print(seed_sbom(args.output_dir))
+        elif args.command == "freeze":
+            print(freeze(args.output_dir))
+        else:
+            print(
+                attach_attestations(
+                    args.output_dir, args.provenance_bundle, args.sbom_bundle
+                )
+            )
+    except (CandidateError, OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"build-release-candidate: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check-consumer-check-extension.sh
+++ b/ci/check-consumer-check-extension.sh
@@ -155,6 +155,9 @@ else
     if ! "$ROOT/ci/check-workflow-template.sh" "$RENDERED" >/dev/null; then
         fail "rendered ${RENDERED} failed the canonical workflow-template contract"
     fi
+    if ! python3 "$ROOT/ci/check-static-server-template.py" "$RENDERED" >/dev/null; then
+        fail "rendered ${RENDERED} lost the direct static-server lifecycle contract"
+    fi
 
     # Negative mutation proof: comments cannot satisfy an executable action
     # pin, and package-manager-cache belongs specifically to setup-node's

--- a/ci/check-consumer-receipt.py
+++ b/ci/check-consumer-receipt.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Causal fixture for the consumer receipt's PR-merge and gitlink binding."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "ci" / "write-consumer-receipt.py"
+LOADER = importlib.machinery.SourceFileLoader("write_consumer_receipt", str(SCRIPT))
+SPEC = importlib.util.spec_from_loader(LOADER.name, LOADER)
+assert SPEC is not None
+receipt = importlib.util.module_from_spec(SPEC)
+LOADER.exec_module(receipt)
+
+
+def run(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def commit(root: Path, message: str) -> str:
+    run(root, "add", "-A")
+    run(root, "-c", "user.name=fixture", "-c", "user.email=fixture@example.test", "commit", "-m", message)
+    return run(root, "rev-parse", "HEAD")
+
+
+@contextmanager
+def environment(values: dict[str, str]):
+    before = os.environ.copy()
+    os.environ.update(values)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(before)
+
+
+def expect_failure(root: Path, fragment: str) -> None:
+    try:
+        receipt.build(root)
+    except receipt.ReceiptError as exc:
+        if fragment not in str(exc):
+            raise AssertionError(f"expected {fragment!r}, got {exc!r}") from exc
+    else:
+        raise AssertionError(f"receipt unexpectedly accepted mutant: {fragment}")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="typikon-consumer-receipt-") as tmp:
+        scratch = Path(tmp)
+        theme = scratch / "typikon"
+        theme.mkdir()
+        run(theme, "init", "-q", "-b", "main")
+        (theme / "theme.toml").write_text('name = "fixture"\n', encoding="utf-8")
+        theme_commit = commit(theme, "theme")
+
+        consumer = scratch / "consumer"
+        consumer.mkdir()
+        run(consumer, "init", "-q", "-b", "main")
+        (consumer / ".github" / "workflows").mkdir(parents=True)
+        (consumer / ".github" / "workflows" / "deploy.yml").write_text(
+            "name: fixture\n", encoding="utf-8"
+        )
+        run(
+            consumer,
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            str(theme),
+            "themes/typikon",
+        )
+        base = commit(consumer, "base")
+        run(consumer, "checkout", "-q", "-b", "feature")
+        (consumer / "feature.txt").write_text("candidate\n", encoding="utf-8")
+        head = commit(consumer, "candidate")
+        run(consumer, "checkout", "-q", "main")
+        run(
+            consumer,
+            "-c",
+            "user.name=fixture",
+            "-c",
+            "user.email=fixture@example.test",
+            "merge",
+            "--no-ff",
+            "feature",
+            "-m",
+            "synthetic merge",
+        )
+        merge = run(consumer, "rev-parse", "HEAD")
+        event = scratch / "event.json"
+        event.write_text(
+            json.dumps(
+                {
+                    "pull_request": {
+                        "number": 37,
+                        "base": {"sha": base},
+                        "head": {"sha": head},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        env = {
+            "GITHUB_EVENT_NAME": "pull_request",
+            "GITHUB_REPOSITORY": "forkwright/ardent-site",
+            "GITHUB_EVENT_PATH": str(event),
+            "GITHUB_WORKFLOW_REF": "forkwright/ardent-site/.github/workflows/deploy.yml@refs/pull/37/merge",
+            "GITHUB_SHA": merge,
+            "GITHUB_WORKFLOW_SHA": merge,
+            "GITHUB_RUN_ID": "12345",
+            "GITHUB_RUN_ATTEMPT": "2",
+        }
+        with environment(env):
+            value = receipt.build(consumer)
+            assert value["consumer"]["checkout_commit"] == merge
+            assert value["consumer"]["checkout_parents"] == [base, head]
+            assert value["typikon"]["commit"] == theme_commit
+
+            run(consumer, "checkout", "-q", "feature")
+            os.environ["GITHUB_SHA"] = head
+            expect_failure(consumer, "synthetic merge")
+            run(consumer, "checkout", "-q", merge)
+            os.environ["GITHUB_SHA"] = merge
+
+            os.environ["GITHUB_SHA"] = head
+            expect_failure(consumer, "differs from GITHUB_SHA")
+            os.environ["GITHUB_SHA"] = merge
+
+            (theme / "second.txt").write_text("drift\n", encoding="utf-8")
+            second = commit(theme, "second")
+            run(consumer / "themes" / "typikon", "fetch", "-q", str(theme), second)
+            run(consumer / "themes" / "typikon", "checkout", "-q", second)
+            expect_failure(consumer, "differs from the consumer gitlink")
+            run(consumer / "themes" / "typikon", "checkout", "-q", theme_commit)
+
+            os.environ["GITHUB_EVENT_NAME"] = "push"
+            expect_failure(consumer, "only for pull_request")
+            os.environ["GITHUB_EVENT_NAME"] = "pull_request"
+
+            os.environ["GITHUB_WORKFLOW_SHA"] = base
+            expect_failure(consumer, "differs from the pull request synthetic merge")
+            os.environ["GITHUB_WORKFLOW_SHA"] = merge
+
+            os.environ["GITHUB_WORKFLOW_REF"] = "forkwright/other/.github/workflows/deploy.yml@main"
+            expect_failure(consumer, "does not name this repository")
+
+    print("check-consumer-receipt: ok (merge, gitlink, and event mutants rejected)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check-content-heading-collision.py
+++ b/ci/check-content-heading-collision.py
@@ -322,6 +322,49 @@ def run_case(root: Path, theme_dir: Path, case: ContentTemplate, failures: list[
         )
 
 
+def run_error_page_case(root: Path, theme_dir: Path, failures: list[str]) -> None:
+    """Prove a 404 page styles the template-owned H1 through body_class."""
+    site = root / "error-page" / "site"
+    content = site / "content"
+    content.mkdir(parents=True)
+    (site / "themes").mkdir()
+    (site / "themes" / "typikon").symlink_to(theme_dir, target_is_directory=True)
+    (site / "config.toml").write_text(CONFIG_TOML)
+    (content / "_index.md").write_text(HOME_FRONTMATTER)
+    (content / "404.md").write_text(
+        '+++\ntitle = "Aporia"\ndescription = "Page not found."\n'
+        '\n[extra]\nbody_class = "error-page"\ngreek = "Ἀπορία"\n'
+        'skip_sitemap = true\n+++\n'
+        "The requested page is not here.\n"
+    )
+
+    validation = validate_content(site)
+    if validation.returncode != 0:
+        failures.append(
+            "404 body-class contract: schema rejected the valid page:\n"
+            f"{validation.stdout}\n{validation.stderr}"
+        )
+        return
+    result = zola_build(site)
+    if result.returncode != 0:
+        failures.append(f"404 body-class contract: build failed:\n{result.stderr}")
+        return
+    source = rendered_html(site, "404")
+    if '<body class="error-page">' not in source:
+        failures.append("404 body-class contract: rendered body lost class=error-page")
+    if '<h1 data-greek="Ἀπορία"><span>Aporia</span></h1>' not in source:
+        failures.append("404 body-class contract: template-owned qualified H1 is absent")
+    if '<div class="error-page">' in source:
+        failures.append("404 body-class contract: fixture relies on a body-content wrapper")
+
+    css = (theme_dir / "static" / "css" / "style.css").read_text(encoding="utf-8")
+    for selector in ("body.error-page main {", "body.error-page main > h1 {"):
+        if selector not in css:
+            failures.append(
+                f"404 body-class contract: stylesheet does not bind {selector!r}"
+            )
+
+
 def main() -> int:
     # WHY a hard failure, not a skip: same posture as check-home-heading.py
     # — zola is installed unconditionally before ci/run-fixtures.sh runs
@@ -340,6 +383,7 @@ def main() -> int:
 
         for case in CASES:
             run_case(root, theme_dir, case, failures)
+        run_error_page_case(root, theme_dir, failures)
 
     if failures:
         print("check-content-heading-collision: FAIL", file=sys.stderr)
@@ -347,7 +391,7 @@ def main() -> int:
             print(f"  - {f}", file=sys.stderr)
         return 1
 
-    total = len(CASES) * 3 + 6
+    total = len(CASES) * 3 + 7
     print(f"check-content-heading-collision: ok ({total}/{total} fixtures behaved as required)")
     return 0
 

--- a/ci/check-published-release.py
+++ b/ci/check-published-release.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Causal fixture for the exact predecessor-publication gate."""
+
+from __future__ import annotations
+
+import copy
+import importlib.machinery
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "verify-published-release.py"
+LOADER = importlib.machinery.SourceFileLoader("verify_published_release", str(SCRIPT))
+SPEC = importlib.util.spec_from_loader(LOADER.name, LOADER)
+assert SPEC is not None
+published = importlib.util.module_from_spec(SPEC)
+LOADER.exec_module(published)
+
+LEGACY_BODY = """## [0.5.0](https://github.com/forkwright/typikon/compare/v0.4.2...v0.5.0) (2026-08-17)
+
+
+### Features
+
+* **templates,css,ci:** expose a real consumer design API, split Leather's skin out of core ([#175](https://github.com/forkwright/typikon/issues/175)) ([b61228c](https://github.com/forkwright/typikon/commit/b61228cbbf3ca9e88a04161173dcf2faea79a8ec))
+* **templates,schemas:** render audience, derive the journal word count from Zola ([#178](https://github.com/forkwright/typikon/issues/178)) ([af66fa0](https://github.com/forkwright/typikon/commit/af66fa027563466ba3e36df99dbf3f598c3c2ff9))"""
+
+
+class FakeApi:
+    def __init__(self):
+        self.ref = {
+            "object": {
+                "type": "commit",
+                "sha": published.LEGACY["commit"],
+                "url": (
+                    "https://api.github.com/repos/forkwright/typikon/git/commits/"
+                    + published.LEGACY["commit"]
+                ),
+            }
+        }
+        self.release = {
+            "id": published.LEGACY["release_id"],
+            "tag_name": published.LEGACY["tag"],
+            "target_commitish": published.LEGACY["commit"],
+            "name": published.LEGACY["tag"],
+            "body": LEGACY_BODY,
+            "draft": False,
+            "prerelease": False,
+        }
+        self.assets = []
+        self.downloads: dict[int, bytes] = {}
+
+    def get_ref(self, _tag):
+        return self.ref
+
+    def get_release(self, _tag):
+        return self.release
+
+    def list_assets(self, _release_id):
+        return self.assets
+
+    def download_asset(self, asset_id):
+        return self.downloads[asset_id]
+
+
+def expect_error(call, fragment: str) -> None:
+    try:
+        call()
+    except published.PublishedReleaseError as exc:
+        if fragment not in str(exc):
+            raise AssertionError(f"expected {fragment!r}, got {exc!r}") from exc
+    else:
+        raise AssertionError(f"published predecessor gate accepted mutant: {fragment}")
+
+
+def main() -> int:
+    api = FakeApi()
+    assert published.verify(api, "0.5.0") == "legacy-bootstrap"
+    for label, mutate in (
+        ("tag identity", lambda value: value.ref["object"].update(type="tag")),
+        ("release identity", lambda value: value.release.update(draft=True)),
+        ("unexpectedly has assets", lambda value: value.assets.append({"id": 1})),
+    ):
+        mutant = copy.deepcopy(api)
+        mutate(mutant)
+        expect_error(lambda mutant=mutant: published.verify(mutant, "0.5.0"), label)
+
+    with tempfile.TemporaryDirectory(prefix="typikon-published-release-") as tmp:
+        root = Path(tmp)
+        lock_dir = root / "release" / "compatibility"
+        lock_dir.mkdir(parents=True)
+        candidate = "a" * 40
+        (lock_dir / "v0.6.0.json").write_text(
+            json.dumps({"release": {"candidate_commit": candidate}}),
+            encoding="utf-8",
+        )
+        locked = FakeApi()
+        locked.release = {"id": 88, "draft": False}
+        names = sorted(published.publisher.expected_asset_names("v0.6.0"))
+        locked.assets = [
+            {"id": index, "name": name}
+            for index, name in enumerate(names, start=1)
+        ]
+        locked.downloads = {
+            index: name.encode() for index, name in enumerate(names, start=1)
+        }
+        original_validate = published.publisher.validate_staged_evidence
+        original_inspect = published.publisher.inspect
+        original_expected = published.publisher.expected_assets
+        observed = {}
+
+        def expected_assets(directory, tag):
+            values = original_expected(directory, tag)
+            observed["names"] = set(values)
+            return values
+
+        def validate_staged(payloads, tag, subject, _digest, lock_path):
+            assert set(payloads) == set(names)
+            assert tag == "v0.6.0" and subject == candidate
+            assert lock_path == lock_dir / "v0.6.0.json"
+
+        published.publisher.expected_assets = expected_assets
+        published.publisher.validate_staged_evidence = validate_staged
+        published.publisher.inspect = lambda *_args: "published"
+        try:
+            assert published.verify(locked, "0.6.0", root) == "locked-release"
+            assert observed["names"] == set(names)
+
+            missing = copy.deepcopy(locked)
+            missing.assets.pop()
+            expect_error(
+                lambda: published.verify(missing, "0.6.0", root),
+                "asset names are not exact",
+            )
+
+            duplicate = copy.deepcopy(locked)
+            duplicate.assets[-1]["name"] = duplicate.assets[0]["name"]
+            expect_error(
+                lambda: published.verify(duplicate, "0.6.0", root),
+                "asset names are not exact",
+            )
+
+            published.publisher.inspect = lambda *_args: "draft"
+            expect_error(
+                lambda: published.verify(locked, "0.6.0", root),
+                "not exact and published",
+            )
+        finally:
+            published.publisher.expected_assets = original_expected
+            published.publisher.validate_staged_evidence = original_validate
+            published.publisher.inspect = original_inspect
+
+    print("check-published-release: ok (legacy and locked predecessor states)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check-release-candidate.py
+++ b/ci/check-release-candidate.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Causal fixture for detecting and freezing an exact untagged release commit."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import base64
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "build-release-candidate.py"
+LOADER = importlib.machinery.SourceFileLoader("build_release_candidate", str(SCRIPT))
+SPEC = importlib.util.spec_from_loader(LOADER.name, LOADER)
+assert SPEC is not None
+candidate = importlib.util.module_from_spec(SPEC)
+LOADER.exec_module(candidate)
+
+
+def bundle(kind: str, archive_name: str, digest: str) -> str:
+    predicate = {
+        "provenance": "https://slsa.dev/provenance/v1",
+        "sbom": "https://cyclonedx.org/bom",
+    }[kind]
+    statement = {
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": [{"name": archive_name, "digest": {"sha256": digest}}],
+        "predicateType": predicate,
+        "predicate": {},
+    }
+    record = {
+        "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+        "verificationMaterial": {"certificate": {"rawBytes": "fixture"}},
+        "dsseEnvelope": {
+            "payloadType": "application/vnd.in-toto+json",
+            "payload": base64.b64encode(json.dumps(statement).encode()).decode(),
+            "signatures": [{"sig": "fixture"}],
+        },
+    }
+    return json.dumps(record) + "\n"
+
+
+def git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def commit(root: Path, message: str) -> str:
+    git(root, "add", "-A")
+    git(
+        root,
+        "-c",
+        "user.name=fixture",
+        "-c",
+        "user.email=fixture@example.test",
+        "commit",
+        "-m",
+        message,
+    )
+    return git(root, "rev-parse", "HEAD")
+
+
+def main() -> int:
+    blocked_inventory = candidate.component_inventory
+    candidate.component_inventory = candidate.validated_component_inventory
+    with tempfile.TemporaryDirectory(prefix="typikon-release-candidate-") as tmp:
+        repo = Path(tmp) / "repo"
+        repo.mkdir()
+        git(repo, "init", "-q", "-b", "main")
+        (repo / ".release-please-manifest.json").write_text(
+            '{".": "0.5.0"}\n', encoding="utf-8"
+        )
+        (repo / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+        (repo / "static" / "fonts").mkdir(parents=True)
+        (repo / "static" / "fonts" / "fixture.woff2").write_bytes(b"font fixture")
+        (repo / "release").mkdir()
+        (repo / "release" / "components.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "components": [
+                        {
+                            "name": "Fixture WOFF2",
+                            "version": "1.0.0",
+                            "purl": "pkg:generic/fixture-font@1.0.0?file_name=fixture.woff2",
+                            "scope": "required",
+                            "license": "OFL-1.1",
+                            "hash": {
+                                "kind": "repository-file",
+                                "path": "static/fonts/fixture.woff2",
+                            },
+                        },
+                        {
+                            "name": "Fixture renderer",
+                            "version": "2.0.0",
+                            "purl": "pkg:generic/fixture-renderer@2.0.0?arch=x86_64&os=linux",
+                            "scope": "required",
+                            "license": "MIT",
+                            "hash": {
+                                "kind": "external-distribution",
+                                "url": "https://example.test/fixture-renderer.tar.gz",
+                                "sha256": "1" * 64,
+                            },
+                        },
+                    ],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        commit(repo, "initial")
+        (repo / ".release-please-manifest.json").write_text(
+            '{".": "0.6.0"}\n', encoding="utf-8"
+        )
+        (repo / "CHANGELOG.md").write_text(
+            "# Changelog\n\n## [0.6.0](https://example.test/v0.6.0) (2026-08-20)\n\n"
+            "### Features\n\n* exact fixture release\n",
+            encoding="utf-8",
+        )
+        release_commit = commit(repo, "chore(main): release 0.6.0 (#182)")
+
+        candidate.ROOT = repo
+        identity = candidate.release_identity()
+        assert identity is not None
+        assert identity["candidate_commit"] == release_commit
+        assert identity["version"] == "0.6.0"
+        assert identity["release_pr"] == 182
+
+        git(repo, "tag", "v0.6.0", release_commit)
+        try:
+            candidate.release_identity()
+        except candidate.CandidateError as exc:
+            assert "already tagged" in str(exc)
+        else:
+            raise AssertionError("candidate accepted an already-published tag subject")
+        git(repo, "tag", "-d", "v0.6.0")
+
+        output = Path(tmp) / "candidate"
+        output.mkdir()
+        archive = output / "typikon-v0.6.0.tar.gz"
+        archive.write_bytes(b"stale archive must be overwritten")
+        sbom = output / "typikon-v0.6.0.tar.gz.cdx.json"
+        candidate.seed_sbom(output)
+        before = archive.read_bytes()
+        os.environ.update(
+            {
+                "GITHUB_REPOSITORY": "forkwright/typikon",
+                "GITHUB_RUN_ID": "123",
+                "GITHUB_RUN_ATTEMPT": "1",
+            }
+        )
+        manifest_path = candidate.freeze(output)
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert archive.read_bytes() != before
+        assert manifest["release"]["candidate_commit"] == release_commit
+        assert manifest["archive"]["size"] == archive.stat().st_size
+        assert manifest["checksum"]["name"] == "typikon-v0.6.0.tar.gz.sha256"
+        checksum = output / manifest["checksum"]["name"]
+        assert checksum.read_text() == f"{candidate.sha256(archive)}  {archive.name}\n"
+        assert manifest["notes"]["body"] == "### Features\n\n* exact fixture release"
+        assert manifest["notes"]["sha256"] == candidate.sha256_bytes(
+            manifest["notes"]["body"].encode()
+        )
+        sbom_doc = json.loads(sbom.read_text())
+        root_component = sbom_doc["metadata"]["component"]
+        assert root_component["name"] == "typikon"
+        assert root_component["version"] == "0.6.0"
+        assert root_component["purl"] == "pkg:github/forkwright/typikon@0.6.0"
+        assert root_component["hashes"][0]["content"] == candidate.sha256(archive)
+        assert sbom_doc["serialNumber"].startswith("urn:uuid:")
+        assert {component["purl"] for component in sbom_doc["components"]} == {
+            "pkg:generic/fixture-font@1.0.0?file_name=fixture.woff2",
+            "pkg:generic/fixture-renderer@2.0.0?arch=x86_64&os=linux",
+        }
+        dependency_rows = {
+            row["ref"]: row["dependsOn"] for row in sbom_doc["dependencies"]
+        }
+        assert dependency_rows[root_component["purl"]] == sorted(
+            component["purl"] for component in sbom_doc["components"]
+        )
+        assert all(
+            dependency_rows[component["purl"]] == []
+            for component in sbom_doc["components"]
+        )
+
+        provenance = Path(tmp) / "provenance.jsonl"
+        sbom_bundle = Path(tmp) / "sbom.jsonl"
+        archive_digest = candidate.sha256(archive)
+        provenance.write_text(bundle("provenance", archive.name, archive_digest))
+        sbom_bundle.write_text(bundle("sbom", archive.name, archive_digest))
+        candidate.attach_attestations(output, provenance, sbom_bundle)
+        finalized = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert set(finalized["attestations"]) == {"provenance", "sbom"}
+        for item in finalized["attestations"].values():
+            assert (output / item["name"]).is_file()
+            assert item["sha256"] == candidate.sha256(output / item["name"])
+
+        malformed_bundle = Path(tmp) / "malformed.jsonl"
+        malformed_bundle.write_text("not json\n")
+        try:
+            candidate.read_bundle(
+                malformed_bundle, "provenance", archive.name, archive_digest
+            )
+        except candidate.CandidateError as exc:
+            assert "invalid JSONL" in str(exc)
+        else:
+            raise AssertionError("candidate accepted a malformed attestation bundle")
+
+        empty_bundle = Path(tmp) / "empty.jsonl"
+        empty_bundle.write_text("{}\n")
+        try:
+            candidate.read_bundle(
+                empty_bundle, "provenance", archive.name, archive_digest
+            )
+        except candidate.CandidateError as exc:
+            assert "Sigstore media type" in str(exc)
+        else:
+            raise AssertionError("candidate accepted an unbound attestation object")
+
+        wrong_subject = Path(tmp) / "wrong-subject.jsonl"
+        wrong_subject.write_text(bundle("provenance", archive.name, "0" * 64))
+        try:
+            candidate.read_bundle(
+                wrong_subject, "provenance", archive.name, archive_digest
+            )
+        except candidate.CandidateError as exc:
+            assert "subject differs" in str(exc)
+        else:
+            raise AssertionError("candidate accepted an attestation for other bytes")
+
+        complete_component = {
+            "type": "library",
+            "name": "fixture dependency",
+            "version": "1.0.0",
+            "purl": "pkg:generic/fixture-dependency@1.0.0",
+            "scope": "required",
+            "licenses": [{"expression": "MIT"}],
+            "hashes": [{"alg": "SHA-256", "content": "0" * 64}],
+        }
+
+        def reject_sbom(mutator, fragment: str) -> None:
+            document = {
+                "bomFormat": "CycloneDX",
+                "serialNumber": sbom_doc["serialNumber"],
+                "specVersion": "1.6",
+                "components": [json.loads(json.dumps(complete_component))],
+                "dependencies": [],
+            }
+            mutator(document)
+            try:
+                candidate.normalize_and_validate_sbom(document, identity, archive)
+            except candidate.CandidateError:
+                return
+            raise AssertionError(f"SBOM validator accepted {fragment}")
+
+        reject_sbom(lambda value: value.update(specVersion="1.4"), "CycloneDX 1.4")
+        reject_sbom(
+            lambda value: value.pop("serialNumber"),
+            "SBOM without a candidate-bound serial number",
+        )
+        for field in ("purl", "scope"):
+            reject_sbom(
+                lambda value, field=field: value["components"][0].pop(field),
+                f"component missing {field}",
+            )
+        reject_sbom(
+            lambda value: value["components"][0].update(scope="runtime-ish"),
+            "component with invalid scope",
+        )
+        reject_sbom(
+            lambda value: value["components"][0].pop("licenses"),
+            "component missing license",
+        )
+        reject_sbom(
+            lambda value: value["components"][0].pop("hashes"),
+            "component missing SHA-256",
+        )
+        reject_sbom(
+            lambda value: value["components"][0].update(
+                components=[{"type": "library", "name": "nested incomplete"}]
+            ),
+            "nested incomplete component",
+        )
+
+        inventory = repo / "release" / "components.json"
+        inventory_doc = json.loads(inventory.read_text())
+        inventory_doc["components"] = inventory_doc["components"][1:]
+        inventory.write_text(json.dumps(inventory_doc), encoding="utf-8")
+        try:
+            candidate.component_inventory()
+        except candidate.CandidateError as exc:
+            assert "does not exactly cover embedded files" in str(exc)
+        else:
+            raise AssertionError("inventory accepted an unowned embedded font")
+        git(repo, "checkout", "--", "release/components.json")
+
+        inventory_doc = json.loads(inventory.read_text())
+        inventory_doc["components"] = inventory_doc["components"][:1]
+        inventory.write_text(json.dumps(inventory_doc), encoding="utf-8")
+        try:
+            candidate.component_inventory()
+        except candidate.CandidateError as exc:
+            assert "no external distribution" in str(exc)
+        else:
+            raise AssertionError("inventory accepted no external runtime distribution")
+        git(repo, "checkout", "--", "release/components.json")
+
+        # A release-shaped commit with an unrelated file is not a pure,
+        # untagged candidate and must fail rather than silently absorb it.
+        git(repo, "reset", "--hard", "HEAD^")
+        (repo / ".release-please-manifest.json").write_text(
+            '{".": "0.6.0"}\n', encoding="utf-8"
+        )
+        (repo / "CHANGELOG.md").write_text(
+            "# Changelog\n\n## [0.6.0](https://example.test/v0.6.0)\n\n* release\n"
+        )
+        (repo / "unrelated.txt").write_text("not release material\n")
+        commit(repo, "chore(main): release 0.6.0 (#182)")
+        try:
+            candidate.release_identity()
+        except candidate.CandidateError as exc:
+            assert "may change only" in str(exc)
+        else:
+            raise AssertionError("candidate accepted an unrelated changed file")
+
+        # A normal merge can present the same final two-file diff, but it is
+        # not the squash subject whose commit/archive consumers must test.
+        initial = git(repo, "rev-parse", f"{release_commit}^")
+        git(repo, "reset", "--hard", initial)
+        git(repo, "checkout", "-q", "-b", "release-fixture")
+        (repo / ".release-please-manifest.json").write_text(
+            '{".": "0.6.0"}\n', encoding="utf-8"
+        )
+        (repo / "CHANGELOG.md").write_text(
+            "# Changelog\n\n## [0.6.0](https://example.test/v0.6.0)\n\n* release\n",
+            encoding="utf-8",
+        )
+        commit(repo, "release side")
+        git(repo, "checkout", "-q", "main")
+        (repo / "side.txt").write_text("side history\n", encoding="utf-8")
+        commit(repo, "main side")
+        git(
+            repo,
+            "-c",
+            "user.name=fixture",
+            "-c",
+            "user.email=fixture@example.test",
+            "merge",
+            "--no-ff",
+            "release-fixture",
+            "-m",
+            "chore(main): release 0.6.0 (#182)",
+        )
+        try:
+            candidate.release_identity()
+        except candidate.CandidateError as exc:
+            assert "one-parent squash" in str(exc)
+        else:
+            raise AssertionError("candidate accepted a two-parent merge")
+
+    candidate.ROOT = SCRIPT.parent.parent
+    candidate.component_inventory = blocked_inventory
+    try:
+        candidate.component_inventory()
+    except candidate.CandidateError as exc:
+        if "forkwright/typikon#58" not in str(exc):
+            raise
+    else:
+        raise AssertionError("current incomplete release dependency graph did not block")
+
+    real_inventory = candidate.validated_component_inventory()
+    if len(real_inventory) != 9:
+        raise AssertionError(
+            f"real release inventory must contain Zola plus eight fonts, found {len(real_inventory)}"
+        )
+    if [item["name"] for item in real_inventory].count("Zola") != 1:
+        raise AssertionError("real release inventory does not contain exactly one Zola")
+
+    print("check-release-candidate: ok (stale bytes and impure commit rejected)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check-release-handoff.py
+++ b/ci/check-release-handoff.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Causal fixture for the raw, digest-bound release handoff extractor."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.machinery
+import importlib.util
+import io
+import tempfile
+import threading
+import warnings
+import zipfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "materialize-release-handoff.py"
+LOADER = importlib.machinery.SourceFileLoader("release_handoff", str(SCRIPT))
+SPEC = importlib.util.spec_from_loader(LOADER.name, LOADER)
+assert SPEC is not None
+handoff = importlib.util.module_from_spec(SPEC)
+LOADER.exec_module(handoff)
+
+
+def make_zip(tag: str, *, extra: str | None = None, duplicate: bool = False) -> bytes:
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name in sorted(handoff.expected_names(tag)):
+            archive.writestr(name, f"fixture:{name}\n")
+        if extra:
+            archive.writestr(extra, b"unexpected")
+        if duplicate:
+            archive.writestr("candidate.json", b"duplicate")
+    return stream.getvalue()
+
+
+def rejected(raw: bytes, digest: str, tag: str, label: str) -> None:
+    with tempfile.TemporaryDirectory(prefix="typikon-handoff-reject-") as tmp:
+        try:
+            handoff.materialize_zip(raw, digest, tag, Path(tmp) / "out")
+        except handoff.HandoffError:
+            return
+    raise AssertionError(f"handoff accepted {label}")
+
+
+class RedirectSource(BaseHTTPRequestHandler):
+    target = ""
+    authorization = None
+
+    def do_GET(self):  # noqa: N802
+        type(self).authorization = self.headers.get("Authorization")
+        self.send_response(302)
+        self.send_header("Location", type(self).target)
+        self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+
+class RedirectTarget(BaseHTTPRequestHandler):
+    authorization = None
+    payload = b""
+
+    def do_GET(self):  # noqa: N802
+        type(self).authorization = self.headers.get("Authorization")
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(type(self).payload)))
+        self.end_headers()
+        self.wfile.write(type(self).payload)
+
+    def log_message(self, *args):
+        pass
+
+
+def redirect_probe(raw: bytes) -> None:
+    RedirectTarget.payload = raw
+    target = ThreadingHTTPServer(("127.0.0.1", 0), RedirectTarget)
+    source = ThreadingHTTPServer(("127.0.0.1", 0), RedirectSource)
+    RedirectSource.target = f"http://127.0.0.1:{target.server_port}/signed"
+    threads = [
+        threading.Thread(target=target.serve_forever, daemon=True),
+        threading.Thread(target=source.serve_forever, daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+    try:
+        token = handoff.SecretToken("fixture-token")
+        try:
+            handoff.download_zip(
+                f"http://127.0.0.1:{source.server_port}/artifact",
+                "fixture-token",
+                require_https=False,
+            )
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("handoff downloader accepted a bare token string")
+        actual = handoff.download_zip(
+            f"http://127.0.0.1:{source.server_port}/artifact",
+            token,
+            require_https=False,
+        )
+        assert actual == raw
+        assert RedirectSource.authorization == "Bearer fixture-token"
+        assert RedirectTarget.authorization is None
+    finally:
+        source.shutdown()
+        target.shutdown()
+        source.server_close()
+        target.server_close()
+
+
+def main() -> int:
+    tag = "v0.6.0"
+    raw = make_zip(tag)
+    digest = hashlib.sha256(raw).hexdigest()
+    redirect_probe(raw)
+    metadata = {
+        "id": 91,
+        "name": f"typikon-{tag}-verified-publication-123-1",
+        "expired": False,
+        "digest": f"sha256:{digest}",
+        "workflow_run": {"id": 123},
+    }
+    assert handoff.validate_metadata(
+        metadata,
+        artifact_id=91,
+        artifact_digest=digest,
+        run_id=123,
+        run_attempt=1,
+        tag=tag,
+    ) == f"sha256:{digest}"
+    for label, mutate in (
+        ("artifact id", lambda value: value.__setitem__("id", 92)),
+        ("artifact name/attempt", lambda value: value.__setitem__("name", f"typikon-{tag}-verified-publication-123-2")),
+        ("expired artifact", lambda value: value.__setitem__("expired", True)),
+        ("artifact digest", lambda value: value.__setitem__("digest", "sha256:" + "0" * 64)),
+        ("workflow run", lambda value: value.__setitem__("workflow_run", {"id": 124})),
+    ):
+        mutant = dict(metadata)
+        mutant["workflow_run"] = dict(metadata["workflow_run"])
+        mutate(mutant)
+        try:
+            handoff.validate_metadata(
+                mutant,
+                artifact_id=91,
+                artifact_digest=digest,
+                run_id=123,
+                run_attempt=1,
+                tag=tag,
+            )
+        except handoff.HandoffError:
+            pass
+        else:
+            raise AssertionError(f"handoff accepted wrong {label}")
+    with tempfile.TemporaryDirectory(prefix="typikon-handoff-") as tmp:
+        output = Path(tmp) / "out"
+        handoff.materialize_zip(raw, digest, tag, output)
+        assert {path.name for path in output.iterdir()} == handoff.expected_names(tag)
+    corrupted = bytearray(raw)
+    corrupted[-1] ^= 1
+    rejected(bytes(corrupted), digest, tag, "bytes with the upload digest")
+    rejected(raw, "0" * 64, tag, "a false digest")
+    extra = make_zip(tag, extra="unexpected")
+    rejected(extra, hashlib.sha256(extra).hexdigest(), tag, "an extra member")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        duplicate = make_zip(tag, duplicate=True)
+    rejected(duplicate, hashlib.sha256(duplicate).hexdigest(), tag, "a duplicate member")
+    traversal = make_zip(tag, extra="../escape")
+    rejected(traversal, hashlib.sha256(traversal).hexdigest(), tag, "path traversal")
+    print("check-release-handoff: ok (raw digest and exact members enforced)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check-release-lock.py
+++ b/ci/check-release-lock.py
@@ -1,0 +1,992 @@
+#!/usr/bin/env python3
+"""Causal snapshot fixture for the release compatibility-lock verifier."""
+
+from __future__ import annotations
+
+import base64
+import copy
+import gzip
+import hashlib
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import tarfile
+import tempfile
+import threading
+import zipfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import jsonschema
+import release_archive as archive_verifier
+
+SCRIPT = Path(__file__).resolve().parent / "verify-release-lock.py"
+LOADER = importlib.machinery.SourceFileLoader("verify_release_lock", str(SCRIPT))
+SPEC = importlib.util.spec_from_loader(LOADER.name, LOADER)
+assert SPEC is not None
+verifier = importlib.util.module_from_spec(SPEC)
+LOADER.exec_module(verifier)
+SCHEMA = json.loads(
+    (Path(__file__).resolve().parent.parent / "release" / "compatibility-lock.schema.json").read_text(
+        encoding="utf-8"
+    )
+)
+
+
+def git(root: Path, *args: str, binary: bool = False):
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True,
+        text=not binary,
+        check=True,
+    )
+    return result.stdout if binary else result.stdout.strip()
+
+
+def commit(root: Path, message: str) -> str:
+    git(root, "add", "-A")
+    git(
+        root,
+        "-c",
+        "user.name=fixture",
+        "-c",
+        "user.email=fixture@example.test",
+        "commit",
+        "-m",
+        message,
+    )
+    return git(root, "rev-parse", "HEAD")
+
+
+def zip_bytes(files: dict[str, bytes]) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_STORED) as archive:
+        for name, payload in sorted(files.items()):
+            archive.writestr(name, payload)
+    return output.getvalue()
+
+
+def rewrite_tar(
+    payload: bytes,
+    *,
+    mutate=None,
+    extra: list[tuple[tarfile.TarInfo, bytes | None]] | None = None,
+) -> bytes:
+    output = io.BytesIO()
+    with tarfile.open(fileobj=io.BytesIO(payload), mode="r:gz") as source:
+        with tarfile.open(
+            fileobj=output,
+            mode="w:gz",
+            format=tarfile.PAX_FORMAT,
+            pax_headers=dict(source.pax_headers),
+        ) as destination:
+            for source_member in source.getmembers():
+                member = copy.copy(source_member)
+                handle = source.extractfile(source_member) if source_member.isfile() else None
+                body = handle.read() if handle is not None else None
+                if mutate is not None:
+                    mutate(member, body)
+                destination.addfile(member, io.BytesIO(body) if body is not None else None)
+            for member, body in extra or []:
+                destination.addfile(member, io.BytesIO(body) if body is not None else None)
+    return output.getvalue()
+
+
+def digest(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def expect_lock_error(call, fragment: str) -> None:
+    try:
+        call()
+    except verifier.LockError as exc:
+        if fragment not in str(exc):
+            raise AssertionError(f"expected {fragment!r}, got {exc!r}") from exc
+    else:
+        raise AssertionError(f"verifier accepted mutant: {fragment}")
+
+
+def receipt(consumer: dict[str, object]) -> bytes:
+    value = {
+        "schema_version": 1,
+        "consumer": {
+            "repository": consumer["repository"],
+            "pull_request": consumer["pull_request"],
+            "base_commit": consumer["base_commit"],
+            "head_commit": consumer["head_commit"],
+            "checkout_commit": consumer["merge_commit"],
+            "checkout_tree": consumer["merge_tree"],
+            "checkout_parents": [consumer["base_commit"], consumer["head_commit"]],
+        },
+        "typikon": {
+            "path": "themes/typikon",
+            "mode": "160000",
+            "commit": consumer["gitlink_commit"],
+            "tree": consumer["gitlink_tree"],
+        },
+        "workflow": {
+            "path": consumer["workflow_path"],
+            "commit": consumer["workflow_commit"],
+            "blob": consumer["workflow_blob"],
+            "run_id": consumer["workflow_run_id"],
+            "run_attempt": consumer["run_attempt"],
+            "event": "pull_request",
+        },
+    }
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
+
+
+def build_fixture(root: Path):
+    git(root, "init", "-q", "-b", "main")
+    (root / "templates").mkdir()
+    (root / "templates" / "page.html").write_text(
+        "fixture template\n", encoding="utf-8"
+    )
+    (root / ".release-please-manifest.json").write_text(
+        '{".": "0.4.0"}\n', encoding="utf-8"
+    )
+    (root / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+    old_leather = commit(root, "old leather pin")
+    old_leather_tree = git(root, "rev-parse", "HEAD^{tree}")
+    (root / ".release-please-manifest.json").write_text(
+        '{".": "0.5.0"}\n', encoding="utf-8"
+    )
+    (root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## 0.5.0\n", encoding="utf-8"
+    )
+    old_tools = commit(root, "old tools pin")
+    old_tools_tree = git(root, "rev-parse", "HEAD^{tree}")
+    (root / ".release-please-manifest.json").write_text(
+        '{".": "0.6.0"}\n', encoding="utf-8"
+    )
+    (root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [0.6.0](https://example.test/v0.6.0) (2026-08-20)\n\n"
+        "### Features\n\n* exact release fixture\n",
+        encoding="utf-8",
+    )
+    candidate = commit(root, "chore(main): release 0.6.0 (#182)")
+    candidate_tree = git(root, "rev-parse", "HEAD^{tree}")
+    release_head = "9" * 40
+    archive = git(root, "archive", "--format=tar.gz", candidate, binary=True)
+    checksum = f"{digest(archive)}  typikon-v0.6.0.tar.gz\n".encode()
+    sbom = b'{"bomFormat":"CycloneDX","specVersion":"1.6"}\n'
+    provenance_bundle = (
+        b'{"mediaType":"application/vnd.dev.sigstore.bundle+json;version=0.3"}\n'
+    )
+    sbom_bundle = (
+        b'{"mediaType":"application/vnd.dev.sigstore.bundle+json;version=0.3"}\n'
+    )
+
+    consumers = []
+    definitions = [
+        (
+            "tools",
+            "ardent-tools/ardent-tools-site",
+            169,
+            old_tools,
+            old_tools_tree,
+            "1",
+        ),
+        (
+            "leather",
+            "forkwright/ardent-site",
+            37,
+            old_leather,
+            old_leather_tree,
+            "2",
+        ),
+    ]
+    for index, (identifier, repository, pr, previous, previous_tree, digit) in enumerate(
+        definitions, start=1
+    ):
+        consumer = {
+            "id": identifier,
+            "repository": repository,
+            "pull_request": pr,
+            "base_commit": digit * 40,
+            "head_commit": format(index + 2, "x") * 40,
+            "head_tree": format(index + 4, "x") * 40,
+            "merge_commit": format(index + 6, "x") * 40,
+            "merge_tree": format(index + 8, "x") * 40,
+            "gitlink_path": "themes/typikon",
+            "previous_gitlink_commit": previous,
+            "previous_gitlink_tree": previous_tree,
+            "gitlink_commit": candidate,
+            "gitlink_tree": candidate_tree,
+            "workflow_path": ".github/workflows/deploy.yml",
+            "workflow_commit": format(index + 6, "x") * 40,
+            "workflow_blob": chr(ord("a") + index) * 40,
+            "workflow_run_id": 1000 + index,
+            "run_attempt": 1,
+            "required_job": "gate-and-deploy",
+            "receipt_path": f"release/compatibility/receipts/{identifier}.json",
+            "receipt_sha256": "",
+            "artifact_id": 2000 + index,
+            "artifact_name": f"typikon-consumer-receipt-{1000 + index}-1",
+            "artifact_digest": "",
+        }
+        receipt_bytes = receipt(consumer)
+        receipt_zip = zip_bytes({"typikon-consumer-receipt.json": receipt_bytes})
+        consumer["receipt_sha256"] = digest(receipt_bytes)
+        consumer["artifact_digest"] = f"sha256:{digest(receipt_zip)}"
+        consumer["_receipt"] = receipt_bytes
+        consumer["_artifact"] = receipt_zip
+        consumers.append(consumer)
+
+    candidate_doc = {
+        "schema_version": 1,
+        "release": {
+            "version": "0.6.0",
+            "tag": "v0.6.0",
+            "release_pr": 182,
+            "candidate_commit": candidate,
+            "candidate_tree": candidate_tree,
+            "parent_commit": old_tools,
+        },
+        "workflow": {
+            "repository": "forkwright/typikon",
+            "run_id": 900,
+            "run_attempt": 1,
+        },
+        "archive": {
+            "name": "typikon-v0.6.0.tar.gz",
+            "sha256": digest(archive),
+            "size": len(archive),
+        },
+        "checksum": {
+            "name": "typikon-v0.6.0.tar.gz.sha256",
+            "sha256": digest(checksum),
+            "size": len(checksum),
+        },
+        "sbom": {
+            "name": "typikon-v0.6.0.tar.gz.cdx.json",
+            "sha256": digest(sbom),
+            "size": len(sbom),
+        },
+        "notes": {
+            "body": "### Features\n\n* exact release fixture",
+            "sha256": digest(b"### Features\n\n* exact release fixture"),
+            "size": len(b"### Features\n\n* exact release fixture"),
+        },
+        "attestations": {
+            "provenance": {
+                "name": "typikon-v0.6.0.tar.gz.provenance.intoto.jsonl",
+                "sha256": digest(provenance_bundle),
+                "size": len(provenance_bundle),
+            },
+            "sbom": {
+                "name": "typikon-v0.6.0.tar.gz.sbom.intoto.jsonl",
+                "sha256": digest(sbom_bundle),
+                "size": len(sbom_bundle),
+            },
+        },
+    }
+    candidate_json = (json.dumps(candidate_doc, indent=2, sort_keys=True) + "\n").encode()
+    candidate_zip = zip_bytes(
+        {
+            "candidate.json": candidate_json,
+            "typikon-v0.6.0.tar.gz": archive,
+            "typikon-v0.6.0.tar.gz.sha256": checksum,
+            "typikon-v0.6.0.tar.gz.cdx.json": sbom,
+            "typikon-v0.6.0.tar.gz.provenance.intoto.jsonl": provenance_bundle,
+            "typikon-v0.6.0.tar.gz.sbom.intoto.jsonl": sbom_bundle,
+        }
+    )
+
+    lock_consumers = []
+    for consumer in consumers:
+        public = {key: value for key, value in consumer.items() if not key.startswith("_")}
+        lock_consumers.append(public)
+    lock = {
+        "schema_version": 1,
+        "release": {
+            "version": "0.6.0",
+            "tag": "v0.6.0",
+            "release_pr": 182,
+            "candidate_commit": candidate,
+            "candidate_tree": candidate_tree,
+        },
+        "candidate_artifact": {
+            "workflow_run_id": 900,
+            "run_attempt": 1,
+            "artifact_id": 1900,
+            "artifact_name": "typikon-v0.6.0-candidate",
+            "artifact_digest": f"sha256:{digest(candidate_zip)}",
+            "archive_name": "typikon-v0.6.0.tar.gz",
+            "archive_sha256": digest(archive),
+            "archive_size": len(archive),
+            "checksum_name": "typikon-v0.6.0.tar.gz.sha256",
+            "checksum_sha256": digest(checksum),
+            "checksum_size": len(checksum),
+            "sbom_name": "typikon-v0.6.0.tar.gz.cdx.json",
+            "sbom_sha256": digest(sbom),
+            "sbom_size": len(sbom),
+            "provenance_bundle_name": "typikon-v0.6.0.tar.gz.provenance.intoto.jsonl",
+            "provenance_bundle_sha256": digest(provenance_bundle),
+            "provenance_bundle_size": len(provenance_bundle),
+            "sbom_bundle_name": "typikon-v0.6.0.tar.gz.sbom.intoto.jsonl",
+            "sbom_bundle_sha256": digest(sbom_bundle),
+            "sbom_bundle_size": len(sbom_bundle),
+        },
+        "consumers": lock_consumers,
+    }
+
+    receipt_dir = root / "release" / "compatibility" / "receipts"
+    receipt_dir.mkdir(parents=True)
+    for consumer in consumers:
+        (root / consumer["receipt_path"]).write_bytes(consumer["_receipt"])
+    lock_path = root / "release" / "compatibility" / "v0.6.0.json"
+    lock_path.write_text(json.dumps(lock, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    evidence = commit(root, "chore(release): lock v0.6.0 compatibility evidence")
+
+    snapshot = {
+        "forkwright/typikon|pulls/182": {
+            "merged": True,
+            "merge_commit_sha": candidate,
+            "title": "chore(main): release 0.6.0",
+            "user": {"login": "github-actions[bot]", "type": "Bot"},
+            "base": {
+                "ref": "main",
+                "sha": old_tools,
+                "repo": {"full_name": "forkwright/typikon"},
+            },
+            "head": {
+                "ref": "release-please--branches--main",
+                "sha": release_head,
+                "repo": {"full_name": "forkwright/typikon"},
+            },
+            "labels": [{"name": "autorelease: pending"}],
+        },
+        f"forkwright/typikon|git/commits/{candidate}": {
+            "tree": {"sha": candidate_tree},
+            "parents": [{"sha": old_tools}],
+        },
+        f"forkwright/typikon|git/commits/{release_head}": {
+            "tree": {"sha": candidate_tree}
+        },
+        f"forkwright/typikon|git/commits/{old_tools}": {
+            "tree": {"sha": old_tools_tree}
+        },
+        f"forkwright/typikon|git/commits/{old_leather}": {
+            "tree": {"sha": old_leather_tree}
+        },
+        "forkwright/typikon|actions/runs/900": {
+            "status": "completed",
+            "conclusion": "success",
+            "event": "push",
+            "head_sha": candidate,
+            "run_attempt": 1,
+            "path": ".github/workflows/release-candidate.yml",
+            "pull_requests": [],
+        },
+        "forkwright/typikon|actions/runs/900/attempts/1/jobs?per_page=100": {
+            "jobs": [{"name": "freeze-candidate", "conclusion": "success"}]
+        },
+        "forkwright/typikon|actions/artifacts/1900": {
+            "expired": False,
+            "name": "typikon-v0.6.0-candidate",
+            "digest": f"sha256:{digest(candidate_zip)}",
+            "workflow_run": {"id": 900},
+        },
+        "forkwright/typikon|artifact_zip/1900": base64.b64encode(candidate_zip).decode(),
+    }
+
+    for consumer in consumers:
+        repo = consumer["repository"]
+        pr = consumer["pull_request"]
+        snapshot[f"{repo}|pulls/{pr}"] = {
+            "state": "open",
+            "base": {
+                "ref": "main",
+                "sha": consumer["base_commit"],
+                "repo": {"full_name": repo},
+            },
+            "head": {
+                "sha": consumer["head_commit"],
+                "repo": {"full_name": repo},
+            },
+            "merge_commit_sha": consumer["merge_commit"],
+        }
+        base_tree = ("c" if consumer["id"] == "tools" else "d") * 40
+        snapshot[f"{repo}|git/commits/{consumer['base_commit']}"] = {
+            "tree": {"sha": base_tree}
+        }
+        snapshot[f"{repo}|git/commits/{consumer['head_commit']}"] = {
+            "tree": {"sha": consumer["head_tree"]}
+        }
+        snapshot[f"{repo}|git/commits/{consumer['merge_commit']}"] = {
+            "tree": {"sha": consumer["merge_tree"]},
+            "parents": [
+                {"sha": consumer["base_commit"]},
+                {"sha": consumer["head_commit"]},
+            ],
+        }
+        snapshot[f"{repo}|git/trees/{base_tree}?recursive=1"] = {
+            "tree": [
+                {
+                    "path": "themes/typikon",
+                    "mode": "160000",
+                    "sha": consumer["previous_gitlink_commit"],
+                }
+            ]
+        }
+        snapshot[f"{repo}|git/trees/{consumer['merge_tree']}?recursive=1"] = {
+            "tree": [
+                {
+                    "path": "themes/typikon",
+                    "mode": "160000",
+                    "sha": candidate,
+                },
+                {
+                    "path": consumer["workflow_path"],
+                    "mode": "100644",
+                    "sha": consumer["workflow_blob"],
+                },
+            ]
+        }
+        run_id = consumer["workflow_run_id"]
+        snapshot[f"{repo}|actions/runs/{run_id}"] = {
+            "status": "completed",
+            "conclusion": "success",
+            "event": "pull_request",
+            "head_sha": consumer["head_commit"],
+            "run_attempt": 1,
+            "path": consumer["workflow_path"],
+            "pull_requests": [
+                {
+                    "number": pr,
+                    "head": {"sha": consumer["head_commit"]},
+                    "base": {"sha": consumer["base_commit"]},
+                }
+            ],
+        }
+        snapshot[f"{repo}|actions/runs/{run_id}/attempts/1/jobs?per_page=100"] = {
+            "jobs": [{"name": "gate-and-deploy", "conclusion": "success"}]
+        }
+        snapshot[f"{repo}|actions/artifacts/{consumer['artifact_id']}"] = {
+            "expired": False,
+            "name": consumer["artifact_name"],
+            "digest": consumer["artifact_digest"],
+            "workflow_run": {"id": run_id},
+        }
+        snapshot[f"{repo}|artifact_zip/{consumer['artifact_id']}"] = base64.b64encode(
+            consumer["_artifact"]
+        ).decode()
+    return lock, lock_path, snapshot, evidence
+
+
+class RedirectApi(BaseHTTPRequestHandler):
+    target = ""
+    authorization = None
+
+    def do_GET(self):  # noqa: N802
+        type(self).authorization = self.headers.get("Authorization")
+        self.send_response(302)
+        self.send_header("Location", type(self).target)
+        self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+
+class RedirectTarget(BaseHTTPRequestHandler):
+    authorization = None
+
+    def do_GET(self):  # noqa: N802
+        type(self).authorization = self.headers.get("Authorization")
+        self.send_response(200)
+        self.send_header("Content-Length", "2")
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, *args):
+        pass
+
+
+def redirect_probe() -> None:
+    target = ThreadingHTTPServer(("127.0.0.1", 0), RedirectTarget)
+    source = ThreadingHTTPServer(("127.0.0.1", 0), RedirectApi)
+    RedirectApi.target = f"http://127.0.0.1:{target.server_port}/signed"
+    threads = [
+        threading.Thread(target=target.serve_forever, daemon=True),
+        threading.Thread(target=source.serve_forever, daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+    try:
+        token = verifier.SecretToken("fixture-token")
+        assert str(token) == "[REDACTED]"
+        assert "fixture-token" not in repr(token)
+        try:
+            verifier.download_signed_redirect(
+                f"http://127.0.0.1:{source.server_port}/artifact",
+                "fixture-token",
+                require_https=False,
+            )
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("artifact downloader accepted a bare token string")
+        payload = verifier.download_signed_redirect(
+            f"http://127.0.0.1:{source.server_port}/artifact",
+            token,
+            require_https=False,
+        )
+        assert payload == b"ok"
+        assert RedirectApi.authorization == "Bearer fixture-token"
+        assert RedirectTarget.authorization is None
+    finally:
+        source.shutdown()
+        target.shutdown()
+        source.server_close()
+        target.server_close()
+
+
+def main() -> int:
+    original_root = verifier.ROOT
+    with tempfile.TemporaryDirectory(prefix="typikon-release-lock-") as tmp:
+        root = Path(tmp) / "repo"
+        root.mkdir()
+        lock, lock_path, snapshot, evidence = build_fixture(root)
+        verifier.ROOT = root
+        os.environ.pop("GITHUB_ACTIONS", None)
+        jsonschema.Draft202012Validator(SCHEMA).validate(lock)
+        assert verifier.validate_lock_shape(copy.deepcopy(lock)) == lock
+
+        bundles = verifier.verify_live(lock, verifier.GitHub(snapshot), lock_path)
+        verifier.validate_bundle(lock, bundles)
+
+        archive_name = lock["candidate_artifact"]["archive_name"]
+        frozen_archive = bundles["candidate"][archive_name]
+        tar_bytes = gzip.decompress(frozen_archive)
+        recompressed = gzip.compress(tar_bytes, compresslevel=1, mtime=0)
+        verifier.verify_archive(
+            recompressed, root, lock["release"]["candidate_commit"]
+        )
+        corrupted_tar = tar_bytes.replace(b'"0.6.0"', b'"9.9.9"', 1)
+        if corrupted_tar == tar_bytes:
+            raise AssertionError("archive content mutant did not change fixture bytes")
+        try:
+            verifier.verify_archive(
+                gzip.compress(corrupted_tar, mtime=0),
+                root,
+                lock["release"]["candidate_commit"],
+            )
+        except verifier.ArchiveError:
+            pass
+        else:
+            raise AssertionError("archive verifier accepted changed tree content")
+
+        for label, changed_mode in (("permission drift", 0o644), ("setuid", 0o4664)):
+            changed = False
+
+            def mutate_file_mode(member, _body):
+                nonlocal changed
+                if not changed and member.isfile():
+                    member.mode = changed_mode
+                    changed = True
+
+            mode_mutant = rewrite_tar(frozen_archive, mutate=mutate_file_mode)
+            try:
+                verifier.verify_archive(
+                    mode_mutant, root, lock["release"]["candidate_commit"]
+                )
+            except verifier.ArchiveError:
+                pass
+            else:
+                raise AssertionError(f"archive verifier accepted {label}")
+
+        changed_directory = False
+
+        def mutate_directory_mode(member, _body):
+            nonlocal changed_directory
+            if not changed_directory and member.isdir():
+                member.mode = 0o777
+                changed_directory = True
+
+        directory_mode_mutant = rewrite_tar(
+            frozen_archive, mutate=mutate_directory_mode
+        )
+        try:
+            verifier.verify_archive(
+                directory_mode_mutant, root, lock["release"]["candidate_commit"]
+            )
+        except verifier.ArchiveError:
+            pass
+        else:
+            raise AssertionError("archive verifier accepted directory mode drift")
+
+        extra_directory = tarfile.TarInfo("untracked/")
+        extra_directory.type = tarfile.DIRTYPE
+        extra_directory.mode = 0o775
+        extra_directory_mutant = rewrite_tar(
+            frozen_archive, extra=[(extra_directory, None)]
+        )
+        try:
+            verifier.verify_archive(
+                extra_directory_mutant, root, lock["release"]["candidate_commit"]
+            )
+        except verifier.ArchiveError:
+            pass
+        else:
+            raise AssertionError("archive verifier accepted an extra directory")
+
+        with tarfile.open(fileobj=io.BytesIO(frozen_archive), mode="r:gz") as source:
+            original_content_bytes = sum(
+                member.size for member in source.getmembers() if member.isfile()
+            )
+        extra_file = tarfile.TarInfo("aggregate-overflow")
+        extra_file.mode = 0o664
+        extra_file.size = 1
+        aggregate_mutant = rewrite_tar(
+            frozen_archive, extra=[(extra_file, b"x")]
+        )
+        original_limit = archive_verifier.MAX_ARCHIVE_CONTENT_BYTES
+        archive_verifier.MAX_ARCHIVE_CONTENT_BYTES = original_content_bytes
+        try:
+            try:
+                verifier.verify_archive(
+                    aggregate_mutant, root, lock["release"]["candidate_commit"]
+                )
+            except verifier.ArchiveError as exc:
+                if "expands beyond" not in str(exc):
+                    raise AssertionError(
+                        f"aggregate archive limit failed for the wrong reason: {exc}"
+                    ) from exc
+            else:
+                raise AssertionError("archive verifier accepted aggregate overflow")
+        finally:
+            archive_verifier.MAX_ARCHIVE_CONTENT_BYTES = original_limit
+
+        expired = copy.deepcopy(snapshot)
+        expired["forkwright/typikon|actions/artifacts/1900"]["expired"] = True
+        expect_lock_error(
+            lambda: verifier.verify_live(lock, verifier.GitHub(expired), lock_path),
+            "expired",
+        )
+
+        wrong_pr = copy.deepcopy(snapshot)
+        wrong_pr["ardent-tools/ardent-tools-site|pulls/169"]["base"]["ref"] = "staging"
+        expect_lock_error(
+            lambda: verifier.verify_live(lock, verifier.GitHub(wrong_pr), lock_path),
+            "does not target owned main",
+        )
+
+        for label, mutate in (
+            (
+                "title",
+                lambda value: value["forkwright/typikon|pulls/182"].__setitem__(
+                    "title", "chore(main): release 0.6.1"
+                ),
+            ),
+            (
+                "head ref",
+                lambda value: value["forkwright/typikon|pulls/182"]["head"].__setitem__(
+                    "ref", "manual-release"
+                ),
+            ),
+            (
+                "bot author",
+                lambda value: value["forkwright/typikon|pulls/182"]["user"].__setitem__(
+                    "login", "operator"
+                ),
+            ),
+            (
+                "bot author type",
+                lambda value: value["forkwright/typikon|pulls/182"]["user"].__setitem__(
+                    "type", "User"
+                ),
+            ),
+            (
+                "base ref",
+                lambda value: value["forkwright/typikon|pulls/182"]["base"].__setitem__(
+                    "ref", "staging"
+                ),
+            ),
+            (
+                "base repo",
+                lambda value: value["forkwright/typikon|pulls/182"]["base"][
+                    "repo"
+                ].__setitem__("full_name", "forkwright/other"),
+            ),
+            (
+                "base subject",
+                lambda value: value["forkwright/typikon|pulls/182"]["base"].__setitem__(
+                    "sha", "0" * 40
+                ),
+            ),
+            (
+                "head repo",
+                lambda value: value["forkwright/typikon|pulls/182"]["head"][
+                    "repo"
+                ].__setitem__("full_name", "forkwright/other"),
+            ),
+        ):
+            wrong_release_pr = copy.deepcopy(snapshot)
+            mutate(wrong_release_pr)
+            expect_lock_error(
+                lambda value=wrong_release_pr: verifier.verify_live(
+                    lock, verifier.GitHub(value), lock_path
+                ),
+                "exact Release Please main-branch proposal",
+            )
+
+        no_release_label = copy.deepcopy(snapshot)
+        no_release_label["forkwright/typikon|pulls/182"]["labels"] = []
+        expect_lock_error(
+            lambda: verifier.verify_live(
+                lock, verifier.GitHub(no_release_label), lock_path
+            ),
+            "no Release Please lifecycle label",
+        )
+
+        wrong_release_head = copy.deepcopy(snapshot)
+        release_pr = wrong_release_head["forkwright/typikon|pulls/182"]
+        release_head = release_pr["head"]["sha"]
+        wrong_release_head[f"forkwright/typikon|git/commits/{release_head}"][
+            "tree"
+        ]["sha"] = "0" * 40
+        expect_lock_error(
+            lambda: verifier.verify_live(
+                lock, verifier.GitHub(wrong_release_head), lock_path
+            ),
+            "Release Please head tree",
+        )
+
+        wrong_release_parent = copy.deepcopy(snapshot)
+        candidate_commit = lock["release"]["candidate_commit"]
+        wrong_release_parent[
+            f"forkwright/typikon|git/commits/{candidate_commit}"
+        ]["parents"] = [{"sha": "0" * 40}]
+        expect_lock_error(
+            lambda: verifier.verify_live(
+                lock, verifier.GitHub(wrong_release_parent), lock_path
+            ),
+            "candidate parent differs",
+        )
+
+        wrong_parents = copy.deepcopy(snapshot)
+        wrong_parents[
+            f"ardent-tools/ardent-tools-site|git/commits/{lock['consumers'][0]['merge_commit']}"
+        ]["parents"].reverse()
+        expect_lock_error(
+            lambda: verifier.verify_live(
+                lock, verifier.GitHub(wrong_parents), lock_path
+            ),
+            "merge parents drifted",
+        )
+
+        failed_job = copy.deepcopy(snapshot)
+        failed_job[
+            "forkwright/ardent-site|actions/runs/1002/attempts/1/jobs?per_page=100"
+        ]["jobs"][0]["conclusion"] = "failure"
+        expect_lock_error(
+            lambda: verifier.verify_live(lock, verifier.GitHub(failed_job), lock_path),
+            "required job",
+        )
+
+        paged_jobs = copy.deepcopy(snapshot)
+        tools_jobs = (
+            "ardent-tools/ardent-tools-site|"
+            "actions/runs/1001/attempts/1/jobs?per_page=100"
+        )
+        paged_jobs[tools_jobs]["jobs"] = [
+            {"name": f"decoy-{index}", "conclusion": "success"}
+            for index in range(100)
+        ]
+        paged_jobs[f"{tools_jobs}&page=2"] = {
+            "jobs": [{"name": "gate-and-deploy", "conclusion": "success"}]
+        }
+        verifier.verify_live(lock, verifier.GitHub(paged_jobs), lock_path)
+
+        duplicate_paged_job = copy.deepcopy(paged_jobs)
+        duplicate_paged_job[tools_jobs]["jobs"][-1] = {
+            "name": "gate-and-deploy",
+            "conclusion": "success",
+        }
+        expect_lock_error(
+            lambda: verifier.verify_live(
+                lock, verifier.GitHub(duplicate_paged_job), lock_path
+            ),
+            "required job is not exactly one success",
+        )
+
+        vacuous_rollback = copy.deepcopy(lock)
+        vacuous_rollback["consumers"][0]["previous_gitlink_commit"] = vacuous_rollback[
+            "consumers"
+        ][0]["gitlink_commit"]
+        expect_lock_error(
+            lambda: verifier.verify_live(
+                vacuous_rollback, verifier.GitHub(snapshot), lock_path
+            ),
+            "rollback and promotion gitlinks are identical",
+        )
+
+        wrong_rollback = copy.deepcopy(lock)
+        wrong_rollback["consumers"][0]["previous_gitlink_tree"] = "f" * 40
+        expect_lock_error(
+            lambda: verifier.verify_live(
+                wrong_rollback, verifier.GitHub(snapshot), lock_path
+            ),
+            "rollback Typikon tree drifted",
+        )
+
+        wrong_workflow = copy.deepcopy(lock)
+        wrong_workflow["consumers"][1]["workflow_blob"] = "0" * 40
+        expect_lock_error(
+            lambda: verifier.verify_live(
+                wrong_workflow, verifier.GitHub(snapshot), lock_path
+            ),
+            "workflow blob drifted",
+        )
+
+        wrong_workflow_subject = copy.deepcopy(lock)
+        wrong_workflow_subject["consumers"][0]["workflow_commit"] = "0" * 40
+        expect_lock_error(
+            lambda: verifier.validate_lock_shape(wrong_workflow_subject),
+            "workflow commit is not its synthetic merge commit",
+        )
+
+        wrong_zip = copy.deepcopy(snapshot)
+        wrong_zip["forkwright/typikon|artifact_zip/1900"] = base64.b64encode(
+            b"not the artifact"
+        ).decode()
+        expect_lock_error(
+            lambda: verifier.verify_live(lock, verifier.GitHub(wrong_zip), lock_path),
+            "downloaded artifact digest",
+        )
+
+        extra_member_lock = copy.deepcopy(lock)
+        extra_member_snapshot = copy.deepcopy(snapshot)
+        consumer = extra_member_lock["consumers"][0]
+        receipt_bytes = (root / consumer["receipt_path"]).read_bytes()
+        extra_zip = zip_bytes(
+            {"typikon-consumer-receipt.json": receipt_bytes, "extra.txt": b"extra"}
+        )
+        extra_digest = f"sha256:{digest(extra_zip)}"
+        consumer["artifact_digest"] = extra_digest
+        artifact_key = f"{consumer['repository']}|actions/artifacts/{consumer['artifact_id']}"
+        zip_key = f"{consumer['repository']}|artifact_zip/{consumer['artifact_id']}"
+        extra_member_snapshot[artifact_key]["digest"] = extra_digest
+        extra_member_snapshot[zip_key] = base64.b64encode(extra_zip).decode()
+        expect_lock_error(
+            lambda: verifier.verify_live(
+                extra_member_lock, verifier.GitHub(extra_member_snapshot), lock_path
+            ),
+            "artifact members",
+        )
+
+        duplicate = copy.deepcopy(lock)
+        duplicate["consumers"][1] = copy.deepcopy(duplicate["consumers"][0])
+        try:
+            jsonschema.Draft202012Validator(SCHEMA).validate(duplicate)
+        except jsonschema.ValidationError:
+            pass
+        else:
+            raise AssertionError("schema accepted a duplicate cohort tuple")
+        expect_lock_error(
+            lambda: verifier.validate_lock_shape(duplicate),
+            "cohort tuple",
+        )
+
+        for label, mutate in (
+            (
+                "malformed candidate SHA",
+                lambda value: value["release"].__setitem__("candidate_commit", "abc"),
+            ),
+            (
+                "wrong candidate member name",
+                lambda value: value["candidate_artifact"].__setitem__(
+                    "checksum_name", "other.sha256"
+                ),
+            ),
+            (
+                "unknown lock field",
+                lambda value: value.__setitem__("surprise", True),
+            ),
+            (
+                "boolean schema version",
+                lambda value: value.__setitem__("schema_version", True),
+            ),
+            (
+                "boolean release PR",
+                lambda value: value["release"].__setitem__("release_pr", True),
+            ),
+            (
+                "boolean artifact ID",
+                lambda value: value["candidate_artifact"].__setitem__(
+                    "artifact_id", True
+                ),
+            ),
+            (
+                "boolean consumer run ID",
+                lambda value: value["consumers"][0].__setitem__(
+                    "workflow_run_id", True
+                ),
+            ),
+        ):
+            malformed = copy.deepcopy(lock)
+            mutate(malformed)
+            try:
+                jsonschema.Draft202012Validator(SCHEMA).validate(malformed)
+            except jsonschema.ValidationError:
+                pass
+            else:
+                raise AssertionError(f"JSON Schema accepted {label}")
+            try:
+                verifier.validate_lock_shape(malformed)
+            except verifier.LockError:
+                pass
+            else:
+                raise AssertionError(f"stdlib lock validator accepted {label}")
+
+        tagged_without_release = copy.deepcopy(snapshot)
+        tagged_without_release["forkwright/typikon|pulls/182"]["labels"] = [
+            {"name": "autorelease: tagged"}
+        ]
+        expect_lock_error(
+            lambda: verifier.verify_live(
+                lock, verifier.GitHub(tagged_without_release), lock_path
+            ),
+            "without an exact published release",
+        )
+
+        saved_tokens = {
+            name: os.environ.pop(name, None)
+            for name in ("TOOLS_RECEIPT_TOKEN", "LEATHER_RECEIPT_TOKEN")
+        }
+        try:
+            expect_lock_error(
+                lambda: verifier.GitHub().get(
+                    "ardent-tools/ardent-tools-site", "pulls/169"
+                ),
+                "TOOLS_RECEIPT_TOKEN is required",
+            )
+            expect_lock_error(
+                lambda: verifier.GitHub().artifact_zip("forkwright/ardent-site", 2002),
+                "LEATHER_RECEIPT_TOKEN is required",
+            )
+        finally:
+            for name, value in saved_tokens.items():
+                if value is not None:
+                    os.environ[name] = value
+
+        (root / "forbidden.txt").write_text("post-candidate drift\n", encoding="utf-8")
+        commit(root, "forbidden evidence drift")
+        expect_lock_error(
+            lambda: verifier.verify_evidence_delta(lock, lock_path),
+            "evidence delta",
+        )
+        git(root, "reset", "--hard", evidence)
+
+    verifier.ROOT = original_root
+    redirect_probe()
+    print("check-release-lock: ok (live snapshot, artifact, cohort, and auth mutants)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check-release-publication.py
+++ b/ci/check-release-publication.py
@@ -1,0 +1,677 @@
+#!/usr/bin/env python3
+"""Causal fixture for interrupted, conflicting, and completed publication states."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import subprocess
+import tempfile
+import threading
+from collections import Counter
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "publish-locked-release.py"
+LOADER = importlib.machinery.SourceFileLoader("publish_locked_release", str(SCRIPT))
+SPEC = importlib.util.spec_from_loader(LOADER.name, LOADER)
+assert SPEC is not None
+publication = importlib.util.module_from_spec(SPEC)
+LOADER.exec_module(publication)
+
+TAG = "v0.6.0"
+CANDIDATE = "a" * 40
+LOCK = "b" * 64
+MESSAGE = publication.exact_tag_message(TAG, LOCK)
+MARKER = publication.release_marker(CANDIDATE, LOCK)
+EVIDENCE = "d" * 40
+
+
+class ClientFixture(BaseHTTPRequestHandler):
+    paths = []
+    authorization = []
+    release_pages = {}
+    asset_pages = {}
+
+    def do_GET(self):  # noqa: N802
+        type(self).paths.append(self.path)
+        type(self).authorization.append(self.headers.get("Authorization"))
+        if self.path == "/repos/forkwright/typikon":
+            payload = json.dumps({"default_branch": "main"}).encode()
+        elif self.path.startswith(
+            "/repos/forkwright/typikon/releases?per_page=100&page="
+        ):
+            page = int(self.path.rsplit("=", 1)[1])
+            payload = json.dumps(type(self).release_pages.get(page, [])).encode()
+        elif self.path.startswith(
+            "/repos/forkwright/typikon/releases/77/assets?per_page=100&page="
+        ):
+            page = int(self.path.rsplit("=", 1)[1])
+            payload = json.dumps(type(self).asset_pages.get(page, [])).encode()
+        else:
+            self.send_error(404)
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_DELETE(self):  # noqa: N802
+        type(self).paths.append(self.path)
+        type(self).authorization.append(self.headers.get("Authorization"))
+        if self.path != "/repos/forkwright/typikon/releases/assets/42":
+            self.send_error(404)
+            return
+        self.send_response(204)
+        self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+
+def client_probe() -> None:
+    ClientFixture.paths = []
+    ClientFixture.authorization = []
+    target_release = {
+        "id": 77,
+        "tag_name": TAG,
+        "target_commitish": CANDIDATE,
+        "name": f"Typikon {TAG}",
+        "body": MARKER,
+        "draft": True,
+        "prerelease": False,
+    }
+    ClientFixture.release_pages = {
+        1: [{"id": index, "tag_name": f"v0.0.{index}"} for index in range(100)],
+        2: [target_release],
+    }
+    ClientFixture.asset_pages = {
+        1: [{"id": index, "name": f"decoy-{index}"} for index in range(100)],
+        2: [{"id": 101, "name": "page-two"}],
+    }
+    server = ThreadingHTTPServer(("127.0.0.1", 0), ClientFixture)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        try:
+            publication.GitHubApi("forkwright/typikon", "fixture-token")
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("publisher accepted a bare token string")
+        api = publication.GitHubApi(
+            "forkwright/typikon", publication.SecretToken("fixture-token")
+        )
+        api.api_root = f"http://127.0.0.1:{server.server_port}/repos/forkwright/typikon"
+        assert api.get_default_branch() == "main"
+        draft = api.get_release(TAG)
+        assert draft is not None and draft["draft"] is True
+        assert len(api.list_assets(77)) == 101
+        ClientFixture.release_pages = {
+            1: [
+                *[{"id": index, "tag_name": f"v0.0.{index}"} for index in range(99)],
+                target_release,
+            ],
+            2: [dict(target_release, id=78)],
+        }
+        try:
+            api.get_release(TAG)
+        except publication.PublishError as exc:
+            assert "multiple releases" in str(exc)
+        else:
+            raise AssertionError("publisher accepted duplicate releases across pages")
+        ClientFixture.asset_pages = {
+            1: [
+                {"id": index, "name": f"decoy-{index}", "state": "uploaded"}
+                for index in range(100)
+            ],
+            2: [{"id": 101, "name": "decoy-0", "state": "uploaded"}],
+        }
+        try:
+            publication.reconcile_assets(
+                api,
+                {"id": 77},
+                {f"decoy-{index}": b"" for index in range(100)},
+                allow_upload=False,
+            )
+        except publication.PublishError as exc:
+            assert "duplicate asset" in str(exc)
+        else:
+            raise AssertionError("publisher accepted duplicate assets across pages")
+        assert api.delete_asset(42) is None
+        assert any(path.endswith("releases?per_page=100&page=2") for path in ClientFixture.paths)
+        assert any(path.endswith("assets?per_page=100&page=2") for path in ClientFixture.paths)
+        assert ClientFixture.paths[-1] == "/repos/forkwright/typikon/releases/assets/42"
+        assert all(value == "Bearer fixture-token" for value in ClientFixture.authorization)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class FakeApi:
+    def __init__(self):
+        self.ref = None
+        self.tag = None
+        self.release = None
+        self.assets: dict[str, dict[str, object]] = {}
+        self.next_asset = 100
+        self.body = "Release notes"
+        self.main = EVIDENCE
+        self.calls: Counter[str] = Counter()
+        self.hook = None
+
+    def event(self, name):
+        self.calls[name] += 1
+        if self.hook is not None:
+            self.hook(self, name, self.calls[name])
+
+    def get_branch_head(self, branch):
+        assert branch == "main"
+        self.event("get_branch_head")
+        return self.main
+
+    def get_default_branch(self):
+        self.event("get_default_branch")
+        return "main"
+
+    def get_ref(self, tag):
+        assert tag == TAG
+        self.event("get_ref")
+        return self.ref
+
+    def create_tag(self, tag, message, candidate):
+        assert (tag, message, candidate) == (TAG, MESSAGE, CANDIDATE)
+        self.tag = {
+            "sha": "c" * 40,
+            "tag": tag,
+            "message": message,
+            "object": {"type": "commit", "sha": candidate},
+        }
+        self.event("create_tag")
+        return self.tag
+
+    def create_ref(self, tag, object_id):
+        assert (tag, object_id) == (TAG, "c" * 40)
+        self.ref = {"object": {"type": "tag", "sha": object_id}}
+        self.event("create_ref")
+
+    def get_tag(self, object_id):
+        assert self.tag is not None and object_id == self.tag["sha"]
+        self.event("get_tag")
+        return self.tag
+
+    def get_release(self, tag):
+        assert tag == TAG
+        self.event("get_release")
+        return self.release
+
+    def pull_body(self, number):
+        assert number == 182
+        return self.body
+
+    def create_release(self, tag, candidate, name, body):
+        assert tag == TAG and candidate == CANDIDATE and name == f"Typikon {TAG}"
+        assert MARKER in body
+        self.release = {
+            "id": 77,
+            "tag_name": tag,
+            # GitHub may report the default branch because target_commitish is
+            # unused once the exact annotated tag exists. The tag object and
+            # release marker, not this response field, bind the candidate.
+            "target_commitish": "main",
+            "name": name,
+            "body": body,
+            "draft": True,
+            "prerelease": False,
+        }
+        self.event("create_release")
+        return self.release
+
+    def list_assets(self, release_id):
+        assert release_id == 77
+        return [dict(value) for value in self.assets.values()]
+
+    def download_asset(self, asset_id):
+        for asset in self.assets.values():
+            if asset["id"] == asset_id:
+                self.event("download_asset")
+                return asset["payload"]
+        raise AssertionError(f"unknown asset {asset_id}")
+
+    def upload_asset(self, release_id, name, payload):
+        assert release_id == 77 and name not in self.assets
+        self.next_asset += 1
+        asset = {
+            "id": self.next_asset,
+            "name": name,
+            "state": "uploaded",
+            "payload": payload,
+        }
+        self.assets[name] = asset
+        self.event("upload_asset")
+        return asset
+
+    def delete_asset(self, asset_id):
+        for name, asset in list(self.assets.items()):
+            if asset["id"] == asset_id:
+                del self.assets[name]
+                return
+        raise AssertionError(f"unknown asset {asset_id}")
+
+    def publish_release(self, release_id):
+        assert release_id == 77 and self.release is not None
+        self.release["draft"] = False
+        self.event("publish_release")
+        return self.release
+
+
+def expect_failure(api, payloads, fragment):
+    try:
+        publication.publish(api, TAG, CANDIDATE, LOCK, payloads, api.main)
+    except publication.PublishError as exc:
+        if fragment not in str(exc):
+            raise AssertionError(f"expected {fragment!r}, got {exc!r}") from exc
+    else:
+        raise AssertionError(f"publication accepted mutant: {fragment}")
+
+
+def main() -> int:
+    global CANDIDATE, EVIDENCE, LOCK, MARKER, MESSAGE
+    client_probe()
+    with tempfile.TemporaryDirectory(prefix="typikon-publication-") as tmp:
+        repo = Path(tmp) / "repo"
+        staging = Path(tmp) / "staging"
+        repo.mkdir()
+        staging.mkdir()
+        subprocess.run(["git", "-C", str(repo), "init", "-q", "-b", "main"], check=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.name", "fixture"], check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.email", "fixture@example.test"],
+            check=True,
+        )
+        (repo / "CHANGELOG.md").write_text(
+            "# Changelog\n\n## [0.6.0](https://example.test/v0.6.0)\n\n"
+            "### Features\n\n* exact fixture release\n",
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "-C", str(repo), "add", "CHANGELOG.md"], check=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-q", "-m", "release candidate"],
+            check=True,
+        )
+        CANDIDATE = subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True
+        ).strip()
+        publication.ROOT = repo
+        archive_name = f"typikon-{TAG}.tar.gz"
+        sbom_name = f"{archive_name}.cdx.json"
+        archive = subprocess.check_output(
+            ["git", "-C", str(repo), "archive", "--format=tar.gz", CANDIDATE]
+        )
+        checksum = f"{publication.digest_bytes(archive)}  {archive_name}\n".encode()
+        sbom = b'{"bomFormat":"CycloneDX"}\n'
+        provenance_bundle = b'{"mediaType":"application/vnd.dev.sigstore.bundle+json;version=0.3"}\n'
+        sbom_bundle = b'{"mediaType":"application/vnd.dev.sigstore.bundle+json;version=0.3"}\n'
+        tools_receipt = b'{"consumer":"tools"}\n'
+        leather_receipt = b'{"consumer":"leather"}\n'
+        candidate_manifest = {
+            "release": {
+                "version": "0.6.0",
+                "tag": TAG,
+                "candidate_commit": CANDIDATE,
+            },
+            "archive": {
+                "name": archive_name,
+                "sha256": publication.digest_bytes(archive),
+                "size": len(archive),
+            },
+            "checksum": {
+                "name": f"{archive_name}.sha256",
+                "sha256": publication.digest_bytes(checksum),
+                "size": len(checksum),
+            },
+            "sbom": {
+                "name": sbom_name,
+                "sha256": publication.digest_bytes(sbom),
+                "size": len(sbom),
+            },
+            "attestations": {
+                "provenance": {
+                    "name": f"{archive_name}.provenance.intoto.jsonl",
+                    "sha256": publication.digest_bytes(provenance_bundle),
+                    "size": len(provenance_bundle),
+                },
+                "sbom": {
+                    "name": f"{archive_name}.sbom.intoto.jsonl",
+                    "sha256": publication.digest_bytes(sbom_bundle),
+                    "size": len(sbom_bundle),
+                },
+            },
+            "notes": {
+                "body": "### Features\n\n* exact fixture release",
+                "sha256": publication.digest_bytes(
+                    b"### Features\n\n* exact fixture release"
+                ),
+                "size": len(b"### Features\n\n* exact fixture release"),
+            },
+        }
+        lock = {
+            "release": {
+                "version": "0.6.0",
+                "tag": TAG,
+                "candidate_commit": CANDIDATE,
+            },
+            "candidate_artifact": {
+                "archive_name": archive_name,
+                "archive_sha256": publication.digest_bytes(archive),
+                "archive_size": len(archive),
+                "checksum_name": f"{archive_name}.sha256",
+                "checksum_sha256": publication.digest_bytes(checksum),
+                "checksum_size": len(checksum),
+                "sbom_name": sbom_name,
+                "sbom_sha256": publication.digest_bytes(sbom),
+                "sbom_size": len(sbom),
+                "provenance_bundle_name": f"{archive_name}.provenance.intoto.jsonl",
+                "provenance_bundle_sha256": publication.digest_bytes(provenance_bundle),
+                "provenance_bundle_size": len(provenance_bundle),
+                "sbom_bundle_name": f"{archive_name}.sbom.intoto.jsonl",
+                "sbom_bundle_sha256": publication.digest_bytes(sbom_bundle),
+                "sbom_bundle_size": len(sbom_bundle),
+            },
+            "consumers": [
+                {
+                    "id": "tools",
+                    "receipt_path": "release/compatibility/receipts/tools.json",
+                    "receipt_sha256": publication.digest_bytes(tools_receipt),
+                },
+                {
+                    "id": "leather",
+                    "receipt_path": "release/compatibility/receipts/leather.json",
+                    "receipt_sha256": publication.digest_bytes(leather_receipt),
+                },
+            ],
+        }
+        (staging / "candidate.json").write_text(json.dumps(candidate_manifest))
+        (staging / archive_name).write_bytes(archive)
+        (staging / f"{archive_name}.sha256").write_bytes(checksum)
+        (staging / sbom_name).write_bytes(sbom)
+        (staging / f"{archive_name}.provenance.intoto.jsonl").write_bytes(
+            provenance_bundle
+        )
+        (staging / f"{archive_name}.sbom.intoto.jsonl").write_bytes(sbom_bundle)
+        tracked_lock = repo / "release" / "compatibility" / "v0.6.0.json"
+        receipts = tracked_lock.parent / "receipts"
+        receipts.mkdir(parents=True)
+        tracked_lock.write_text(json.dumps(lock), encoding="utf-8")
+        (receipts / "tools.json").write_bytes(tools_receipt)
+        (receipts / "leather.json").write_bytes(leather_receipt)
+        subprocess.run(["git", "-C", str(repo), "add", "release"], check=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-q", "-m", "release evidence"],
+            check=True,
+        )
+        EVIDENCE = subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True
+        ).strip()
+        lock_path = staging / f"typikon-{TAG}-compatibility-lock.json"
+        lock_path.write_bytes(tracked_lock.read_bytes())
+        (staging / f"typikon-{TAG}-tools-receipt.json").write_bytes(tools_receipt)
+        (staging / f"typikon-{TAG}-leather-receipt.json").write_bytes(leather_receipt)
+        payloads = publication.expected_assets(staging, TAG)
+        staged_lock_digest = publication.digest_bytes(lock_path.read_bytes())
+        LOCK = staged_lock_digest
+        MESSAGE = publication.exact_tag_message(TAG, LOCK)
+        MARKER = publication.release_marker(CANDIDATE, LOCK)
+        publication.validate_staged_evidence(
+            payloads, TAG, CANDIDATE, staged_lock_digest, tracked_lock
+        )
+        try:
+            publication.validate_staged_evidence(
+                payloads, TAG, CANDIDATE, "0" * 64, tracked_lock
+            )
+        except publication.PublishError as exc:
+            assert "lock digest" in str(exc)
+        else:
+            raise AssertionError("publisher accepted a different staged lock digest")
+        release_body = publication.exact_release_body(
+            payloads, CANDIDATE, LOCK
+        )
+
+        # While the verified evidence commit remains current, a fresh attempt
+        # can tear after the tag, draft, or any upload and resumes exactly.
+        api = FakeApi()
+        publication.ensure_tag(api, TAG, CANDIDATE, MESSAGE, api.main)
+        assert publication.inspect(api, TAG, CANDIDATE, LOCK, payloads) == "tagged"
+        assert publication.publish(api, TAG, CANDIDATE, LOCK, payloads, api.main) == "published"
+        assert publication.publish(api, TAG, CANDIDATE, LOCK, payloads, api.main) == "published"
+
+        # An already-public retry still reads every asset before returning a
+        # success receipt. Movement during that readback must invalidate the
+        # receipt even though the exact public release remains unchanged.
+        published_resume_race = FakeApi()
+        evidence = published_resume_race.main
+        assert publication.publish(
+            published_resume_race, TAG, CANDIDATE, LOCK, payloads, evidence
+        ) == "published"
+        published_resume_race.calls.clear()
+        published_resume_race.hook = (
+            lambda value, name, count: setattr(value, "main", "e" * 40)
+            if name == "download_asset" and count == 1
+            else None
+        )
+        try:
+            publication.publish(
+                published_resume_race,
+                TAG,
+                CANDIDATE,
+                LOCK,
+                payloads,
+                evidence,
+            )
+        except publication.PublishError as exc:
+            assert "main moved" in str(exc)
+        else:
+            raise AssertionError(
+                "published resume ignored main movement during asset readback"
+            )
+        assert published_resume_race.release is not None
+        assert published_resume_race.release["draft"] is False
+
+        partial = FakeApi()
+        publication.ensure_tag(partial, TAG, CANDIDATE, MESSAGE, partial.main)
+        release = partial.create_release(
+            TAG, CANDIDATE, f"Typikon {TAG}", release_body
+        )
+        first = sorted(payloads)[0]
+        partial.upload_asset(int(release["id"]), first, payloads[first])
+        assert publication.inspect(partial, TAG, CANDIDATE, LOCK, payloads) == "draft"
+        assert publication.publish(partial, TAG, CANDIDATE, LOCK, payloads, partial.main) == "published"
+
+        starter = FakeApi()
+        publication.ensure_tag(starter, TAG, CANDIDATE, MESSAGE, starter.main)
+        release = starter.create_release(
+            TAG, CANDIDATE, f"Typikon {TAG}", release_body
+        )
+        first = sorted(payloads)[0]
+        starter.upload_asset(int(release["id"]), first, b"")
+        starter.assets[first]["state"] = "starter"
+        assert publication.publish(starter, TAG, CANDIDATE, LOCK, payloads, starter.main) == "published"
+
+        wrong_tag = FakeApi()
+        publication.ensure_tag(wrong_tag, TAG, CANDIDATE, MESSAGE, wrong_tag.main)
+        wrong_tag.tag["message"] = "wrong"
+        expect_failure(wrong_tag, payloads, "tag identity drifted")
+
+        wrong_asset = FakeApi()
+        publication.ensure_tag(
+            wrong_asset, TAG, CANDIDATE, MESSAGE, wrong_asset.main
+        )
+        release = wrong_asset.create_release(
+            TAG, CANDIDATE, f"Typikon {TAG}", release_body
+        )
+        first = sorted(payloads)[0]
+        wrong_asset.upload_asset(int(release["id"]), first, b"wrong")
+        expect_failure(wrong_asset, payloads, "differs from staged bytes")
+
+        published_partial = FakeApi()
+        publication.ensure_tag(
+            published_partial, TAG, CANDIDATE, MESSAGE, published_partial.main
+        )
+        release = published_partial.create_release(
+            TAG, CANDIDATE, f"Typikon {TAG}", release_body
+        )
+        release["draft"] = False
+        expect_failure(published_partial, payloads, "published release is missing asset")
+
+        moved = FakeApi()
+        try:
+            publication.publish(
+                moved, TAG, CANDIDATE, LOCK, payloads, "e" * 40
+            )
+        except publication.PublishError as exc:
+            assert "main moved" in str(exc)
+        else:
+            raise AssertionError("publication accepted a stale evidence commit")
+
+        # Movement while inspect reads the release is caught before any tag
+        # object or ref can be created.
+        inspect_race = FakeApi()
+        evidence = inspect_race.main
+        inspect_race.hook = (
+            lambda value, name, count: setattr(value, "main", "e" * 40)
+            if name == "get_release" and count == 1
+            else None
+        )
+        try:
+            publication.publish(
+                inspect_race, TAG, CANDIDATE, LOCK, payloads, evidence
+            )
+        except publication.PublishError as exc:
+            assert "main moved" in str(exc)
+        else:
+            raise AssertionError("publication ignored main movement during inspect")
+        assert inspect_race.calls["create_tag"] == 0
+        assert inspect_race.ref is None and inspect_race.release is None
+
+        # Movement during tag-object creation leaves no named tag, draft, or
+        # assets. The unreferenced tag object is harmless API residue.
+        object_race = FakeApi()
+        evidence = object_race.main
+        object_race.hook = (
+            lambda value, name, count: setattr(value, "main", "e" * 40)
+            if name == "create_tag" and count == 1
+            else None
+        )
+        try:
+            publication.publish(
+                object_race, TAG, CANDIDATE, LOCK, payloads, evidence
+            )
+        except publication.PublishError as exc:
+            assert "main moved" in str(exc)
+        else:
+            raise AssertionError("publication ignored main movement after tag object")
+        assert object_race.ref is None and object_race.release is None
+        assert object_race.calls["create_ref"] == 0
+
+        # The GitHub API cannot atomically compare main and create another ref.
+        # Movement during the tag-ref POST may therefore leave one exact,
+        # provisional tag. It must stop before the draft. Because restoring an
+        # old main tip is not a safe recovery, retries stay failed until a
+        # separately reviewed tag-residue action resolves the public ref.
+        ref_race = FakeApi()
+        evidence = ref_race.main
+        ref_race.hook = (
+            lambda value, name, count: setattr(value, "main", "e" * 40)
+            if name == "create_ref" and count == 1
+            else None
+        )
+        try:
+            publication.publish(
+                ref_race, TAG, CANDIDATE, LOCK, payloads, evidence
+            )
+        except publication.PublishError as exc:
+            assert "main moved" in str(exc)
+        else:
+            raise AssertionError("publication ignored main movement after tag ref")
+        assert ref_race.ref is not None and ref_race.release is None
+        assert ref_race.calls["create_tag"] == 1
+        ref_race.hook = None
+        try:
+            publication.publish(
+                ref_race, TAG, CANDIDATE, LOCK, payloads, evidence
+            )
+        except publication.PublishError as exc:
+            assert "main moved" in str(exc)
+        else:
+            raise AssertionError("publisher resumed a provisional tag from stale evidence")
+        assert ref_race.calls["create_tag"] == 1
+
+        # Movement after tag/draft/assets but before publication leaves an
+        # exact private draft and also refuses stale-evidence retries.
+        readback_race = FakeApi()
+        evidence = readback_race.main
+        readback_race.hook = (
+            lambda value, name, count: setattr(value, "main", "e" * 40)
+            if name == "download_asset" and count == 1
+            else None
+        )
+        try:
+            publication.publish(
+                readback_race, TAG, CANDIDATE, LOCK, payloads, evidence
+            )
+        except publication.PublishError as exc:
+            assert "main moved" in str(exc)
+        else:
+            raise AssertionError("publication ignored main movement before publish")
+        assert readback_race.release is not None
+        assert readback_race.release["draft"] is True
+        readback_race.hook = None
+        try:
+            publication.publish(
+                readback_race, TAG, CANDIDATE, LOCK, payloads, evidence
+            )
+        except publication.PublishError as exc:
+            assert "main moved" in str(exc)
+        else:
+            raise AssertionError("publisher resumed a private draft from stale evidence")
+
+        # GitHub cannot atomically compare main with the draft-to-public PATCH.
+        # Movement during that write is detected after exact release readback,
+        # leaving a public exact release but never a green publication receipt.
+        publish_race = FakeApi()
+        evidence = publish_race.main
+        publish_race.hook = (
+            lambda value, name, count: setattr(value, "main", "e" * 40)
+            if name == "publish_release" and count == 1
+            else None
+        )
+        try:
+            publication.publish(
+                publish_race, TAG, CANDIDATE, LOCK, payloads, evidence
+            )
+        except publication.PublishError as exc:
+            assert "main moved" in str(exc)
+        else:
+            raise AssertionError("publication ignored main movement during publish")
+        assert publish_race.release is not None
+        assert publish_race.release["draft"] is False
+        publish_race.hook = None
+        try:
+            publication.publish(
+                publish_race, TAG, CANDIDATE, LOCK, payloads, evidence
+            )
+        except publication.PublishError as exc:
+            assert "main moved" in str(exc)
+        else:
+            raise AssertionError("publisher accepted a public release from stale evidence")
+
+    print("check-release-publication: ok (exact retries and fail-closed race residue)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check-release-workflows.py
+++ b/ci/check-release-workflows.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""Structural regression guard for two-phase Typikon release workflows."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RELEASE = ROOT / ".github" / "workflows" / "release-please.yml"
+CANDIDATE = ROOT / ".github" / "workflows" / "release-candidate.yml"
+VERIFIER = ROOT / "ci" / "verify-release-lock.py"
+CONSUMER = ROOT / "ci" / "github-workflow.yml.tmpl"
+RELEASING = ROOT / "docs" / "RELEASING.md"
+
+
+class ContractError(RuntimeError):
+    pass
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ContractError(message)
+
+
+def action_refs(text: str) -> list[str]:
+    return re.findall(r"^\s*-?\s*uses:\s+[^@\s]+@([^\s#]+)", text, re.MULTILINE)
+
+
+def step_blocks(text: str) -> dict[str, str]:
+    matches = list(re.finditer(r"^      - name: (.+)$", text, re.MULTILINE))
+    result = {}
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        result[match.group(1)] = text[match.start() : end]
+    return result
+
+
+def job_block(text: str, name: str) -> str:
+    match = re.search(rf"^  {re.escape(name)}:\n", text, re.MULTILINE)
+    if match is None:
+        return ""
+    following = re.search(r"^  [A-Za-z0-9_-]+:\n", text[match.end() :], re.MULTILINE)
+    end = match.end() + following.start() if following else len(text)
+    return text[match.start() : end]
+
+
+def validate(release: str, candidate: str, verifier: str) -> None:
+    require(
+        "if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'"
+        in release,
+        "manual publisher is not bound to refs/heads/main",
+    )
+    require(
+        "acknowledge_private_consumer_metadata:" in release
+        and "default: false" in release
+        and 'test "$PRIVACY_ACKNOWLEDGED" = true' in release,
+        "public private-consumer metadata lacks an explicit operator acknowledgment",
+    )
+    require("default_branch=$(gh api" in release, "verifier does not prove default branch")
+    require(
+        release.count('test "$live_head" = "$GITHUB_SHA"') == 2,
+        "verifier does not bind both live reads to the evidence checkout",
+    )
+    require(
+        "skip-github-release: true" in release
+        and "skip-github-release: false" not in release,
+        "push preparation may create a release",
+    )
+    require(
+        'python3 -I ci/verify-published-release.py --version "$version"' in release
+        and "--jq '.draft == false' | grep -Fxq true" not in release
+        and "git show-ref --verify" not in release,
+        "release preparation does not verify the exact published predecessor",
+    )
+
+    verify_job = job_block(release, "verify-locked-release")
+    publish_job = job_block(release, "publish-locked-release")
+    require(verify_job and publish_job, "split verify/publish jobs are missing")
+    verify_preamble = verify_job.split("    steps:\n", 1)[0]
+    publish_preamble = publish_job.split("    steps:\n", 1)[0]
+    require("contents: write" not in verify_preamble, "verifier has content-write authority")
+    require("pull-requests: write" not in verify_preamble, "verifier has PR-write authority")
+    require("contents: write" in publish_preamble, "publisher lacks release authority")
+    require(
+        "needs: verify-locked-release" in publish_preamble
+        and "needs.verify-locked-release.result == 'success'" in publish_preamble,
+        "publisher is not gated on the read-only verifier job",
+    )
+    require("    env:" not in publish_preamble, "publisher has job-global credentials")
+    blocks = step_blocks(release)
+    replay = blocks.get(
+        "Replay candidate, artifact, consumer, workflow, and PR evidence", ""
+    )
+    revalidate = blocks.get("Revalidate live evidence before sealing the handoff", "")
+    seal = blocks.get("Seal the verified publication handoff", "")
+    handoff = blocks.get("Materialize the raw digest-bound publication handoff", "")
+    publisher = blocks.get("Publish or resume the exact locked release", "")
+    require(
+        replay and revalidate and seal and handoff and publisher,
+        "release evidence handoff steps are missing",
+    )
+    for secret in ("TOOLS_RECEIPT_TOKEN", "LEATHER_RECEIPT_TOKEN"):
+        require(
+            release.count(f"secrets.{secret}") == 2,
+            f"{secret} is not scoped to two verifier steps",
+        )
+        require(secret in replay and secret in revalidate, f"{secret} escaped verifier steps")
+        require(secret not in publish_job, f"{secret} escaped into the publisher job")
+    require(
+        "--materialize-candidate" in replay and "--materialize-candidate" in revalidate,
+        "both live validations must materialize immutable candidate bytes",
+    )
+    require(
+        'diff -qr "$PUBLISH_DIR" "$reverified"' in revalidate
+        and 'mv "$reverified" "$PUBLISH_DIR"' in revalidate,
+        "final release staging is not rebuilt and byte-compared",
+    )
+    second_verify = release.index(
+        "      - name: Revalidate live evidence before sealing the handoff"
+    )
+    sealed = release.index("      - name: Seal the verified publication handoff")
+    publish = release.index("      - name: Publish or resume the exact locked release")
+    require(
+        second_verify < sealed < publish,
+        "publication handoff can precede final live verification",
+    )
+    require(
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+        in seal
+        and "ci/materialize-release-handoff.py" in handoff
+        and '--artifact-id "${{ needs.verify-locked-release.outputs.staging_artifact_id }}"'
+        in handoff
+        and '--artifact-digest "${{ needs.verify-locked-release.outputs.staging_artifact_digest }}"'
+        in handoff
+        and '--run-id "${{ needs.verify-locked-release.outputs.staging_run_id }}"'
+        in handoff
+        and '--run-attempt "${{ needs.verify-locked-release.outputs.staging_run_attempt }}"'
+        in handoff
+        and 'test "$GITHUB_RUN_ID" = "${{ needs.verify-locked-release.outputs.staging_run_id }}"'
+        in handoff
+        and 'test "$GITHUB_RUN_ATTEMPT" != "${{ needs.verify-locked-release.outputs.staging_run_attempt }}"'
+        in handoff,
+        "sealed cross-job publication handoff is not ID/digest bound",
+    )
+    require(
+        "actions/attest-build-provenance@" not in release
+        and "actions/attest-sbom@" not in release,
+        "publisher regenerates attestations instead of reusing frozen candidate bundles",
+    )
+    require(
+        "ci/publish-locked-release.py publish" in publisher
+        and '--evidence-commit "${{ needs.verify-locked-release.outputs.evidence_commit }}"'
+        in publisher,
+        "publisher does not use the replayable evidence-bound state machine",
+    )
+    require(
+        "$RUNNER_TEMP/release-verifier" not in publish_job
+        and "pip install" not in publish_job
+        and "verify-release-lock.py" not in publish_job,
+        "third-party verifier dependencies escaped into the write-authorized job",
+    )
+    require("gh release" not in release, "workflow bypasses the publication state machine")
+    require("git/refs" not in release, "workflow creates a tag outside the state machine")
+
+    for ref in action_refs(release) + action_refs(candidate):
+        require(re.fullmatch(r"[0-9a-f]{40}", ref) is not None, f"mutable action ref {ref}")
+    require(
+        release.count("persist-credentials: false") == 3,
+        "all three release checkouts are not exactly fail-closed",
+    )
+    require(
+        candidate.count("persist-credentials: false") == 1,
+        "candidate checkout credentials are not exactly fail-closed",
+    )
+
+    require("workflow_dispatch:" not in candidate, "candidate freezer is manually writable")
+    require("contents: write" not in candidate, "candidate freezer has write authority")
+    require("secrets." not in candidate, "candidate freezer consumes a repository secret")
+    require("freeze-candidate:" in candidate, "candidate freeze job is missing")
+    require(
+        'ci/build-release-candidate.py seed-sbom --output-dir "$CANDIDATE_DIR"'
+        in candidate
+        and "ci/build-release-candidate.py freeze" in candidate
+        and "actions/upload-artifact@" in candidate,
+        "candidate workflow does not seed, freeze, and upload exact bytes",
+    )
+    require(
+        "anchore/sbom-action@" not in candidate,
+        "candidate delegates SBOM generation to an unbound downloader",
+    )
+    candidate_order = [
+        candidate.index("      - name: Generate the inventory-backed CycloneDX SBOM"),
+        candidate.index("      - name: Freeze exact archive and candidate manifest"),
+        candidate.index("      - name: Validate the CycloneDX schema"),
+        candidate.index("      - name: Attest the frozen source archive"),
+        candidate.index("      - name: Attest the frozen CycloneDX SBOM"),
+        candidate.index("      - name: Freeze the offline attestation bundles"),
+        candidate.index("      - name: Verify both frozen offline attestation bundles"),
+        candidate.index("      - name: Upload immutable candidate bundle"),
+    ]
+    require(
+        candidate_order == sorted(candidate_order),
+        "candidate inventory, archive, validation, attestations, and upload are misordered",
+    )
+    require(
+        "attestations: write" in candidate
+        and "id-token: write" in candidate
+        and "provenance.outputs.bundle-path" in candidate
+        and "sbom_attestation.outputs.bundle-path" in candidate,
+        "candidate workflow does not freeze both offline attestation bundles",
+    )
+    candidate_blocks = step_blocks(candidate)
+    schema_check = candidate_blocks.get("Validate the CycloneDX schema", "")
+    provenance = candidate_blocks.get("Attest the frozen source archive", "")
+    sbom_attestation = candidate_blocks.get("Attest the frozen CycloneDX SBOM", "")
+    attach = candidate_blocks.get("Freeze the offline attestation bundles", "")
+    offline_verify = candidate_blocks.get(
+        "Verify both frozen offline attestation bundles", ""
+    )
+    require(
+        "bfc8b2538da86fe239bc53658bbb63c1c8c510a293c1e6891aa5bea5d3c58746"
+        in schema_check
+        and "cyclonedx-cli/releases/download/v0.33.1/cyclonedx-linux-x64"
+        in schema_check
+        and "sha256sum --check --strict" in schema_check
+        and '"$cli" validate' in schema_check
+        and "--input-format json" in schema_check
+        and "--fail-on-errors" in schema_check,
+        "candidate CycloneDX schema validator is not version/hash/command bound",
+    )
+    archive_subject = (
+        "subject-path: ${{ env.CANDIDATE_DIR }}/"
+        "typikon-${{ steps.detect.outputs.tag }}.tar.gz"
+    )
+    require(
+        archive_subject in provenance
+        and ".tar.gz.cdx.json" not in provenance,
+        "provenance attestation does not bind the source archive",
+    )
+    require(
+        archive_subject in sbom_attestation
+        and "sbom-path: ${{ env.CANDIDATE_DIR }}/"
+        "typikon-${{ steps.detect.outputs.tag }}.tar.gz.cdx.json"
+        in sbom_attestation,
+        "SBOM attestation does not bind the source archive and CycloneDX document",
+    )
+    require(
+        '--provenance-bundle "${{ steps.provenance.outputs.bundle-path }}"'
+        in attach
+        and '--sbom-bundle "${{ steps.sbom_attestation.outputs.bundle-path }}"'
+        in attach,
+        "candidate finalizer does not receive both action-produced bundles",
+    )
+    require(
+        offline_verify.count("gh attestation verify") == 2
+        and '--bundle "$archive.provenance.intoto.jsonl"' in offline_verify
+        and '--bundle "$archive.sbom.intoto.jsonl"' in offline_verify
+        and '--signer-workflow "$signer"' in offline_verify
+        and '--source-digest "$GITHUB_SHA"' in offline_verify
+        and "--predicate-type https://slsa.dev/provenance/v1" in offline_verify
+        and "--predicate-type https://cyclonedx.org/bom" in offline_verify,
+        "candidate does not cryptographically verify both frozen offline bundles",
+    )
+    for suffix in (
+        ".tar.gz.sha256",
+        ".tar.gz.provenance.intoto.jsonl",
+        ".tar.gz.sbom.intoto.jsonl",
+    ):
+        require(
+            release.count(suffix) == 2,
+            f"verifier does not stage and restage the frozen {suffix} member",
+        )
+    require(
+        '".github/workflows/release-candidate.yml"' in verifier,
+        "lock verifier names the wrong candidate workflow",
+    )
+
+
+def validate_consumer_receipt(template: str) -> None:
+    blocks = step_blocks(template)
+    record = blocks.get("Record Typikon consumer receipt", "")
+    upload = blocks.get("Upload Typikon consumer receipt", "")
+    require(record and upload, "consumer receipt record/upload steps are missing")
+    for block in (record, upload):
+        require(
+            "if: github.event_name == 'pull_request'" in block,
+            "consumer receipt step is not PR-only",
+        )
+    require(
+        "themes/typikon/ci/write-consumer-receipt.py" in record
+        and "--root \"$GITHUB_WORKSPACE\"" in record
+        and "--output /tmp/typikon-consumer-receipt.json" in record,
+        "consumer receipt writer is not bound to the hosted checkout",
+    )
+    require(
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in upload
+        and "name: typikon-consumer-receipt-${{ github.run_id }}-${{ github.run_attempt }}"
+        in upload
+        and "path: /tmp/typikon-consumer-receipt.json" in upload
+        and "if-no-files-found: error" in upload
+        and "retention-days: 90" in upload,
+        "consumer receipt artifact identity or retention drifted",
+    )
+    require(
+        template.index("      - name: Consumer checks")
+        < template.index("      - name: Record Typikon consumer receipt")
+        < template.index("      - name: Upload Typikon consumer receipt")
+        < template.index("      # ── Deploy on green pushes to main only"),
+        "consumer receipt does not follow the exact gate and precede deployment",
+    )
+
+
+def validate_releasing_docs(document: str) -> None:
+    signer = (
+        "--signer-workflow "
+        "forkwright/typikon/.github/workflows/release-candidate.yml"
+    )
+    require(
+        document.count(signer) == 2,
+        "offline verification does not bind both bundles to the candidate workflow",
+    )
+    require(
+        document.count('--source-digest "$R"') == 2,
+        "offline verification does not bind both bundles to candidate R",
+    )
+
+
+def reject_consumer_mutant(template: str, fragment: str) -> None:
+    try:
+        validate_consumer_receipt(template)
+    except ContractError:
+        return
+    raise AssertionError(f"consumer receipt contract accepted mutant: {fragment}")
+
+
+def reject_mutant(release: str, candidate: str, verifier: str, fragment: str) -> None:
+    try:
+        validate(release, candidate, verifier)
+    except ContractError:
+        return
+    raise AssertionError(f"release workflow contract accepted mutant: {fragment}")
+
+
+def main() -> int:
+    release = RELEASE.read_text(encoding="utf-8")
+    candidate = CANDIDATE.read_text(encoding="utf-8")
+    verifier = VERIFIER.read_text(encoding="utf-8")
+    consumer = CONSUMER.read_text(encoding="utf-8")
+    releasing = RELEASING.read_text(encoding="utf-8")
+    validate(release, candidate, verifier)
+    validate_consumer_receipt(consumer)
+    validate_releasing_docs(releasing)
+
+    reject_mutant(
+        release.replace(" && github.ref == 'refs/heads/main'", "", 1),
+        candidate,
+        verifier,
+        "branch-dispatch publisher",
+    )
+    reject_mutant(
+        release.replace('test "$PRIVACY_ACKNOWLEDGED" = true', "true", 1),
+        candidate,
+        verifier,
+        "private-consumer metadata published without acknowledgment",
+    )
+    release_prefix, release_publish_job = release.split(
+        "  publish-locked-release:\n", 1
+    )
+    reject_mutant(
+        release_prefix
+        + "  publish-locked-release:\n"
+        + release_publish_job.replace(
+            "    steps:\n",
+            "    env:\n      LEATHER_RECEIPT_TOKEN: leak\n    steps:\n",
+            1,
+        ),
+        candidate,
+        verifier,
+        "job-global private token",
+    )
+    reject_mutant(
+        release.replace("skip-github-release: true", "skip-github-release: false", 1),
+        candidate,
+        verifier,
+        "push can release",
+    )
+    reject_mutant(
+        release.replace(
+            'python3 -I ci/verify-published-release.py --version "$version"',
+            "true # published-state check removed",
+            1,
+        ),
+        candidate,
+        verifier,
+        "tag-only state can advance Release Please",
+    )
+    reject_mutant(
+        release.replace('diff -qr "$PUBLISH_DIR" "$reverified"', "true", 1),
+        candidate,
+        verifier,
+        "staged bytes may mutate after verification",
+    )
+    reject_mutant(
+        release,
+        candidate.replace(
+            "            --provenance-bundle \"${{ steps.provenance.outputs.bundle-path }}\" \\\n",
+            "",
+            1,
+        ),
+        verifier,
+        "offline provenance bundle is not frozen",
+    )
+    candidate_blocks = step_blocks(candidate)
+    schema_block = candidate_blocks["Validate the CycloneDX schema"]
+    reject_mutant(
+        release,
+        candidate.replace(schema_block, schema_block.split("        run:", 1)[0] + "        run: true\n", 1),
+        verifier,
+        "CycloneDX schema validation removed",
+    )
+    reject_mutant(
+        release,
+        candidate.replace("sha256sum --check --strict", "true", 1),
+        verifier,
+        "CycloneDX CLI digest not checked",
+    )
+    reject_mutant(
+        release,
+        candidate.replace(
+            "subject-path: ${{ env.CANDIDATE_DIR }}/typikon-${{ steps.detect.outputs.tag }}.tar.gz",
+            "subject-path: ${{ env.CANDIDATE_DIR }}/typikon-${{ steps.detect.outputs.tag }}.tar.gz.cdx.json",
+            1,
+        ),
+        verifier,
+        "provenance attests the SBOM instead of the archive",
+    )
+    reject_mutant(
+        release,
+        candidate.replace("gh attestation verify", "true # removed", 1),
+        verifier,
+        "offline provenance bundle is not cryptographically verified",
+    )
+    reject_mutant(
+        release,
+        candidate.replace(
+            "--predicate-type https://cyclonedx.org/bom",
+            "--predicate-type https://slsa.dev/provenance/v1",
+            1,
+        ),
+        verifier,
+        "offline SBOM bundle predicate is not enforced",
+    )
+    reject_mutant(
+        release.replace("16a9c90856f42705d54a6fda1823352bdc62cf38", "v4", 1),
+        candidate,
+        verifier,
+        "mutable action pin",
+    )
+    reject_mutant(
+        release,
+        candidate.replace("contents: read", "contents: write", 1),
+        verifier,
+        "candidate has write authority",
+    )
+    reject_mutant(
+        release,
+        candidate,
+        verifier.replace("release-candidate.yml", "release-please.yml", 1),
+        "verifier accepts the mixed preparation run",
+    )
+    reject_consumer_mutant(
+        consumer.replace("      - name: Record Typikon consumer receipt", "      - name: Removed receipt", 1),
+        "record step removed",
+    )
+    reject_consumer_mutant(
+        consumer.replace("if: github.event_name == 'pull_request'", "if: always()", 1),
+        "receipt writer not PR-only",
+    )
+    reject_consumer_mutant(
+        consumer.replace("043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "v7", 1),
+        "receipt uploader mutable",
+    )
+    for fragment in (
+        "--signer-workflow "
+        "forkwright/typikon/.github/workflows/release-candidate.yml",
+        '--source-digest "$R"',
+    ):
+        try:
+            validate_releasing_docs(releasing.replace(fragment, "removed", 1))
+        except ContractError:
+            pass
+        else:
+            raise AssertionError(
+                f"offline release documentation accepted missing binding: {fragment}"
+            )
+
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise ContractError("PyYAML is required for fail-closed workflow parsing") from exc
+    yaml.load(release, Loader=yaml.BaseLoader)
+    yaml.load(candidate, Loader=yaml.BaseLoader)
+
+    for script in (
+        VERIFIER,
+        ROOT / "ci" / "publish-locked-release.py",
+        ROOT / "ci" / "verify-published-release.py",
+    ):
+        result = subprocess.run(
+            [sys.executable, "-I", str(script), "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        require(
+            result.returncode == 0,
+            f"{script.name} cannot start under workflow isolation: {result.stderr}",
+        )
+
+    print("check-release-workflows: ok (authority, evidence, and phase mutants rejected)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check-static-server-template.py
+++ b/ci/check-static-server-template.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Prove generated workflows background and later kill the server process itself."""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT = ROOT / "ci" / "github-workflow.yml.tmpl"
+STEP = "      - name: Serve public-local/ for browser-based gates\n"
+NEXT_STEP = "      - name: pa11y (WCAG 2.1 AA)\n"
+DIRECT = "          python3 -m http.server --directory public-local 8080 &\n"
+PID = "          echo $! > /tmp/server.pid\n"
+TEARDOWN = "      - name: Tear down static server\n"
+
+
+def server_step(source: str) -> str:
+    if source.count(STEP) != 1 or source.count(NEXT_STEP) != 1:
+        raise ValueError("workflow must carry exactly one named server and pa11y step")
+    start = source.index(STEP)
+    end = source.index(NEXT_STEP, start)
+    return source[start:end]
+
+
+def named_step(source: str, marker: str) -> str:
+    if source.count(marker) != 1:
+        raise ValueError(f"workflow must carry exactly one {marker.strip()!r} step")
+    start = source.index(marker)
+    next_step = source.find("\n      - name:", start + len(marker))
+    return source[start:] if next_step == -1 else source[start : next_step + 1]
+
+
+def run_block(step: str) -> str:
+    marker = "        run: |\n"
+    if step.count(marker) != 1:
+        raise ValueError("workflow step must carry exactly one block run command")
+    lines: list[str] = []
+    for line in step.splitlines()[step.splitlines().index("        run: |") + 1 :]:
+        if line and not line.startswith("          "):
+            break
+        lines.append(line[10:] if line else "")
+    if not lines:
+        raise ValueError("workflow run block is empty")
+    return "\n".join(lines) + "\n"
+
+
+def unused_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def exercise_process_topology(source: str) -> None:
+    """Run the extracted server and teardown blocks against a scratch tree."""
+    server = run_block(server_step(source))
+    teardown = run_block(named_step(source, TEARDOWN))
+    port = unused_port()
+    pid = 0
+    process_group = 0
+    with tempfile.TemporaryDirectory(prefix="typikon-static-server-") as tmp:
+        root = Path(tmp)
+        public = root / "public-local"
+        public.mkdir()
+        sentinel = "typikon-static-server-sentinel"
+        (public / "index.html").write_text(sentinel, encoding="utf-8")
+        pid_file = root / "server.pid"
+        server = server.replace("8080", str(port)).replace("/tmp/server.pid", str(pid_file))
+        teardown = teardown.replace("/tmp/server.pid", str(pid_file))
+        try:
+            shell = subprocess.Popen(
+                ["bash", "-euo", "pipefail", "-c", server],
+                cwd=root,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            process_group = shell.pid
+            result = shell.wait(timeout=10)
+            if result:
+                raise RuntimeError(
+                    f"extracted server step exited {result}"
+                )
+            pid = int(pid_file.read_text(encoding="utf-8").strip())
+            cmdline = Path(f"/proc/{pid}/cmdline").read_bytes().replace(b"\0", b" ").decode()
+            expected = f"python3 -m http.server --directory public-local {port}"
+            if expected not in cmdline:
+                raise RuntimeError(f"$! names {cmdline!r}, not the direct server process")
+            body = ""
+            for _ in range(20):
+                try:
+                    with urllib.request.urlopen(
+                        f"http://127.0.0.1:{port}/", timeout=1
+                    ) as response:
+                        body = response.read().decode()
+                    break
+                except OSError:
+                    time.sleep(0.1)
+            if body != sentinel:
+                raise RuntimeError("recorded server PID did not serve public-local")
+            result = subprocess.run(
+                ["bash", "-euo", "pipefail", "-c", teardown],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+            if result.returncode:
+                raise RuntimeError(f"extracted teardown step failed: {result.stderr}")
+            for _ in range(30):
+                if not Path(f"/proc/{pid}").exists():
+                    break
+                time.sleep(0.1)
+            if Path(f"/proc/{pid}").exists():
+                raise RuntimeError("teardown left the recorded server process alive")
+        finally:
+            if pid and Path(f"/proc/{pid}").exists():
+                os.kill(pid, signal.SIGKILL)
+            if process_group:
+                try:
+                    os.killpg(process_group, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+
+def validate(source: str) -> list[str]:
+    errors: list[str] = []
+    try:
+        step = server_step(source)
+    except ValueError as exc:
+        return [str(exc)]
+    if step.count(DIRECT) != 1:
+        errors.append("server step must background the direct --directory invocation exactly once")
+    if step.count(PID) != 1:
+        errors.append("server step must persist the direct child PID exactly once")
+    if "cd public-local &&" in step:
+        errors.append("server step must not background a cd/python compound command")
+    if step.find(DIRECT) > step.find(PID):
+        errors.append("server must start before its PID is recorded")
+    return errors
+
+
+def main() -> int:
+    path = Path(sys.argv[1]) if len(sys.argv) == 2 else DEFAULT
+    if len(sys.argv) > 2:
+        print(f"usage: {Path(sys.argv[0]).name} [workflow]", file=sys.stderr)
+        return 2
+    source = path.read_text(encoding="utf-8")
+    errors = validate(source)
+    if errors:
+        for error in errors:
+            print(f"check-static-server-template: FAIL: {error}", file=sys.stderr)
+        return 1
+
+    if path == DEFAULT:
+        mutants = {
+            "compound-command": source.replace(
+                DIRECT,
+                "          cd public-local && python3 -m http.server 8080 &\n",
+                1,
+            ),
+            "subshell-child": source.replace(
+                DIRECT,
+                "          (python3 -m http.server --directory public-local 8080) &\n",
+                1,
+            ),
+            "missing-pid": source.replace(PID, "", 1),
+        }
+        for label, mutant in mutants.items():
+            if not validate(mutant):
+                print(
+                    f"check-static-server-template: FAIL: accepted {label} mutant",
+                    file=sys.stderr,
+                )
+                return 1
+    try:
+        exercise_process_topology(source)
+    except (OSError, RuntimeError, subprocess.SubprocessError, ValueError) as exc:
+        print(
+            f"check-static-server-template: FAIL: process topology: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"check-static-server-template: ok ({path})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check-tera2-contract.py
+++ b/ci/check-tera2-contract.py
@@ -10,6 +10,8 @@ fixtures. It does not replace that renderer proof.
 
 from __future__ import annotations
 
+import copy
+import json
 import re
 import sys
 from pathlib import Path
@@ -114,11 +116,79 @@ def check_pin_coherence() -> list[str]:
         detail = ", ".join(f"{path.relative_to(ROOT)}={value}" for path, value in hashes)
         failures.append(f"Zola artifact hashes disagree: {detail}")
 
+    try:
+        inventory = json.loads(
+            (ROOT / "release" / "components.json").read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(f"release/components.json: cannot read Zola inventory: {exc}")
+    else:
+        artifact_hash = hashes[0][1] if hashes else ""
+        failures.extend(check_inventory_zola_pin(inventory, default, artifact_hash))
+
     for path in (ROOT / "ci" / "github-workflow.yml.tmpl", ROOT / "ci" / "kanon-ci.toml.tmpl"):
         if "{{ ZOLA_VERSION }}" not in path.read_text(encoding="utf-8"):
             failures.append(f"{path.relative_to(ROOT)}: missing canonical ZOLA_VERSION placeholder")
 
     return failures
+
+
+def check_inventory_zola_pin(
+    inventory: object, version: str, artifact_hash: str
+) -> list[str]:
+    if not isinstance(inventory, dict) or not isinstance(
+        inventory.get("components"), list
+    ):
+        return ["release/components.json: components must be an array"]
+    rows = [
+        row
+        for row in inventory["components"]
+        if isinstance(row, dict) and row.get("name") == "Zola"
+    ]
+    if len(rows) != 1:
+        return ["release/components.json: expected exactly one Zola component"]
+    row = rows[0]
+    expected_url = (
+        "https://github.com/getzola/zola/releases/download/"
+        f"v{version}/zola-v{version}-x86_64-unknown-linux-gnu.tar.gz"
+    )
+    expected = {
+        "version": version,
+        "purl": f"pkg:github/getzola/zola@{version}?arch=x86_64&os=linux",
+        "hash": {
+            "kind": "external-distribution",
+            "url": expected_url,
+            "sha256": artifact_hash,
+        },
+    }
+    actual = {key: row.get(key) for key in expected}
+    if actual != expected:
+        return [
+            "release/components.json: Zola distribution differs from the runtime pin: "
+            f"{actual!r} != {expected!r}"
+        ]
+    return []
+
+
+def check_inventory_pin_witness() -> list[str]:
+    """Prove a drifted inventory digest is rejected by the coherence check."""
+    try:
+        inventory = json.loads(
+            (ROOT / "release" / "components.json").read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError):
+        return []
+    mutated = copy.deepcopy(inventory)
+    for row in mutated.get("components", []):
+        if isinstance(row, dict) and row.get("name") == "Zola":
+            row.get("hash", {})["sha256"] = "0" * 64
+    if not check_inventory_zola_pin(
+        mutated,
+        "0.23.3",
+        "f07c92607e5745268b576bd325ceef3a582aada253bb64db8d92a8a85303d958",
+    ):
+        return ["internal Zola inventory detector accepted a drifted artifact digest"]
+    return []
 
 
 def check_xml_preamble() -> list[str]:
@@ -177,6 +247,7 @@ def check_template_dialect() -> list[str]:
 def main() -> int:
     failures = [
         *check_pattern_witnesses(),
+        *check_inventory_pin_witness(),
         *check_pin_coherence(),
         *check_xml_preamble(),
         *check_template_dialect(),

--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -227,7 +227,10 @@ jobs:
         # and lychee already ran against public/ above and are
         # unaffected by this substitution.
         run: |
-          cd public-local && python3 -m http.server 8080 &
+          # WARNING: start Python itself in the background. A compound `cd ... &&
+          # python ... &` gives $! to a shell process and can leave the real
+          # server alive after teardown (forkwright/typikon#186).
+          python3 -m http.server --directory public-local 8080 &
           echo $! > /tmp/server.pid
           sleep 2
 
@@ -288,6 +291,27 @@ jobs:
         # borrows the budget of the nearest comparable stage rather than guessing.
         timeout-minutes: 2
         run: bash ci/consumer-check.sh
+
+      # A successful PR run is later eligible for a release-cohort lock only
+      # when its exact checkout, workflow, and Typikon gitlink are retained as
+      # machine-readable evidence. The job conclusion remains GitHub-owned and
+      # is verified separately; this step records the subject it evaluated.
+      - name: Record Typikon consumer receipt
+        if: github.event_name == 'pull_request'
+        run: |
+          python3 themes/typikon/ci/write-consumer-receipt.py \
+            --root "$GITHUB_WORKSPACE" \
+            --output /tmp/typikon-consumer-receipt.json
+
+      - name: Upload Typikon consumer receipt
+        if: github.event_name == 'pull_request'
+        id: typikon_receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: typikon-consumer-receipt-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/typikon-consumer-receipt.json
+          if-no-files-found: error
+          retention-days: 90
 
       # ── Deploy on green pushes to main only ───────────────────
       # Conditioned on ref being main (or master, for legacy consumer

--- a/ci/materialize-release-handoff.py
+++ b/ci/materialize-release-handoff.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Download and fail-closed extract one sealed same-run release handoff."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import stat
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from release_secret import SecretToken, require_secret
+
+MAX_BYTES = 64 * 1024 * 1024
+
+
+class HandoffError(RuntimeError):
+    pass
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        return None
+
+
+def request_json(url: str, token: SecretToken) -> Any:
+    token = require_secret(token)
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token.expose()}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "typikon-release-handoff",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        raise HandoffError(f"artifact metadata returned HTTP {exc.code}: {detail}") from exc
+
+
+def download_zip(
+    url: str, token: SecretToken, *, require_https: bool = True
+) -> bytes:
+    token = require_secret(token)
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/octet-stream",
+            "Authorization": f"Bearer {token.expose()}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "typikon-release-handoff",
+        },
+    )
+    opener = urllib.request.build_opener(NoRedirect)
+    try:
+        response = opener.open(request, timeout=30)
+    except urllib.error.HTTPError as exc:
+        if exc.code not in {301, 302, 303, 307, 308}:
+            raise HandoffError(f"artifact download returned HTTP {exc.code}") from exc
+        location = exc.headers.get("Location", "")
+    else:
+        with response:
+            payload = response.read(MAX_BYTES + 1)
+        if len(payload) > MAX_BYTES:
+            raise HandoffError("sealed handoff exceeds 64 MiB")
+        return payload
+    parsed = urllib.parse.urlsplit(location)
+    allowed_schemes = {"https"} if require_https else {"http", "https"}
+    if parsed.scheme not in allowed_schemes or not parsed.netloc or parsed.username:
+        raise HandoffError("artifact API returned an unsafe redirect URL")
+    unsigned = urllib.request.Request(
+        location, headers={"User-Agent": "typikon-release-handoff"}
+    )
+    try:
+        with urllib.request.urlopen(unsigned, timeout=60) as response:
+            payload = response.read(MAX_BYTES + 1)
+    except urllib.error.HTTPError as exc:
+        raise HandoffError(f"signed artifact download returned HTTP {exc.code}") from exc
+    if len(payload) > MAX_BYTES:
+        raise HandoffError("sealed handoff exceeds 64 MiB")
+    return payload
+
+
+def expected_names(tag: str) -> set[str]:
+    archive = f"typikon-{tag}.tar.gz"
+    return {
+        "candidate.json",
+        archive,
+        f"{archive}.sha256",
+        f"{archive}.cdx.json",
+        f"{archive}.provenance.intoto.jsonl",
+        f"{archive}.sbom.intoto.jsonl",
+        f"typikon-{tag}-compatibility-lock.json",
+        f"typikon-{tag}-tools-receipt.json",
+        f"typikon-{tag}-leather-receipt.json",
+    }
+
+
+def validate_metadata(
+    metadata: Any,
+    *,
+    artifact_id: int,
+    artifact_digest: str,
+    run_id: int,
+    run_attempt: int,
+    tag: str,
+) -> str:
+    expected_name = (
+        f"typikon-{tag}-verified-publication-{run_id}-{run_attempt}"
+    )
+    expected_digest = f"sha256:{artifact_digest.removeprefix('sha256:')}"
+    workflow_run = metadata.get("workflow_run") if isinstance(metadata, dict) else None
+    if (
+        not isinstance(metadata, dict)
+        or metadata.get("id") != artifact_id
+        or metadata.get("name") != expected_name
+        or metadata.get("expired") is not False
+        or metadata.get("digest") != expected_digest
+        or not isinstance(workflow_run, dict)
+        or workflow_run.get("id") != run_id
+    ):
+        raise HandoffError("sealed handoff metadata differs from this run")
+    return expected_digest
+
+
+def materialize_zip(raw: bytes, digest: str, tag: str, output: Path) -> None:
+    expected_digest = digest.removeprefix("sha256:")
+    actual_digest = hashlib.sha256(raw).hexdigest()
+    if expected_digest != actual_digest:
+        raise HandoffError(
+            f"sealed handoff digest differs: {actual_digest} != {expected_digest}"
+        )
+    try:
+        with zipfile.ZipFile(io.BytesIO(raw)) as archive:
+            infos = archive.infolist()
+            names = [item.filename for item in infos]
+            expected = expected_names(tag)
+            if len(names) != len(set(names)) or set(names) != expected:
+                raise HandoffError(
+                    f"sealed handoff members must be {sorted(expected)}, found {sorted(names)}"
+                )
+            total = 0
+            payloads: dict[str, bytes] = {}
+            for info in infos:
+                mode = stat.S_IFMT(info.external_attr >> 16)
+                if (
+                    info.is_dir()
+                    or info.flag_bits & 0x1
+                    or mode not in {0, stat.S_IFREG}
+                    or Path(info.filename).name != info.filename
+                    or info.file_size > MAX_BYTES
+                ):
+                    raise HandoffError(f"sealed handoff member is unsafe: {info.filename!r}")
+                total += info.file_size
+                if total > MAX_BYTES:
+                    raise HandoffError("sealed handoff expands beyond 64 MiB")
+                payloads[info.filename] = archive.read(info)
+    except zipfile.BadZipFile as exc:
+        raise HandoffError("sealed handoff is not a valid ZIP") from exc
+    output.mkdir(parents=True, exist_ok=False)
+    for name, payload in payloads.items():
+        destination = output / name
+        with destination.open("xb") as handle:
+            handle.write(payload)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--artifact-id", required=True, type=int)
+    parser.add_argument("--artifact-digest", required=True)
+    parser.add_argument("--run-id", required=True, type=int)
+    parser.add_argument("--run-attempt", required=True, type=int)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        try:
+            token = SecretToken.from_env("GITHUB_TOKEN")
+        except ValueError:
+            token = None
+        if not args.repository or token is None:
+            raise HandoffError("GITHUB_REPOSITORY and GITHUB_TOKEN are required")
+        root = f"https://api.github.com/repos/{args.repository}"
+        metadata = request_json(
+            f"{root}/actions/artifacts/{args.artifact_id}", token
+        )
+        expected_digest = validate_metadata(
+            metadata,
+            artifact_id=args.artifact_id,
+            artifact_digest=args.artifact_digest,
+            run_id=args.run_id,
+            run_attempt=args.run_attempt,
+            tag=args.tag,
+        )
+        raw = download_zip(
+            f"{root}/actions/artifacts/{args.artifact_id}/zip", token
+        )
+        materialize_zip(raw, expected_digest, args.tag, args.output)
+        print(
+            json.dumps(
+                {
+                    "status": "pass",
+                    "artifact_id": args.artifact_id,
+                    "sha256": hashlib.sha256(raw).hexdigest(),
+                },
+                sort_keys=True,
+            )
+        )
+    except (HandoffError, OSError, ValueError, TypeError) as exc:
+        print(f"materialize-release-handoff: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/publish-locked-release.py
+++ b/ci/publish-locked-release.py
@@ -1,0 +1,724 @@
+#!/usr/bin/env python3
+"""Idempotently publish one compatibility-locked Typikon release."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import mimetypes
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from release_archive import ArchiveError, verify_archive
+from release_secret import SecretToken, require_secret
+
+MAX_ASSET_BYTES = 64 * 1024 * 1024
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class PublishError(RuntimeError):
+    pass
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        return None
+
+
+def digest_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def git_bytes(*args: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), *args],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode:
+        raise PublishError(
+            result.stderr.decode(errors="replace").strip()
+            or f"git {' '.join(args)} failed"
+        )
+    return result.stdout
+
+
+def changelog_notes(candidate: str, version: str) -> str:
+    text = git_bytes("show", f"{candidate}:CHANGELOG.md").decode()
+    header = re.compile(rf"^## \[{re.escape(version)}\].*$", re.MULTILINE)
+    matches = list(header.finditer(text))
+    if len(matches) != 1:
+        raise PublishError(
+            f"candidate CHANGELOG must contain exactly one heading for {version}"
+        )
+    start = matches[0].end()
+    following = re.search(r"^## ", text[start:], re.MULTILINE)
+    end = start + following.start() if following else len(text)
+    notes = text[start:end].strip()
+    if not notes:
+        raise PublishError("candidate CHANGELOG release notes are empty")
+    return notes
+
+
+def exact_tag_message(tag: str, lock_sha256: str) -> str:
+    return f"Typikon {tag}\n\nCompatibility-Lock-SHA256: {lock_sha256}"
+
+
+def api_download(url: str, token: SecretToken) -> bytes:
+    token = require_secret(token)
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/octet-stream",
+            "Authorization": f"Bearer {token.expose()}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "typikon-release-publisher",
+        },
+    )
+    opener = urllib.request.build_opener(NoRedirect)
+    try:
+        response = opener.open(request, timeout=30)
+    except urllib.error.HTTPError as exc:
+        if exc.code not in {301, 302, 303, 307, 308}:
+            raise PublishError(f"asset API returned HTTP {exc.code}") from exc
+        location = exc.headers.get("Location", "")
+    else:
+        with response:
+            payload = response.read(MAX_ASSET_BYTES + 1)
+        if len(payload) > MAX_ASSET_BYTES:
+            raise PublishError("release asset exceeds 64 MiB")
+        return payload
+    parsed = urllib.parse.urlsplit(location)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.username:
+        raise PublishError("asset API returned an unsafe redirect URL")
+    unsigned = urllib.request.Request(
+        location, headers={"User-Agent": "typikon-release-publisher"}
+    )
+    with urllib.request.urlopen(unsigned, timeout=60) as response:
+        payload = response.read(MAX_ASSET_BYTES + 1)
+    if len(payload) > MAX_ASSET_BYTES:
+        raise PublishError("release asset exceeds 64 MiB")
+    return payload
+
+
+class GitHubApi:
+    def __init__(self, repository: str, token: SecretToken):
+        self.repository = repository
+        self.token = require_secret(token)
+        self.api_root = f"https://api.github.com/repos/{repository}"
+
+    def json(
+        self,
+        method: str,
+        endpoint: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        missing_ok: bool = False,
+    ) -> Any:
+        data = None if payload is None else json.dumps(payload).encode()
+        url = self.api_root if not endpoint else f"{self.api_root}/{endpoint}"
+        request = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token.expose()}",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "typikon-release-publisher",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                raw = response.read()
+                return None if not raw else json.loads(raw)
+        except urllib.error.HTTPError as exc:
+            if missing_ok and exc.code == 404:
+                return None
+            detail = exc.read().decode(errors="replace")
+            raise PublishError(
+                f"GitHub {method} {endpoint} returned {exc.code}: {detail}"
+            ) from exc
+
+    def get_ref(self, tag: str) -> dict[str, Any] | None:
+        return self.json("GET", f"git/ref/tags/{tag}", missing_ok=True)
+
+    def get_branch_head(self, branch: str) -> str:
+        value = self.json("GET", f"git/ref/heads/{branch}")
+        head = value.get("object", {}).get("sha")
+        if not isinstance(head, str):
+            raise PublishError(f"refs/heads/{branch} has no object id")
+        return head
+
+    def get_default_branch(self) -> str:
+        value = self.json("GET", "")
+        branch = value.get("default_branch")
+        if not isinstance(branch, str):
+            raise PublishError("repository has no default branch")
+        return branch
+
+    def create_tag(self, tag: str, message: str, candidate: str) -> dict[str, Any]:
+        return self.json(
+            "POST",
+            "git/tags",
+            {"tag": tag, "message": message, "object": candidate, "type": "commit"},
+        )
+
+    def create_ref(self, tag: str, tag_object: str) -> None:
+        self.json(
+            "POST", "git/refs", {"ref": f"refs/tags/{tag}", "sha": tag_object}
+        )
+
+    def get_tag(self, object_id: str) -> dict[str, Any]:
+        return self.json("GET", f"git/tags/{object_id}")
+
+    def get_release(self, tag: str) -> dict[str, Any] | None:
+        # GitHub's release-by-tag endpoint returns published releases only.
+        # Publication is deliberately staged through a draft, so use the
+        # authenticated list endpoint and exact-match the tag across every
+        # page. Treat duplicates as corruption instead of selecting one.
+        matches: list[dict[str, Any]] = []
+        for page in range(1, 101):
+            value = self.json("GET", f"releases?per_page=100&page={page}")
+            if not isinstance(value, list):
+                raise PublishError("release list response is not a list")
+            matches.extend(
+                release for release in value if release.get("tag_name") == tag
+            )
+            if len(value) < 100:
+                break
+        else:
+            raise PublishError("release list exceeded 10,000 records")
+        if len(matches) > 1:
+            raise PublishError(f"multiple releases name tag {tag}")
+        return matches[0] if matches else None
+
+    def create_release(
+        self, tag: str, candidate: str, name: str, body: str
+    ) -> dict[str, Any]:
+        return self.json(
+            "POST",
+            "releases",
+            {
+                "tag_name": tag,
+                "target_commitish": candidate,
+                "name": name,
+                "body": body,
+                "draft": True,
+                "prerelease": False,
+            },
+        )
+
+    def list_assets(self, release_id: int) -> list[dict[str, Any]]:
+        result: list[dict[str, Any]] = []
+        for page in range(1, 101):
+            value = self.json(
+                "GET", f"releases/{release_id}/assets?per_page=100&page={page}"
+            )
+            if not isinstance(value, list):
+                raise PublishError("release asset response is not a list")
+            result.extend(value)
+            if len(value) < 100:
+                return result
+        raise PublishError("release asset list exceeded 10,000 records")
+
+    def download_asset(self, asset_id: int) -> bytes:
+        return api_download(
+            f"{self.api_root}/releases/assets/{asset_id}", self.token
+        )
+
+    def upload_asset(self, release_id: int, name: str, payload: bytes) -> dict[str, Any]:
+        query = urllib.parse.urlencode({"name": name})
+        content_type = mimetypes.guess_type(name)[0] or "application/octet-stream"
+        request = urllib.request.Request(
+            f"https://uploads.github.com/repos/{self.repository}/releases/{release_id}/assets?{query}",
+            data=payload,
+            method="POST",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token.expose()}",
+                "Content-Type": content_type,
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "typikon-release-publisher",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode(errors="replace")
+            raise PublishError(f"release asset upload returned {exc.code}: {detail}") from exc
+
+    def delete_asset(self, asset_id: int) -> None:
+        self.json("DELETE", f"releases/assets/{asset_id}")
+
+    def publish_release(self, release_id: int) -> dict[str, Any]:
+        return self.json("PATCH", f"releases/{release_id}", {"draft": False})
+
+
+def expected_asset_names(tag: str) -> set[str]:
+    return {
+        "candidate.json",
+        f"typikon-{tag}.tar.gz",
+        f"typikon-{tag}.tar.gz.sha256",
+        f"typikon-{tag}.tar.gz.cdx.json",
+        f"typikon-{tag}.tar.gz.provenance.intoto.jsonl",
+        f"typikon-{tag}.tar.gz.sbom.intoto.jsonl",
+        f"typikon-{tag}-compatibility-lock.json",
+        f"typikon-{tag}-tools-receipt.json",
+        f"typikon-{tag}-leather-receipt.json",
+    }
+
+
+def expected_assets(directory: Path, tag: str) -> dict[str, bytes]:
+    names = expected_asset_names(tag)
+    actual = {path.name for path in directory.iterdir() if path.is_file()}
+    if actual != names:
+        raise PublishError(
+            f"release staging members must be {sorted(names)}, found {sorted(actual)}"
+        )
+    payloads = {name: (directory / name).read_bytes() for name in sorted(names)}
+    if any(len(payload) > MAX_ASSET_BYTES for payload in payloads.values()):
+        raise PublishError("release staging contains an asset over 64 MiB")
+    return payloads
+
+
+def validate_staged_evidence(
+    payloads: dict[str, bytes],
+    tag: str,
+    candidate: str,
+    lock_sha256: str,
+    tracked_lock: Path,
+) -> dict[str, Any]:
+    resolved_lock = tracked_lock.resolve()
+    compatibility_root = (ROOT / "release" / "compatibility").resolve()
+    if (
+        compatibility_root not in resolved_lock.parents
+        or resolved_lock.suffix != ".json"
+        or not resolved_lock.is_file()
+    ):
+        raise PublishError("tracked lock path is not a compatibility JSON")
+    relative_lock = resolved_lock.relative_to(ROOT).as_posix()
+    git_bytes("ls-files", "--error-unmatch", "--", relative_lock)
+    lock_name = f"typikon-{tag}-compatibility-lock.json"
+    lock_bytes = payloads[lock_name]
+    tracked_lock_bytes = resolved_lock.read_bytes()
+    if lock_bytes != tracked_lock_bytes:
+        raise PublishError("sealed compatibility lock differs from the tracked lock")
+    if digest_bytes(lock_bytes) != lock_sha256:
+        raise PublishError("staged compatibility lock digest differs from the verifier")
+    try:
+        lock = json.loads(lock_bytes)
+        manifest = json.loads(payloads["candidate.json"])
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PublishError(f"staged evidence JSON is invalid: {exc}") from exc
+    release = lock.get("release", {})
+    if release.get("tag") != tag or release.get("candidate_commit") != candidate:
+        raise PublishError("staged compatibility lock names another release subject")
+    candidate_release = manifest.get("release", {})
+    if candidate_release.get("tag") != tag or candidate_release.get(
+        "candidate_commit"
+    ) != candidate:
+        raise PublishError("staged candidate manifest names another release subject")
+    artifact = lock.get("candidate_artifact")
+    if not isinstance(artifact, dict):
+        raise PublishError("staged compatibility lock has no candidate artifact")
+    for kind in ("archive", "checksum", "sbom"):
+        item = manifest.get(kind, {})
+        name = item.get("name")
+        if not isinstance(name, str) or name not in payloads:
+            raise PublishError(f"staged candidate {kind} member is missing")
+        value = payloads[name]
+        if item.get("sha256") != digest_bytes(value) or item.get("size") != len(value):
+            raise PublishError(f"staged candidate {kind} bytes differ from the manifest")
+        expected = {
+            "name": artifact.get(f"{kind}_name"),
+            "sha256": artifact.get(f"{kind}_sha256"),
+            "size": artifact.get(f"{kind}_size"),
+        }
+        if item != expected:
+            raise PublishError(f"staged candidate {kind} differs from the tracked lock")
+    try:
+        verify_archive(payloads[manifest["archive"]["name"]], ROOT, candidate)
+    except ArchiveError as exc:
+        raise PublishError(str(exc)) from exc
+    checksum = manifest["checksum"]
+    expected_checksum = (
+        f"{manifest['archive']['sha256']}  {manifest['archive']['name']}\n".encode()
+    )
+    if payloads[checksum["name"]] != expected_checksum:
+        raise PublishError("staged checksum is not the canonical sha256sum record")
+    notes = manifest.get("notes")
+    if not isinstance(notes, dict) or set(notes) != {"body", "sha256", "size"}:
+        raise PublishError("staged candidate release notes are invalid")
+    body = notes.get("body")
+    if not isinstance(body, str) or not body:
+        raise PublishError("staged candidate release notes are empty")
+    body_bytes = body.encode("utf-8")
+    if notes.get("sha256") != digest_bytes(body_bytes) or notes.get("size") != len(
+        body_bytes
+    ):
+        raise PublishError("staged candidate release notes digest or size differs")
+    if body != changelog_notes(candidate, str(release.get("version", ""))):
+        raise PublishError("staged release notes differ from the candidate CHANGELOG")
+    attestations = manifest.get("attestations")
+    if not isinstance(attestations, dict) or set(attestations) != {"provenance", "sbom"}:
+        raise PublishError("staged candidate attestation manifest is incomplete")
+    for kind in ("provenance", "sbom"):
+        item = attestations[kind]
+        if not isinstance(item, dict) or set(item) != {"name", "sha256", "size"}:
+            raise PublishError(f"staged candidate {kind} attestation manifest is invalid")
+        name = item.get("name")
+        if not isinstance(name, str) or name not in payloads:
+            raise PublishError(f"staged candidate {kind} attestation bundle is missing")
+        value = payloads[name]
+        if item.get("sha256") != digest_bytes(value) or item.get("size") != len(value):
+            raise PublishError(
+                f"staged candidate {kind} attestation bytes differ from the manifest"
+            )
+        expected = {
+            "name": artifact.get(f"{kind}_bundle_name"),
+            "sha256": artifact.get(f"{kind}_bundle_sha256"),
+            "size": artifact.get(f"{kind}_bundle_size"),
+        }
+        if item != expected:
+            raise PublishError(
+                f"staged candidate {kind} attestation differs from the tracked lock"
+            )
+    expected_receipts = {
+        "tools": f"typikon-{tag}-tools-receipt.json",
+        "leather": f"typikon-{tag}-leather-receipt.json",
+    }
+    consumers = lock.get("consumers")
+    if not isinstance(consumers, list) or [item.get("id") for item in consumers] != [
+        "tools",
+        "leather",
+    ]:
+        raise PublishError("staged lock cohort is not Tools then Leather")
+    for consumer in consumers:
+        name = expected_receipts[consumer["id"]]
+        receipt_path = (ROOT / str(consumer.get("receipt_path", ""))).resolve()
+        if ROOT not in receipt_path.parents or not receipt_path.is_file():
+            raise PublishError(f"tracked {consumer['id']} receipt path is unsafe or missing")
+        git_bytes(
+            "ls-files",
+            "--error-unmatch",
+            "--",
+            receipt_path.relative_to(ROOT).as_posix(),
+        )
+        if payloads[name] != receipt_path.read_bytes():
+            raise PublishError(f"sealed {consumer['id']} receipt differs from tracked bytes")
+        if digest_bytes(payloads[name]) != consumer.get("receipt_sha256"):
+            raise PublishError(f"staged {consumer['id']} receipt differs from the lock")
+    return lock
+
+
+def validate_tag(
+    api: Any, ref: dict[str, Any], tag: str, candidate: str, message: str
+) -> str:
+    subject = ref.get("object", {})
+    if subject.get("type") != "tag" or not isinstance(subject.get("sha"), str):
+        raise PublishError(f"refs/tags/{tag} is not an annotated tag")
+    object_id = subject["sha"]
+    document = api.get_tag(object_id)
+    expected = {
+        "tag": tag,
+        "message": message,
+        "type": "commit",
+        "candidate": candidate,
+    }
+    actual = {
+        "tag": document.get("tag"),
+        "message": document.get("message"),
+        "type": document.get("object", {}).get("type"),
+        "candidate": document.get("object", {}).get("sha"),
+    }
+    if actual != expected:
+        raise PublishError(f"annotated tag identity drifted: {actual!r} != {expected!r}")
+    return object_id
+
+
+def require_main_head(api: Any, evidence_commit: str) -> None:
+    if api.get_default_branch() != "main":
+        raise PublishError("repository default branch is not main")
+    if api.get_branch_head("main") != evidence_commit:
+        raise PublishError("main moved away from the verified evidence commit")
+
+
+def ensure_tag(
+    api: Any,
+    tag: str,
+    candidate: str,
+    message: str,
+    evidence_commit: str,
+) -> str:
+    ref = api.get_ref(tag)
+    if ref is None:
+        # Every staged byte is exact before this boundary. These repeated
+        # guards narrow the only unavoidable cross-ref race:
+        # GitHub exposes tag-object and tag-ref creation as separate REST calls.
+        require_main_head(api, evidence_commit)
+        created = api.create_tag(tag, message, candidate)
+        object_id = created.get("sha")
+        if not isinstance(object_id, str):
+            raise PublishError("tag-object creation returned no object id")
+        require_main_head(api, evidence_commit)
+        try:
+            api.create_ref(tag, object_id)
+        except PublishError:
+            # A competing exact retry may have created the ref after our read.
+            ref = api.get_ref(tag)
+            if ref is None:
+                raise
+        else:
+            ref = api.get_ref(tag)
+    if ref is None:
+        raise PublishError(f"refs/tags/{tag} was not created")
+    object_id = validate_tag(api, ref, tag, candidate, message)
+    # If main moved during the ref POST, leave only the exact provisional tag.
+    # Do not try to restore an old main tip. Resolving that public residue is a
+    # separate destructive recovery action with its own review boundary.
+    require_main_head(api, evidence_commit)
+    return object_id
+
+
+def release_marker(candidate: str, lock_sha256: str) -> str:
+    return (
+        f"Candidate commit: `{candidate}`\n"
+        f"Compatibility lock SHA-256: `{lock_sha256}`"
+    )
+
+
+def exact_release_body(
+    payloads: dict[str, bytes], candidate: str, lock_sha256: str
+) -> str:
+    try:
+        manifest = json.loads(payloads["candidate.json"])
+        notes = manifest["notes"]["body"]
+    except (UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise PublishError(f"candidate release notes cannot be read: {exc}") from exc
+    if not isinstance(notes, str) or not notes:
+        raise PublishError("candidate release notes body is empty")
+    return f"{notes}\n\n{release_marker(candidate, lock_sha256)}\n"
+
+
+def validate_release(
+    release: dict[str, Any],
+    tag: str,
+    expected_body: str,
+) -> None:
+    # The annotated tag ref/object is the release subject authority.
+    # GitHub documents target_commitish as unused when tag_name already exists
+    # and may report the default branch for such releases, so it is not an
+    # identity field after ensure_tag() has established the exact commit.
+    if (
+        release.get("tag_name") != tag
+        or release.get("name") != f"Typikon {tag}"
+        or release.get("prerelease") is not False
+        or release.get("body") != expected_body
+    ):
+        raise PublishError("release identity differs from the compatibility lock")
+
+
+def reconcile_assets(
+    api: Any,
+    release: dict[str, Any],
+    payloads: dict[str, bytes],
+    *,
+    allow_upload: bool,
+) -> None:
+    assets = api.list_assets(int(release["id"]))
+    by_name: dict[str, list[dict[str, Any]]] = {}
+    for asset in assets:
+        by_name.setdefault(str(asset.get("name")), []).append(asset)
+    if set(by_name) - set(payloads):
+        raise PublishError(
+            f"release has unexpected assets: {sorted(set(by_name) - set(payloads))}"
+        )
+    for name, expected in payloads.items():
+        matches = by_name.get(name, [])
+        if len(matches) > 1:
+            raise PublishError(f"release has duplicate asset {name}")
+        if not matches:
+            if not allow_upload:
+                raise PublishError(f"published release is missing asset {name}")
+            api.upload_asset(int(release["id"]), name, expected)
+            continue
+        asset = matches[0]
+        if asset.get("state") == "starter" and allow_upload:
+            # GitHub can leave a zero-byte starter record after an upstream
+            # 502. Deleting only that exact draft residue makes retry safe.
+            api.delete_asset(int(asset["id"]))
+            api.upload_asset(int(release["id"]), name, expected)
+            continue
+        if asset.get("state") not in {None, "uploaded"}:
+            raise PublishError(f"release asset {name} is not uploaded")
+        actual = api.download_asset(int(asset["id"]))
+        if actual != expected:
+            raise PublishError(
+                f"release asset {name} differs: {digest_bytes(actual)} != {digest_bytes(expected)}"
+            )
+
+
+def inspect(
+    api: Any,
+    tag: str,
+    candidate: str,
+    lock_sha256: str,
+    payloads: dict[str, bytes],
+) -> str:
+    ref = api.get_ref(tag)
+    if ref is None:
+        if api.get_release(tag) is not None:
+            raise PublishError("release exists without its annotated tag")
+        return "absent"
+    validate_tag(api, ref, tag, candidate, exact_tag_message(tag, lock_sha256))
+    release = api.get_release(tag)
+    if release is None:
+        return "tagged"
+    expected_body = exact_release_body(payloads, candidate, lock_sha256)
+    validate_release(release, tag, expected_body)
+    if release.get("draft") is False:
+        reconcile_assets(api, release, payloads, allow_upload=False)
+        return "published"
+    if release.get("draft") is not True:
+        raise PublishError("release draft state is neither true nor false")
+    # Drafts may be partially populated after an interrupted upload. Existing
+    # names must already be exact; missing names are repaired by publish().
+    existing = api.list_assets(int(release["id"]))
+    for asset in existing:
+        name = str(asset.get("name"))
+        if name not in payloads:
+            raise PublishError(f"draft release has unexpected asset {name}")
+        if asset.get("state") == "starter":
+            continue
+        actual = api.download_asset(int(asset["id"]))
+        if actual != payloads[name]:
+            raise PublishError(f"draft release asset {name} differs from staged bytes")
+    return "draft"
+
+
+def publish(
+    api: Any,
+    tag: str,
+    candidate: str,
+    lock_sha256: str,
+    payloads: dict[str, bytes],
+    evidence_commit: str,
+) -> str:
+    require_main_head(api, evidence_commit)
+    state = inspect(api, tag, candidate, lock_sha256, payloads)
+    if state == "published":
+        require_main_head(api, evidence_commit)
+        return state
+    message = exact_tag_message(tag, lock_sha256)
+    ensure_tag(api, tag, candidate, message, evidence_commit)
+    expected_body = exact_release_body(payloads, candidate, lock_sha256)
+    release = api.get_release(tag)
+    if release is None:
+        release = api.create_release(
+            tag, candidate, f"Typikon {tag}", expected_body
+        )
+    validate_release(release, tag, expected_body)
+    if release.get("draft") is False:
+        reconcile_assets(api, release, payloads, allow_upload=False)
+        require_main_head(api, evidence_commit)
+        return "published"
+    if release.get("draft") is not True:
+        raise PublishError("release draft state is neither true nor false")
+    reconcile_assets(api, release, payloads, allow_upload=True)
+    # Re-read every byte after all uploads and before the irreversible publish.
+    release = api.get_release(tag)
+    if release is None:
+        raise PublishError("draft release disappeared before publication")
+    validate_release(release, tag, expected_body)
+    reconcile_assets(api, release, payloads, allow_upload=False)
+    require_main_head(api, evidence_commit)
+    api.publish_release(int(release["id"]))
+    final = api.get_release(tag)
+    if final is None or final.get("draft") is not False:
+        raise PublishError("release did not become public")
+    validate_release(final, tag, expected_body)
+    final_ref = api.get_ref(tag)
+    if final_ref is None:
+        raise PublishError("annotated tag disappeared after publication")
+    validate_tag(
+        api,
+        final_ref,
+        tag,
+        candidate,
+        message,
+    )
+    reconcile_assets(api, final, payloads, allow_upload=False)
+    # Detection after the irreversible PATCH cannot make the two GitHub REST
+    # writes atomic. It does ensure branch movement never returns a green
+    # publication receipt; the exact public release becomes reviewed residue.
+    require_main_head(api, evidence_commit)
+    return "published"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("inspect", "publish"))
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--lock-sha256", required=True)
+    parser.add_argument("--evidence-commit", required=True)
+    parser.add_argument("--assets-dir", required=True, type=Path)
+    parser.add_argument("--tracked-lock", required=True, type=Path)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+    try:
+        try:
+            token = SecretToken.from_env("GITHUB_TOKEN")
+        except ValueError:
+            token = None
+        if not args.repository or token is None:
+            raise PublishError("GITHUB_REPOSITORY and GITHUB_TOKEN are required")
+        payloads = expected_assets(args.assets_dir, args.tag)
+        lock = validate_staged_evidence(
+            payloads,
+            args.tag,
+            args.candidate,
+            args.lock_sha256,
+            args.tracked_lock,
+        )
+        api = GitHubApi(args.repository, token)
+        if args.command == "inspect":
+            state = inspect(api, args.tag, args.candidate, args.lock_sha256, payloads)
+        else:
+            state = publish(
+                api,
+                args.tag,
+                args.candidate,
+                args.lock_sha256,
+                payloads,
+                args.evidence_commit,
+            )
+        if args.github_output:
+            with args.github_output.open("a", encoding="utf-8") as handle:
+                handle.write(f"state={state}\n")
+                handle.write(f"candidate_commit={lock['release']['candidate_commit']}\n")
+                handle.write(f"lock_sha256={digest_bytes(args.tracked_lock.read_bytes())}\n")
+                handle.write(f"release_pr={lock['release']['release_pr']}\n")
+                handle.write(f"tag={lock['release']['tag']}\n")
+        print(json.dumps({"status": "pass", "publication_state": state}, sort_keys=True))
+    except (PublishError, OSError, ValueError, KeyError, TypeError) as exc:
+        print(f"publish-locked-release: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/release_archive.py
+++ b/ci/release_archive.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Verify a frozen Git source archive by content, independent of gzip bytes."""
+
+from __future__ import annotations
+
+import io
+import subprocess
+import tarfile
+from pathlib import Path
+
+MAX_ARCHIVE_BYTES = 64 * 1024 * 1024
+MAX_ARCHIVE_CONTENT_BYTES = 64 * 1024 * 1024
+
+
+class ArchiveError(RuntimeError):
+    pass
+
+
+def git_bytes(root: Path, *args: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode:
+        raise ArchiveError(
+            result.stderr.decode(errors="replace").strip()
+            or f"git {' '.join(args)} failed"
+        )
+    return result.stdout
+
+
+def tree_entries(root: Path, revision: str) -> dict[str, tuple[str, bytes]]:
+    raw = git_bytes(root, "ls-tree", "-rz", "--full-tree", "-r", revision)
+    entries: dict[str, tuple[str, bytes]] = {}
+    for record in raw.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, raw_path = record.split(b"\t", 1)
+            mode, kind, object_id = metadata.decode("ascii").split()
+            path = raw_path.decode("utf-8", errors="surrogateescape")
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise ArchiveError("git tree contains an unparseable entry") from exc
+        if kind != "blob" or mode not in {"100644", "100755", "120000"}:
+            raise ArchiveError(
+                f"release tree entry {path!r} has unsupported mode/type {mode} {kind}"
+            )
+        if path in entries:
+            raise ArchiveError(f"release tree contains duplicate path {path!r}")
+        entries[path] = (mode, git_bytes(root, "cat-file", "blob", object_id))
+    return entries
+
+
+def verify_archive(payload: bytes, root: Path, revision: str) -> None:
+    if len(payload) > MAX_ARCHIVE_BYTES:
+        raise ArchiveError("source archive exceeds 64 MiB")
+    expected = tree_entries(root, revision)
+    observed: dict[str, tuple[str, int, bytes | str]] = {}
+    expected_directories = {
+        parent.as_posix()
+        for path in expected
+        for parent in Path(path).parents
+        if parent != Path(".")
+    }
+    observed_directories: set[str] = set()
+    total_content_bytes = 0
+    try:
+        with tarfile.open(fileobj=io.BytesIO(payload), mode="r:gz") as archive:
+            if archive.pax_headers.get("comment") != revision:
+                raise ArchiveError("source archive does not bind the candidate commit")
+            for member in archive.getmembers():
+                path = member.name.rstrip("/") if member.isdir() else member.name
+                parts = Path(path).parts
+                if (
+                    not path
+                    or Path(path).is_absolute()
+                    or ".." in parts
+                    or path in observed
+                    or path in observed_directories
+                ):
+                    raise ArchiveError(f"source archive member is unsafe: {member.name!r}")
+                if member.isdir():
+                    if member.mode & 0o7777 != 0o775:
+                        raise ArchiveError(
+                            f"source archive directory mode differs at {path}"
+                        )
+                    observed_directories.add(path)
+                    continue
+                if member.isfile():
+                    handle = archive.extractfile(member)
+                    if handle is None:
+                        raise ArchiveError(f"source archive cannot read {path!r}")
+                    value: bytes | str = handle.read(MAX_ARCHIVE_BYTES + 1)
+                    if len(value) > MAX_ARCHIVE_BYTES:
+                        raise ArchiveError(f"source archive member is too large: {path!r}")
+                    total_content_bytes += len(value)
+                    kind = "file"
+                elif member.issym():
+                    value = member.linkname
+                    total_content_bytes += len(value.encode("utf-8", errors="surrogateescape"))
+                    kind = "symlink"
+                else:
+                    raise ArchiveError(
+                        f"source archive contains a special member: {member.name!r}"
+                    )
+                if total_content_bytes > MAX_ARCHIVE_CONTENT_BYTES:
+                    raise ArchiveError("source archive expands beyond 64 MiB")
+                observed[path] = (kind, member.mode & 0o7777, value)
+    except (tarfile.TarError, OSError) as exc:
+        raise ArchiveError(f"source archive is invalid: {exc}") from exc
+
+    if observed_directories != expected_directories:
+        raise ArchiveError(
+            "source archive directories differ from the candidate tree: "
+            f"missing={sorted(expected_directories - observed_directories)}, "
+            f"extra={sorted(observed_directories - expected_directories)}"
+        )
+    if set(observed) != set(expected):
+        raise ArchiveError(
+            "source archive paths differ from the candidate tree: "
+            f"missing={sorted(set(expected) - set(observed))}, "
+            f"extra={sorted(set(observed) - set(expected))}"
+        )
+    for path, (mode, blob) in expected.items():
+        kind, archived_mode, value = observed[path]
+        if mode == "120000":
+            target = blob.decode("utf-8", errors="surrogateescape")
+            if kind != "symlink" or archived_mode != 0o777 or value != target:
+                raise ArchiveError(f"source archive symlink differs at {path}")
+            continue
+        expected_mode = 0o775 if mode == "100755" else 0o664
+        if (
+            kind != "file"
+            or archived_mode != expected_mode
+            or value != blob
+        ):
+            raise ArchiveError(f"source archive file differs at {path}")

--- a/ci/release_secret.py
+++ b/ci/release_secret.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Opaque token boundary for the stdlib-only release control scripts."""
+
+from __future__ import annotations
+
+import hmac
+import os
+
+
+class SecretToken:
+    """Keep credential values out of ordinary string/logging paths."""
+
+    __slots__ = ("__value",)
+
+    def __init__(self, value: str):
+        if type(value) is not str or not value:
+            raise ValueError("secret token must be a non-empty string")
+        self.__value = value
+
+    @classmethod
+    def from_env(cls, name: str) -> "SecretToken":
+        value = os.environ.get(name)
+        if not value:
+            raise ValueError(f"{name} is not set")
+        return cls(value)
+
+    def expose(self) -> str:
+        """Return the inner value only at the Authorization-header use site."""
+
+        return self.__value
+
+    def matches(self, other: "SecretToken") -> bool:
+        if not isinstance(other, SecretToken):
+            return False
+        return hmac.compare_digest(self.__value, other.__value)
+
+    def __str__(self) -> str:
+        return "[REDACTED]"
+
+    def __repr__(self) -> str:
+        return "SecretToken([REDACTED])"
+
+
+def require_secret(value: object) -> SecretToken:
+    if not isinstance(value, SecretToken):
+        raise TypeError("credential boundary requires SecretToken")
+    return value

--- a/ci/verify-published-release.py
+++ b/ci/verify-published-release.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Require an exact published predecessor before Release Please advances."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.machinery
+import importlib.util
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from release_secret import SecretToken
+
+PUBLISHER_SCRIPT = Path(__file__).resolve().parent / "publish-locked-release.py"
+PUBLISHER_LOADER = importlib.machinery.SourceFileLoader(
+    "publish_locked_release", str(PUBLISHER_SCRIPT)
+)
+PUBLISHER_SPEC = importlib.util.spec_from_loader(
+    PUBLISHER_LOADER.name, PUBLISHER_LOADER
+)
+assert PUBLISHER_SPEC is not None
+publisher = importlib.util.module_from_spec(PUBLISHER_SPEC)
+PUBLISHER_LOADER.exec_module(publisher)
+
+ROOT = Path(__file__).resolve().parent.parent
+SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+LEGACY = {
+    "version": "0.5.0",
+    "tag": "v0.5.0",
+    "commit": "f0da785dad30d15790929040a5c0f67f0b9cfb54",
+    "release_id": 372569747,
+    "body_sha256": "94b65ccc22705ee6b534a73c006d83d4e9c4357c962fc49d46ac199d285498fd",
+}
+
+
+class PublishedReleaseError(RuntimeError):
+    pass
+
+
+def verify_legacy(api: Any, version: str) -> None:
+    if version != LEGACY["version"]:
+        raise PublishedReleaseError("version is not the one explicit legacy bootstrap")
+    ref = api.get_ref(str(LEGACY["tag"]))
+    object_identity = ref.get("object") if isinstance(ref, dict) else None
+    if (
+        not isinstance(object_identity, dict)
+        or object_identity.get("type") != "commit"
+        or object_identity.get("sha") != LEGACY["commit"]
+    ):
+        raise PublishedReleaseError("legacy bootstrap tag identity drifted")
+    release = api.get_release(str(LEGACY["tag"]))
+    if not isinstance(release, dict):
+        raise PublishedReleaseError("legacy bootstrap release is missing")
+    actual = {
+        "id": release.get("id"),
+        "tag_name": release.get("tag_name"),
+        "target_commitish": release.get("target_commitish"),
+        "name": release.get("name"),
+        "draft": release.get("draft"),
+        "prerelease": release.get("prerelease"),
+        "body_sha256": hashlib.sha256(
+            str(release.get("body", "")).encode("utf-8")
+        ).hexdigest(),
+    }
+    expected = {
+        "id": LEGACY["release_id"],
+        "tag_name": LEGACY["tag"],
+        "target_commitish": LEGACY["commit"],
+        "name": LEGACY["tag"],
+        "draft": False,
+        "prerelease": False,
+        "body_sha256": LEGACY["body_sha256"],
+    }
+    if actual != expected:
+        raise PublishedReleaseError("legacy bootstrap release identity drifted")
+    if api.list_assets(int(LEGACY["release_id"])):
+        raise PublishedReleaseError("legacy bootstrap release unexpectedly has assets")
+
+
+def verify_locked(api: Any, version: str, root: Path = ROOT) -> None:
+    tag = f"v{version}"
+    lock_path = root / "release" / "compatibility" / f"{tag}.json"
+    try:
+        lock_bytes = lock_path.read_bytes()
+        lock = json.loads(lock_bytes)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PublishedReleaseError(f"cannot read tracked compatibility lock: {exc}") from exc
+    candidate = lock.get("release", {}).get("candidate_commit")
+    if not isinstance(candidate, str):
+        raise PublishedReleaseError("compatibility lock has no candidate commit")
+    lock_sha256 = hashlib.sha256(lock_bytes).hexdigest()
+    release = api.get_release(tag)
+    if not isinstance(release, dict) or release.get("draft") is not False:
+        raise PublishedReleaseError("exact published release is missing")
+    assets = api.list_assets(int(release["id"]))
+    names = [str(asset.get("name", "")) for asset in assets]
+    expected_names = publisher.expected_asset_names(tag)
+    if len(names) != len(set(names)) or set(names) != expected_names:
+        raise PublishedReleaseError("published release asset names are not exact")
+    with tempfile.TemporaryDirectory(prefix="typikon-published-release-") as tmp:
+        staging = Path(tmp)
+        for asset in assets:
+            name = str(asset["name"])
+            (staging / name).write_bytes(api.download_asset(int(asset["id"])))
+        payloads = publisher.expected_assets(staging, tag)
+        publisher.validate_staged_evidence(
+            payloads, tag, candidate, lock_sha256, lock_path
+        )
+        if publisher.inspect(api, tag, candidate, lock_sha256, payloads) != "published":
+            raise PublishedReleaseError("release is not exact and published")
+
+
+def verify(api: Any, version: str, root: Path = ROOT) -> str:
+    if SEMVER.fullmatch(version) is None:
+        raise PublishedReleaseError("manifest version is not SemVer")
+    if version == LEGACY["version"]:
+        verify_legacy(api, version)
+        return "legacy-bootstrap"
+    verify_locked(api, version, root)
+    return "locked-release"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    args = parser.parse_args()
+    try:
+        if not args.repository:
+            raise PublishedReleaseError("GITHUB_REPOSITORY is required")
+        try:
+            token = SecretToken.from_env("GITHUB_TOKEN")
+        except ValueError as exc:
+            raise PublishedReleaseError("GITHUB_TOKEN is required") from exc
+        api = publisher.GitHubApi(args.repository, token)
+        authority = verify(api, args.version)
+        print(json.dumps({"status": "pass", "authority": authority}, sort_keys=True))
+    except (
+        PublishedReleaseError,
+        publisher.PublishError,
+        OSError,
+        ValueError,
+        KeyError,
+        TypeError,
+    ) as exc:
+        print(f"verify-published-release: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/verify-release-lock.py
+++ b/ci/verify-release-lock.py
@@ -1,0 +1,903 @@
+#!/usr/bin/env python3
+"""Verify the v0.6 release candidate, two consumer receipts, and live GitHub state."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from release_archive import ArchiveError, verify_archive
+from release_secret import SecretToken, require_secret
+
+ROOT = Path(__file__).resolve().parent.parent
+EXPECTED_COHORT = {
+    "tools": "ardent-tools/ardent-tools-site",
+    "leather": "forkwright/ardent-site",
+}
+TYPIKON_REPOSITORY = "forkwright/typikon"
+TOKEN_BY_REPOSITORY = {
+    TYPIKON_REPOSITORY: "GITHUB_TOKEN",
+    EXPECTED_COHORT["tools"]: "TOOLS_RECEIPT_TOKEN",
+    EXPECTED_COHORT["leather"]: "LEATHER_RECEIPT_TOKEN",
+}
+SHA = re.compile(r"^[0-9a-f]{40}$")
+HEX_DIGEST = re.compile(r"^[0-9a-f]{64}$")
+ARTIFACT_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+
+
+class LockError(RuntimeError):
+    pass
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Expose GitHub's signed artifact URL without forwarding credentials."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        return None
+
+
+def download_signed_redirect(
+    api_url: str, token: SecretToken, *, require_https: bool = True
+) -> bytes:
+    token = require_secret(token)
+    authenticated = urllib.request.Request(
+        api_url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token.expose()}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "typikon-release-lock-verifier",
+        },
+    )
+    opener = urllib.request.build_opener(NoRedirect)
+    try:
+        opener.open(authenticated, timeout=30)
+    except urllib.error.HTTPError as exc:
+        if exc.code not in {301, 302, 303, 307, 308}:
+            raise LockError(f"artifact API returned HTTP {exc.code}") from exc
+        location = exc.headers.get("Location", "")
+    else:
+        raise LockError("artifact API did not return a signed redirect")
+    parsed = urllib.parse.urlsplit(location)
+    allowed_schemes = {"https"} if require_https else {"http", "https"}
+    if parsed.scheme not in allowed_schemes or not parsed.netloc or parsed.username:
+        raise LockError("artifact API returned an unsafe redirect URL")
+    # Fresh request by design: no GitHub Authorization or API-version header
+    # may cross the origin boundary to the signed object-store URL.
+    unsigned = urllib.request.Request(
+        location, headers={"User-Agent": "typikon-release-lock-verifier"}
+    )
+    try:
+        with urllib.request.urlopen(unsigned, timeout=60) as response:
+            data = response.read(64 * 1024 * 1024 + 1)
+    except urllib.error.HTTPError as exc:
+        raise LockError(f"signed artifact download returned HTTP {exc.code}") from exc
+    if len(data) > 64 * 1024 * 1024:
+        raise LockError("artifact exceeds 64 MiB")
+    return data
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def exact_keys(value: Any, expected: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != expected:
+        actual = sorted(value) if isinstance(value, dict) else type(value).__name__
+        raise LockError(f"{label} fields must be {sorted(expected)}, found {actual}")
+    return value
+
+
+def validate_lock_shape(lock: Any) -> dict[str, Any]:
+    document = exact_keys(
+        lock,
+        {"schema_version", "release", "candidate_artifact", "consumers"},
+        "compatibility lock",
+    )
+    if type(document["schema_version"]) is not int or document["schema_version"] != 1:
+        raise LockError("compatibility lock schema_version must be 1")
+    release = exact_keys(
+        document["release"],
+        {"version", "tag", "release_pr", "candidate_commit", "candidate_tree"},
+        "release",
+    )
+    if not isinstance(release["version"], str) or SEMVER.fullmatch(
+        release["version"]
+    ) is None:
+        raise LockError("release version is not SemVer")
+    if release["tag"] != f"v{release['version']}":
+        raise LockError("release tag does not match version")
+    if type(release["release_pr"]) is not int or release["release_pr"] < 1:
+        raise LockError("release PR number is invalid")
+    for field in ("candidate_commit", "candidate_tree"):
+        if not isinstance(release[field], str) or SHA.fullmatch(release[field]) is None:
+            raise LockError(f"release {field} is not a full object id")
+
+    artifact_fields = {
+        "workflow_run_id",
+        "run_attempt",
+        "artifact_id",
+        "artifact_name",
+        "artifact_digest",
+        "archive_name",
+        "archive_sha256",
+        "archive_size",
+        "checksum_name",
+        "checksum_sha256",
+        "checksum_size",
+        "sbom_name",
+        "sbom_sha256",
+        "sbom_size",
+        "provenance_bundle_name",
+        "provenance_bundle_sha256",
+        "provenance_bundle_size",
+        "sbom_bundle_name",
+        "sbom_bundle_sha256",
+        "sbom_bundle_size",
+    }
+    artifact = exact_keys(document["candidate_artifact"], artifact_fields, "candidate artifact")
+    for field in (
+        "workflow_run_id",
+        "run_attempt",
+        "artifact_id",
+        "archive_size",
+        "checksum_size",
+        "sbom_size",
+        "provenance_bundle_size",
+        "sbom_bundle_size",
+    ):
+        if type(artifact[field]) is not int or artifact[field] < 1:
+            raise LockError(f"candidate artifact {field} is invalid")
+    if not isinstance(artifact["artifact_digest"], str) or ARTIFACT_DIGEST.fullmatch(
+        artifact["artifact_digest"]
+    ) is None:
+        raise LockError("candidate artifact digest is invalid")
+    for field in (
+        "archive_sha256",
+        "checksum_sha256",
+        "sbom_sha256",
+        "provenance_bundle_sha256",
+        "sbom_bundle_sha256",
+    ):
+        if not isinstance(artifact[field], str) or HEX_DIGEST.fullmatch(
+            artifact[field]
+        ) is None:
+            raise LockError(f"candidate artifact {field} is invalid")
+    tag = release["tag"]
+    archive_name = f"typikon-{tag}.tar.gz"
+    exact_names = {
+        "artifact_name": f"typikon-{tag}-candidate",
+        "archive_name": archive_name,
+        "checksum_name": f"{archive_name}.sha256",
+        "sbom_name": f"{archive_name}.cdx.json",
+        "provenance_bundle_name": f"{archive_name}.provenance.intoto.jsonl",
+        "sbom_bundle_name": f"{archive_name}.sbom.intoto.jsonl",
+    }
+    for field, expected in exact_names.items():
+        if artifact[field] != expected:
+            raise LockError(f"candidate artifact {field} differs: {artifact[field]!r}")
+
+    consumers = document["consumers"]
+    if not isinstance(consumers, list) or len(consumers) != 2:
+        raise LockError("compatibility cohort must contain exactly two consumers")
+    expected_consumers = [
+        (
+            "tools",
+            "ardent-tools/ardent-tools-site",
+            "release/compatibility/receipts/tools.json",
+        ),
+        (
+            "leather",
+            "forkwright/ardent-site",
+            "release/compatibility/receipts/leather.json",
+        ),
+    ]
+    consumer_fields = {
+        "id",
+        "repository",
+        "pull_request",
+        "base_commit",
+        "head_commit",
+        "head_tree",
+        "merge_commit",
+        "merge_tree",
+        "gitlink_path",
+        "previous_gitlink_commit",
+        "previous_gitlink_tree",
+        "gitlink_commit",
+        "gitlink_tree",
+        "workflow_path",
+        "workflow_commit",
+        "workflow_blob",
+        "workflow_run_id",
+        "run_attempt",
+        "required_job",
+        "receipt_path",
+        "receipt_sha256",
+        "artifact_id",
+        "artifact_name",
+        "artifact_digest",
+    }
+    for consumer, expected in zip(consumers, expected_consumers, strict=True):
+        item = exact_keys(consumer, consumer_fields, f"{expected[0]} consumer")
+        if (item["id"], item["repository"], item["receipt_path"]) != expected:
+            raise LockError(f"consumer cohort tuple differs from {expected!r}")
+        if item["gitlink_path"] != "themes/typikon" or item["required_job"] != "gate-and-deploy":
+            raise LockError(f"{item['id']} consumer contract constants drifted")
+        if item["workflow_commit"] != item["merge_commit"]:
+            raise LockError(
+                f"{item['id']} workflow commit is not its synthetic merge commit"
+            )
+        if type(item["pull_request"]) is not int or item["pull_request"] < 1:
+            raise LockError(f"{item['id']} pull request is invalid")
+        for field in (
+            "base_commit",
+            "head_commit",
+            "head_tree",
+            "merge_commit",
+            "merge_tree",
+            "previous_gitlink_commit",
+            "previous_gitlink_tree",
+            "gitlink_commit",
+            "gitlink_tree",
+            "workflow_commit",
+            "workflow_blob",
+        ):
+            if not isinstance(item[field], str) or SHA.fullmatch(item[field]) is None:
+                raise LockError(f"{item['id']} {field} is not a full object id")
+        if not isinstance(item["workflow_path"], str) or re.fullmatch(
+            r"\.github/workflows/[A-Za-z0-9._/-]+\.ya?ml", item["workflow_path"]
+        ) is None:
+            raise LockError(f"{item['id']} workflow path is invalid")
+        for field in ("workflow_run_id", "run_attempt", "artifact_id"):
+            if type(item[field]) is not int or item[field] < 1:
+                raise LockError(f"{item['id']} {field} is invalid")
+        if not isinstance(item["receipt_sha256"], str) or HEX_DIGEST.fullmatch(
+            item["receipt_sha256"]
+        ) is None:
+            raise LockError(f"{item['id']} receipt SHA-256 is invalid")
+        if not isinstance(item["artifact_digest"], str) or ARTIFACT_DIGEST.fullmatch(
+            item["artifact_digest"]
+        ) is None:
+            raise LockError(f"{item['id']} artifact digest is invalid")
+        expected_artifact = (
+            f"typikon-consumer-receipt-{item['workflow_run_id']}-{item['run_attempt']}"
+        )
+        if item["artifact_name"] != expected_artifact:
+            raise LockError(f"{item['id']} artifact name differs from its run")
+    return document
+
+
+def read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LockError(f"cannot read JSON {path}: {exc}") from exc
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise LockError(result.stderr.strip() or f"git {' '.join(args)} failed")
+    return result.stdout.strip()
+
+
+def changelog_notes(revision: str, version: str) -> str:
+    text = git("show", f"{revision}:CHANGELOG.md")
+    header = re.compile(rf"^## \[{re.escape(version)}\].*$", re.MULTILINE)
+    matches = list(header.finditer(text))
+    if len(matches) != 1:
+        raise LockError(
+            f"candidate CHANGELOG must contain exactly one release heading for {version}"
+        )
+    start = matches[0].end()
+    following = re.search(r"^## ", text[start:], re.MULTILINE)
+    end = start + following.start() if following else len(text)
+    notes = text[start:end].strip()
+    if not notes:
+        raise LockError("candidate CHANGELOG release notes are empty")
+    return notes
+
+
+class GitHub:
+    def __init__(self, snapshot: dict[str, Any] | None = None):
+        self.snapshot = snapshot
+
+    def get(self, repo: str, endpoint: str, *, missing_ok: bool = False) -> Any:
+        key = f"{repo}|{endpoint}"
+        if self.snapshot is not None:
+            if key not in self.snapshot:
+                if missing_ok:
+                    return None
+                raise LockError(f"snapshot has no response for {key}")
+            return self.snapshot[key]
+        token_name = TOKEN_BY_REPOSITORY.get(repo)
+        if token_name is None:
+            raise LockError(f"no credential route is defined for {repo}")
+        try:
+            token = SecretToken.from_env(token_name)
+        except ValueError:
+            raise LockError(f"{token_name} is required to verify {repo}")
+        request = urllib.request.Request(
+            f"https://api.github.com/repos/{repo}/{endpoint}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token.expose()}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "typikon-release-lock-verifier",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as exc:
+            if missing_ok and exc.code == 404:
+                return None
+            detail = exc.read().decode(errors="replace")
+            raise LockError(f"GitHub {repo}/{endpoint} returned {exc.code}: {detail}") from exc
+
+    def artifact_zip(self, repo: str, artifact_id: int) -> bytes:
+        key = f"{repo}|artifact_zip/{artifact_id}"
+        if self.snapshot is not None:
+            encoded = self.snapshot.get(key)
+            if not isinstance(encoded, str):
+                raise LockError(f"snapshot has no artifact bytes for {key}")
+            return base64.b64decode(encoded, validate=True)
+        token_name = TOKEN_BY_REPOSITORY.get(repo)
+        if token_name is None:
+            raise LockError(f"no credential route is defined for {repo}")
+        try:
+            token = SecretToken.from_env(token_name)
+        except ValueError:
+            raise LockError(f"{token_name} is required to download {repo} evidence")
+        return download_signed_redirect(
+            f"https://api.github.com/repos/{repo}/actions/artifacts/{artifact_id}/zip",
+            token,
+        )
+
+
+def validate_receipt(receipt: Any, consumer: dict[str, Any], candidate: dict[str, Any]) -> None:
+    exact_keys(receipt, {"schema_version", "consumer", "typikon", "workflow"}, "receipt")
+    if receipt["schema_version"] != 1:
+        raise LockError("receipt.schema_version must be 1")
+    subject = exact_keys(
+        receipt["consumer"],
+        {
+            "repository",
+            "pull_request",
+            "base_commit",
+            "head_commit",
+            "checkout_commit",
+            "checkout_tree",
+            "checkout_parents",
+        },
+        "receipt.consumer",
+    )
+    theme = exact_keys(receipt["typikon"], {"path", "mode", "commit", "tree"}, "receipt.typikon")
+    workflow = exact_keys(
+        receipt["workflow"],
+        {"path", "commit", "blob", "run_id", "run_attempt", "event"},
+        "receipt.workflow",
+    )
+    pairs = {
+        "repository": (subject["repository"], consumer["repository"]),
+        "pull request": (subject["pull_request"], consumer["pull_request"]),
+        "base commit": (subject["base_commit"], consumer["base_commit"]),
+        "head commit": (subject["head_commit"], consumer["head_commit"]),
+        "checkout commit": (subject["checkout_commit"], consumer["merge_commit"]),
+        "checkout tree": (subject["checkout_tree"], consumer["merge_tree"]),
+        "checkout parents": (
+            subject["checkout_parents"],
+            [consumer["base_commit"], consumer["head_commit"]],
+        ),
+        "gitlink path": (theme["path"], consumer["gitlink_path"]),
+        "gitlink mode": (theme["mode"], "160000"),
+        "gitlink commit": (theme["commit"], consumer["gitlink_commit"]),
+        "gitlink tree": (theme["tree"], consumer["gitlink_tree"]),
+        "workflow path": (workflow["path"], consumer["workflow_path"]),
+        "workflow commit": (workflow["commit"], consumer["workflow_commit"]),
+        "workflow blob": (workflow["blob"], consumer["workflow_blob"]),
+        "run id": (workflow["run_id"], consumer["workflow_run_id"]),
+        "run attempt": (workflow["run_attempt"], consumer["run_attempt"]),
+        "event": (workflow["event"], "pull_request"),
+    }
+    for label, (actual, expected) in pairs.items():
+        if actual != expected:
+            raise LockError(f"receipt {label} mismatch: {actual!r} != {expected!r}")
+    if consumer["gitlink_commit"] != candidate["candidate_commit"]:
+        raise LockError("locked consumer gitlink commit differs from the candidate")
+    if consumer["gitlink_tree"] != candidate["candidate_tree"]:
+        raise LockError("locked consumer gitlink tree differs from the candidate")
+
+
+def validate_bundle(lock: dict[str, Any], bundles: dict[str, dict[str, bytes]]) -> None:
+    release = lock["release"]
+    artifact = lock["candidate_artifact"]
+    if release["tag"] != f"v{release['version']}":
+        raise LockError("release tag does not match version")
+    candidate_files = bundles["candidate"]
+    candidate = json.loads(candidate_files["candidate.json"].decode())
+    exact_keys(
+        candidate,
+        {
+            "schema_version",
+            "release",
+            "workflow",
+            "archive",
+            "checksum",
+            "sbom",
+            "notes",
+            "attestations",
+        },
+        "candidate",
+    )
+    if candidate["schema_version"] != 1:
+        raise LockError("candidate.schema_version must be 1")
+    for key in ("version", "tag", "release_pr", "candidate_commit", "candidate_tree"):
+        if candidate["release"].get(key) != release[key]:
+            raise LockError(f"candidate release {key} differs from the lock")
+    if candidate["workflow"] != {
+        "repository": "forkwright/typikon",
+        "run_id": artifact["workflow_run_id"],
+        "run_attempt": artifact["run_attempt"],
+    }:
+        raise LockError("candidate workflow identity differs from the lock")
+    for kind, lock_prefix in (
+        ("archive", "archive"),
+        ("checksum", "checksum"),
+        ("sbom", "sbom"),
+    ):
+        item = candidate[kind]
+        payload = candidate_files[item["name"]]
+        expected = {
+            "name": artifact[f"{lock_prefix}_name"],
+            "sha256": artifact[f"{lock_prefix}_sha256"],
+            "size": artifact[f"{lock_prefix}_size"],
+        }
+        if item != expected:
+            raise LockError(f"candidate {kind} manifest differs from the lock")
+        if hashlib.sha256(payload).hexdigest() != item["sha256"] or len(payload) != item["size"]:
+            raise LockError(f"candidate {kind} bytes differ from their manifest")
+        if kind == "archive":
+            try:
+                verify_archive(payload, ROOT, release["candidate_commit"])
+            except ArchiveError as exc:
+                raise LockError(str(exc)) from exc
+    expected_checksum = (
+        f"{candidate['archive']['sha256']}  {candidate['archive']['name']}\n".encode()
+    )
+    if candidate_files[candidate["checksum"]["name"]] != expected_checksum:
+        raise LockError("candidate checksum is not the canonical sha256sum record")
+    notes = exact_keys(candidate["notes"], {"body", "sha256", "size"}, "candidate.notes")
+    notes_body = notes.get("body")
+    if not isinstance(notes_body, str):
+        raise LockError("candidate release notes body is not text")
+    notes_bytes = notes_body.encode("utf-8")
+    if (
+        notes.get("sha256") != hashlib.sha256(notes_bytes).hexdigest()
+        or notes.get("size") != len(notes_bytes)
+        or notes_body != changelog_notes(release["candidate_commit"], release["version"])
+    ):
+        raise LockError("candidate release notes differ from the exact CHANGELOG section")
+    attestations = exact_keys(
+        candidate["attestations"], {"provenance", "sbom"}, "candidate.attestations"
+    )
+    for kind in ("provenance", "sbom"):
+        item = exact_keys(
+            attestations[kind], {"name", "sha256", "size"}, f"candidate.attestations.{kind}"
+        )
+        expected = {
+            "name": artifact[f"{kind}_bundle_name"],
+            "sha256": artifact[f"{kind}_bundle_sha256"],
+            "size": artifact[f"{kind}_bundle_size"],
+        }
+        if item != expected:
+            raise LockError(f"candidate {kind} attestation manifest differs from the lock")
+        payload = candidate_files[item["name"]]
+        if hashlib.sha256(payload).hexdigest() != item["sha256"] or len(payload) != item["size"]:
+            raise LockError(f"candidate {kind} attestation bytes differ from their manifest")
+
+    for consumer in lock["consumers"]:
+        tracked = (ROOT / consumer["receipt_path"]).resolve()
+        if ROOT not in tracked.parents:
+            raise LockError(f"receipt path escapes the repository: {tracked}")
+        if sha256(tracked) != consumer["receipt_sha256"]:
+            raise LockError(f"tracked {consumer['id']} receipt digest differs from the lock")
+        downloaded = bundles[consumer["id"]]["typikon-consumer-receipt.json"]
+        if downloaded != tracked.read_bytes():
+            raise LockError(f"downloaded {consumer['id']} receipt differs from tracked bytes")
+        validate_receipt(read_json(tracked), consumer, release)
+
+
+def require_tree_entry(
+    api: GitHub,
+    repo: str,
+    tree: str,
+    path: str,
+    *,
+    mode: str,
+    sha: str,
+    label: str,
+) -> None:
+    tree_doc = api.get(repo, f"git/trees/{tree}?recursive=1")
+    entries = [entry for entry in tree_doc.get("tree", []) if entry.get("path") == path]
+    if len(entries) != 1:
+        raise LockError(f"{repo} {label} has {len(entries)} entries for {path}")
+    entry = entries[0]
+    if entry.get("mode") != mode or entry.get("sha") != sha:
+        raise LockError(f"{repo} {label} {path} differs from the lock")
+
+
+def verify_artifact(api: GitHub, repo: str, fields: dict[str, Any], *, candidate: bool = False) -> dict[str, bytes]:
+    artifact = api.get(repo, f"actions/artifacts/{fields['artifact_id']}")
+    expected_run = fields["workflow_run_id"]
+    if artifact.get("expired"):
+        raise LockError(f"{repo} artifact {fields['artifact_id']} is expired")
+    if artifact.get("name") != fields["artifact_name"]:
+        raise LockError(f"{repo} artifact name drifted")
+    if artifact.get("digest") != fields["artifact_digest"]:
+        raise LockError(f"{repo} artifact digest drifted")
+    if artifact.get("workflow_run", {}).get("id") != expected_run:
+        raise LockError(f"{repo} artifact belongs to another workflow run")
+    raw = api.artifact_zip(repo, fields["artifact_id"])
+    digest = f"sha256:{hashlib.sha256(raw).hexdigest()}"
+    if digest != fields["artifact_digest"]:
+        raise LockError(f"{repo} downloaded artifact digest differs from the lock")
+    expected_names = (
+        {
+            "candidate.json",
+            fields["archive_name"],
+            fields["checksum_name"],
+            fields["sbom_name"],
+            fields["provenance_bundle_name"],
+            fields["sbom_bundle_name"],
+        }
+        if candidate
+        else {"typikon-consumer-receipt.json"}
+    )
+    try:
+        with zipfile.ZipFile(io.BytesIO(raw)) as archive:
+            names = archive.namelist()
+            if len(names) != len(set(names)) or set(names) != expected_names:
+                raise LockError(
+                    f"{repo} artifact members must be {sorted(expected_names)}, found {sorted(names)}"
+                )
+            files: dict[str, bytes] = {}
+            for info in archive.infolist():
+                if info.is_dir() or info.file_size > 48 * 1024 * 1024:
+                    raise LockError(f"{repo} artifact has an invalid member {info.filename!r}")
+                files[info.filename] = archive.read(info)
+    except zipfile.BadZipFile as exc:
+        raise LockError(f"{repo} artifact is not a valid ZIP") from exc
+    return files
+
+
+def verify_run(
+    api: GitHub,
+    repo: str,
+    fields: dict[str, Any],
+    expected_head: str,
+    path: str,
+    *,
+    pull_request: int | None = None,
+) -> None:
+    run_id = fields["workflow_run_id"]
+    attempt = fields["run_attempt"]
+    run = api.get(repo, f"actions/runs/{run_id}")
+    expected = {
+        "status": "completed",
+        "conclusion": "success",
+        "event": fields.get("event", "pull_request"),
+        "head_sha": expected_head,
+        "run_attempt": attempt,
+        "path": path,
+    }
+    for key, value in expected.items():
+        if run.get(key) != value:
+            raise LockError(f"{repo} run {run_id} {key} drifted: {run.get(key)!r} != {value!r}")
+    associations = run.get("pull_requests", [])
+    if pull_request is None:
+        if associations:
+            raise LockError(f"{repo} push run is associated with a pull request")
+    else:
+        if len(associations) != 1:
+            raise LockError(f"{repo} run is not bound to exactly one pull request")
+        association = associations[0]
+        if (
+            association.get("number") != pull_request
+            or association.get("head", {}).get("sha") != fields["head_commit"]
+            or association.get("base", {}).get("sha") != fields["base_commit"]
+        ):
+            raise LockError(f"{repo} run pull-request association drifted")
+    first_endpoint = f"actions/runs/{run_id}/attempts/{attempt}/jobs?per_page=100"
+    first = api.get(repo, first_endpoint)
+    jobs = first.get("jobs", [])
+    if not isinstance(jobs, list):
+        raise LockError(f"{repo} jobs response is not a list")
+    all_jobs = list(jobs)
+    page = 2
+    while len(jobs) == 100:
+        if page > 100:
+            raise LockError(f"{repo} run has more than 10,000 jobs")
+        page_doc = api.get(repo, f"{first_endpoint}&page={page}")
+        jobs = page_doc.get("jobs", [])
+        if not isinstance(jobs, list):
+            raise LockError(f"{repo} jobs page {page} is not a list")
+        all_jobs.extend(jobs)
+        page += 1
+    matches = [
+        job
+        for job in all_jobs
+        if job.get("name") == fields.get("required_job", "gate")
+    ]
+    if len(matches) != 1 or matches[0].get("conclusion") != "success":
+        raise LockError(f"{repo} required job is not exactly one success")
+
+
+def verify_evidence_delta(lock: dict[str, Any], lock_path: Path) -> None:
+    candidate = lock["release"]["candidate_commit"]
+    try:
+        lock_relative = lock_path.resolve().relative_to(ROOT).as_posix()
+    except ValueError as exc:
+        raise LockError("compatibility lock is outside the repository") from exc
+    allowed = {lock_relative, *(consumer["receipt_path"] for consumer in lock["consumers"])}
+    changed = set(git("diff", "--name-only", candidate, "HEAD").splitlines())
+    if changed != allowed:
+        raise LockError(
+            "post-candidate evidence delta must contain exactly "
+            f"{sorted(allowed)}, found {sorted(changed)}"
+        )
+    for path in sorted(allowed):
+        git("ls-files", "--error-unmatch", "--", path)
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        github_sha = os.environ.get("GITHUB_SHA", "")
+        if github_sha != git("rev-parse", "HEAD"):
+            raise LockError("checked-out evidence commit differs from GITHUB_SHA")
+
+
+def verify_live(
+    lock: dict[str, Any], api: GitHub, lock_path: Path
+) -> dict[str, dict[str, bytes]]:
+    release = lock["release"]
+    candidate = release["candidate_commit"]
+    tree = release["candidate_tree"]
+    manifest = json.loads(git("show", f"{candidate}:.release-please-manifest.json"))
+    if manifest != {".": release["version"]}:
+        raise LockError("candidate manifest version differs from the lock")
+    if git("rev-parse", f"{candidate}^{{tree}}") != tree:
+        raise LockError("candidate tree differs from local Git object")
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), "merge-base", "--is-ancestor", candidate, "HEAD"]
+    )
+    if result.returncode:
+        raise LockError("candidate is not an ancestor of the evidence commit")
+    verify_evidence_delta(lock, lock_path)
+
+    pr = api.get(TYPIKON_REPOSITORY, f"pulls/{release['release_pr']}")
+    if not pr.get("merged") or pr.get("merge_commit_sha") != candidate:
+        raise LockError("release PR is not merged at the candidate commit")
+    parent_ids = git("rev-list", "--parents", "-n", "1", candidate).split()[1:]
+    if len(parent_ids) != 1:
+        raise LockError("release candidate is not a one-parent squash commit")
+    parent = parent_ids[0]
+    expected_title = f"chore(main): release {release['version']}"
+    expected_pr_identity = {
+        "title": expected_title,
+        "author_login": "github-actions[bot]",
+        "author_type": "Bot",
+        "base_ref": "main",
+        "base_repo": TYPIKON_REPOSITORY,
+        "base_sha": parent,
+        "head_ref": "release-please--branches--main",
+        "head_repo": TYPIKON_REPOSITORY,
+    }
+    actual_pr_identity = {
+        "title": pr.get("title"),
+        "author_login": pr.get("user", {}).get("login"),
+        "author_type": pr.get("user", {}).get("type"),
+        "base_ref": pr.get("base", {}).get("ref"),
+        "base_repo": pr.get("base", {}).get("repo", {}).get("full_name"),
+        "base_sha": pr.get("base", {}).get("sha"),
+        "head_ref": pr.get("head", {}).get("ref"),
+        "head_repo": pr.get("head", {}).get("repo", {}).get("full_name"),
+    }
+    if actual_pr_identity != expected_pr_identity:
+        raise LockError(
+            "release PR is not the exact Release Please main-branch proposal: "
+            f"{actual_pr_identity!r} != {expected_pr_identity!r}"
+        )
+    labels = {
+        item.get("name") for item in pr.get("labels", []) if isinstance(item, dict)
+    }
+    if not labels.intersection({"autorelease: pending", "autorelease: tagged"}):
+        raise LockError("release PR has no Release Please lifecycle label")
+    if "autorelease: tagged" in labels:
+        published = api.get(
+            TYPIKON_REPOSITORY,
+            f"releases/tags/{release['tag']}",
+            missing_ok=True,
+        )
+        tag_ref = api.get(
+            TYPIKON_REPOSITORY,
+            f"git/ref/tags/{release['tag']}",
+            missing_ok=True,
+        )
+        if (
+            published is None
+            or published.get("draft") is not False
+            or published.get("tag_name") != release["tag"]
+            or tag_ref is None
+        ):
+            raise LockError(
+                "autorelease: tagged is present without an exact published release"
+            )
+    release_head = pr.get("head", {}).get("sha")
+    if not isinstance(release_head, str):
+        raise LockError("release PR has no head commit")
+    release_head_commit = api.get(
+        TYPIKON_REPOSITORY, f"git/commits/{release_head}"
+    )
+    if release_head_commit.get("tree", {}).get("sha") != tree:
+        raise LockError("Release Please head tree differs from the candidate tree")
+    commit = api.get(TYPIKON_REPOSITORY, f"git/commits/{candidate}")
+    if commit.get("tree", {}).get("sha") != tree:
+        raise LockError("GitHub candidate tree differs from the lock")
+    remote_parents = [item.get("sha") for item in commit.get("parents", [])]
+    if remote_parents != [parent]:
+        raise LockError("GitHub candidate parent differs from the release PR base")
+    candidate_fields = dict(lock["candidate_artifact"])
+    candidate_fields["event"] = "push"
+    candidate_fields["required_job"] = "freeze-candidate"
+    verify_run(
+        api,
+        TYPIKON_REPOSITORY,
+        candidate_fields,
+        candidate,
+        ".github/workflows/release-candidate.yml",
+    )
+    bundles = {
+        "candidate": verify_artifact(
+            api, TYPIKON_REPOSITORY, candidate_fields, candidate=True
+        )
+    }
+
+    for consumer in lock["consumers"]:
+        repo = consumer["repository"]
+        if consumer["previous_gitlink_commit"] == consumer["gitlink_commit"]:
+            raise LockError(f"{repo} rollback and promotion gitlinks are identical")
+        pr = api.get(repo, f"pulls/{consumer['pull_request']}")
+        if pr.get("state") != "open":
+            raise LockError(f"{repo} receipt PR is not open")
+        if (
+            pr.get("base", {}).get("ref") != "main"
+            or pr.get("base", {}).get("repo", {}).get("full_name") != repo
+            or pr.get("head", {}).get("repo", {}).get("full_name") != repo
+        ):
+            raise LockError(f"{repo} receipt PR does not target owned main")
+        current = {
+            "base_commit": pr.get("base", {}).get("sha"),
+            "head_commit": pr.get("head", {}).get("sha"),
+            "merge_commit": pr.get("merge_commit_sha"),
+        }
+        for key, actual in current.items():
+            if actual != consumer[key]:
+                raise LockError(f"{repo} PR {key} drifted")
+        head = api.get(repo, f"git/commits/{consumer['head_commit']}")
+        merge = api.get(repo, f"git/commits/{consumer['merge_commit']}")
+        if head.get("tree", {}).get("sha") != consumer["head_tree"]:
+            raise LockError(f"{repo} head tree drifted")
+        if merge.get("tree", {}).get("sha") != consumer["merge_tree"]:
+            raise LockError(f"{repo} merge tree drifted")
+        parents = [parent.get("sha") for parent in merge.get("parents", [])]
+        if parents != [consumer["base_commit"], consumer["head_commit"]]:
+            raise LockError(f"{repo} merge parents drifted")
+        base = api.get(repo, f"git/commits/{consumer['base_commit']}")
+        base_tree = base.get("tree", {}).get("sha")
+        if not isinstance(base_tree, str):
+            raise LockError(f"{repo} base commit has no tree")
+        require_tree_entry(
+            api,
+            repo,
+            base_tree,
+            consumer["gitlink_path"],
+            mode="160000",
+            sha=consumer["previous_gitlink_commit"],
+            label="rollback tree",
+        )
+        previous = api.get(
+            TYPIKON_REPOSITORY,
+            f"git/commits/{consumer['previous_gitlink_commit']}",
+        )
+        if previous.get("tree", {}).get("sha") != consumer["previous_gitlink_tree"]:
+            raise LockError(f"{repo} rollback Typikon tree drifted")
+        require_tree_entry(
+            api,
+            repo,
+            consumer["merge_tree"],
+            consumer["gitlink_path"],
+            mode="160000",
+            sha=consumer["gitlink_commit"],
+            label="promotion tree",
+        )
+        promoted = api.get(
+            TYPIKON_REPOSITORY,
+            f"git/commits/{consumer['gitlink_commit']}",
+        )
+        if promoted.get("tree", {}).get("sha") != consumer["gitlink_tree"]:
+            raise LockError(f"{repo} promoted Typikon tree drifted")
+        workflow_commit = api.get(repo, f"git/commits/{consumer['workflow_commit']}")
+        workflow_tree = workflow_commit.get("tree", {}).get("sha")
+        workflow_doc = api.get(repo, f"git/trees/{workflow_tree}?recursive=1")
+        workflow_entries = [entry for entry in workflow_doc.get("tree", []) if entry.get("path") == consumer["workflow_path"]]
+        if len(workflow_entries) != 1 or workflow_entries[0].get("mode") != "100644" or workflow_entries[0].get("sha") != consumer["workflow_blob"]:
+            raise LockError(f"{repo} workflow blob drifted")
+        verify_run(
+            api,
+            repo,
+            consumer,
+            consumer["head_commit"],
+            consumer["workflow_path"],
+            pull_request=consumer["pull_request"],
+        )
+        bundles[consumer["id"]] = verify_artifact(api, repo, consumer)
+    return bundles
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--lock", required=True, type=Path)
+    parser.add_argument("--snapshot", type=Path)
+    parser.add_argument("--emit-github-output", type=Path)
+    parser.add_argument("--materialize-candidate", type=Path)
+    args = parser.parse_args()
+    try:
+        lock = validate_lock_shape(read_json(args.lock))
+        snapshot = read_json(args.snapshot) if args.snapshot else None
+        bundles = verify_live(lock, GitHub(snapshot), args.lock)
+        validate_bundle(lock, bundles)
+        if args.materialize_candidate:
+            args.materialize_candidate.mkdir(parents=True, exist_ok=False)
+            for name, payload in bundles["candidate"].items():
+                (args.materialize_candidate / name).write_bytes(payload)
+        lock_digest = sha256(args.lock)
+        if args.emit_github_output:
+            with args.emit_github_output.open("a", encoding="utf-8") as handle:
+                handle.write(f"candidate_commit={lock['release']['candidate_commit']}\n")
+                handle.write(f"candidate_tree={lock['release']['candidate_tree']}\n")
+                handle.write(f"tag={lock['release']['tag']}\n")
+                handle.write(f"version={lock['release']['version']}\n")
+                handle.write(f"release_pr={lock['release']['release_pr']}\n")
+                handle.write(f"lock_sha256={lock_digest}\n")
+        print(json.dumps({"status": "pass", "lock_sha256": lock_digest}, sort_keys=True))
+    except (LockError, OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"verify-release-lock: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/write-consumer-receipt.py
+++ b/ci/write-consumer-receipt.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Write a deterministic receipt for a consumer's hosted PR checkout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ReceiptError(RuntimeError):
+    pass
+
+
+def git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise ReceiptError(result.stderr.strip() or f"git {' '.join(args)} failed")
+    return result.stdout.strip()
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name, "")
+    if not value:
+        raise ReceiptError(f"{name} is required")
+    return value
+
+
+def workflow_path(workflow_ref: str, repository: str) -> str:
+    prefix = f"{repository}/"
+    if not workflow_ref.startswith(prefix) or "@" not in workflow_ref:
+        raise ReceiptError("GITHUB_WORKFLOW_REF does not name this repository")
+    path = workflow_ref[len(prefix) :].rsplit("@", 1)[0]
+    if not path.startswith(".github/workflows/") or not path.endswith((".yml", ".yaml")):
+        raise ReceiptError(f"invalid workflow path {path!r}")
+    return path
+
+
+def build(root: Path) -> dict[str, object]:
+    if required_env("GITHUB_EVENT_NAME") != "pull_request":
+        raise ReceiptError("consumer receipts are created only for pull_request runs")
+    repository = required_env("GITHUB_REPOSITORY")
+    event_path = Path(required_env("GITHUB_EVENT_PATH"))
+    event = json.loads(event_path.read_text(encoding="utf-8"))
+    pr = event.get("pull_request")
+    if not isinstance(pr, dict):
+        raise ReceiptError("event has no pull_request object")
+
+    checkout_commit = git(root, "rev-parse", "HEAD")
+    checkout_tree = git(root, "rev-parse", "HEAD^{tree}")
+    if checkout_commit != required_env("GITHUB_SHA"):
+        raise ReceiptError("checked-out commit differs from GITHUB_SHA")
+    parents = git(root, "rev-list", "--parents", "-n", "1", "HEAD").split()[1:]
+    expected_parents = [pr["base"]["sha"], pr["head"]["sha"]]
+    if parents != expected_parents:
+        raise ReceiptError(
+            "checkout is not the pull request synthetic merge: "
+            f"parents={parents}, expected={expected_parents}"
+        )
+    gitlink_fields = git(root, "ls-tree", "HEAD", "themes/typikon").split()
+    if len(gitlink_fields) < 3 or gitlink_fields[0] != "160000" or gitlink_fields[1] != "commit":
+        raise ReceiptError("themes/typikon is not a gitlink in the checked-out tree")
+    gitlink_commit = gitlink_fields[2]
+    submodule_commit = git(root / "themes" / "typikon", "rev-parse", "HEAD")
+    if submodule_commit != gitlink_commit:
+        raise ReceiptError("checked-out Typikon commit differs from the consumer gitlink")
+    gitlink_tree = git(root / "themes" / "typikon", "rev-parse", "HEAD^{tree}")
+
+    path = workflow_path(required_env("GITHUB_WORKFLOW_REF"), repository)
+    workflow_commit = required_env("GITHUB_WORKFLOW_SHA")
+    if not SHA.fullmatch(workflow_commit):
+        raise ReceiptError("GITHUB_WORKFLOW_SHA is not a commit object id")
+    if workflow_commit != checkout_commit:
+        raise ReceiptError(
+            "GITHUB_WORKFLOW_SHA differs from the pull request synthetic merge"
+        )
+    receipt = {
+        "schema_version": 1,
+        "consumer": {
+            "repository": repository,
+            "pull_request": int(pr["number"]),
+            "base_commit": pr["base"]["sha"],
+            "head_commit": pr["head"]["sha"],
+            "checkout_commit": checkout_commit,
+            "checkout_tree": checkout_tree,
+            "checkout_parents": parents,
+        },
+        "typikon": {
+            "path": "themes/typikon",
+            "mode": "160000",
+            "commit": gitlink_commit,
+            "tree": gitlink_tree,
+        },
+        "workflow": {
+            "path": path,
+            "commit": workflow_commit,
+            "blob": git(root, "rev-parse", f"{workflow_commit}:{path}"),
+            "run_id": int(required_env("GITHUB_RUN_ID")),
+            "run_attempt": int(required_env("GITHUB_RUN_ATTEMPT")),
+            "event": "pull_request",
+        },
+    }
+    for value in (
+        receipt["consumer"]["base_commit"],
+        receipt["consumer"]["head_commit"],
+        checkout_commit,
+        checkout_tree,
+        gitlink_commit,
+        gitlink_tree,
+        receipt["workflow"]["blob"],
+        workflow_commit,
+    ):
+        if not isinstance(value, str) or not SHA.fullmatch(value):
+            raise ReceiptError(f"receipt contains an invalid object id: {value!r}")
+    return receipt
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        receipt = build(args.root.resolve())
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    except (ReceiptError, OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"write-consumer-receipt: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/MANIFEST.toml
+++ b/docs/MANIFEST.toml
@@ -17,3 +17,9 @@ path = "docs/AGENTIC.md"
 type = "authored"
 evergreen = true
 description = "Agent operating contract for working on typikon or a consumer site."
+
+[[doc]]
+path = "docs/RELEASING.md"
+type = "authored"
+evergreen = true
+description = "Two-phase release candidate, consumer lock, rollback, and publication contract."

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,140 @@
+# Releasing Typikon
+
+Typikon separates release preparation, candidate freezing, consumer evidence,
+and publication. A green theme gate does not by itself authorize a tag.
+
+Publication remains deliberately blocked by forkwright/typikon#58. The current
+component inventory covers the renderer and embedded fonts but not every
+transitive dependency of the shipped `bin/` and `ci/` surfaces. The candidate
+builder refuses to freeze a release until that lock-derived graph is complete.
+
+## Subjects
+
+- `R` is the one-parent Release Please squash commit. Its diff contains only
+  `CHANGELOG.md` and `.release-please-manifest.json`. The version tag targets
+  this exact commit.
+- The Release Candidate workflow builds the source archive, matching
+  `sha256sum` record, inventory-backed CycloneDX SBOM, and two offline Sigstore
+  bundles once from `R`. Its immutable artifact records the run, commit, tree,
+  byte counts, and SHA-256 digests.
+- Tools and Leather each pin `R` as `themes/typikon`, pass their hosted PR gate,
+  and upload a receipt for the exact synthetic merge checkout and workflow.
+- `E` is a later evidence-only commit. Relative to `R`, it may add exactly one
+  compatibility lock and the two tracked receipt files. The verifier and
+  publisher bytes therefore remain the versions already present in `R`.
+
+The lock types both directions. Promotion records each consumer's gitlink to
+`R`; rollback records the distinct gitlink commit and tree from that consumer's
+exact PR base. The two consumers need not share a prior Typikon pin.
+
+## Credentials
+
+Publication needs two fine-grained, read-only repository tokens because a
+repository-scoped `GITHUB_TOKEN` cannot download another repository's Actions
+artifact and the two consumers have different resource owners.
+
+- `TOOLS_RECEIPT_TOKEN`: access only to
+  `ardent-tools/ardent-tools-site`, with Actions, Contents, and Pull requests
+  set to read.
+- `LEATHER_RECEIPT_TOKEN`: access only to `forkwright/ardent-site`, with the
+  same three read permissions.
+
+The workflow exposes these secrets only to the two verifier steps. Candidate
+freezing, checkout, attestation, and publication do not receive them. Creating
+or changing either repository secret is an operator-owned credential action.
+The Python release clients wrap each environment token before passing it to a
+network helper and expose it only while constructing the Authorization header.
+Python cannot guarantee memory zeroization, so this boundary prevents accidental
+logging without claiming a runtime guarantee the language cannot provide.
+
+## Public evidence boundary
+
+The compatibility lock and both receipts are public release assets. They name
+the Leather repository and disclose its selected PR number, commit and tree
+identities, workflow path and blob, run and artifact identifiers, and digests.
+They do not contain source content or credentials. Because Leather is private,
+publishing that metadata is a separate operator privacy decision. A successful
+verifier does not grant it implicitly.
+
+The manual dispatch requires
+`acknowledge_private_consumer_metadata=true`. That run-scoped input records the
+operator's decision at the publication boundary. Its default is false.
+
+## Sequence
+
+1. Merge release-control changes while the manifest version has an exact
+   published release. The PR-only Release Please action refreshes the pending
+   release PR.
+2. Squash that release PR. The resulting `R` remains untagged. The preparation
+   workflow parks while the manifest version lacks its tag.
+3. Require the Release Candidate run on `R` to finish successfully and retain
+   its exact artifact identity.
+4. Pin both consumer PRs to `R`, run their hosted gates, and retain the exact
+   receipt artifacts.
+5. Add the lock and two byte-identical receipts in evidence commit `E`. Review
+   the per-consumer promotion and rollback subjects.
+6. Install the two read-only secrets only with operator approval, then dispatch
+   Release Please from the current `main` head with the tracked lock path. Keep
+   a reviewed single-writer hold on `main` through terminal release readback.
+   Separate GitHub REST writes cannot atomically bind a branch head and release
+   publication.
+7. The workflow verifies the lock twice, rebuilds the nine-file staged set,
+   seals it as a raw-digest-bound same-run handoff, and publishes through a
+   fail-closed state machine. It creates an annotated tag at `R` whose message
+   carries the lock digest, reconciles a draft and nine exact assets, then
+   publishes only after byte readback. The candidate workflow freezes the two
+   attestation bundles. Publication never regenerates them.
+8. Verify the public annotated tag, release assets, attestations, and consumer
+   repins before merging or deploying either consumer.
+
+An ordinary interruption while `E` is still current may leave an exact tag,
+draft, or partial draft asset set. Rerun the complete workflow so the read-only
+verifier executes again. The workflow rejects publisher-only failed-job
+reruns. The publisher accepts only an exact prior state and removes only a
+same-name GitHub `starter` upload residue.
+
+GitHub exposes annotated-tag object and ref creation as separate REST writes.
+If `main` moves across that boundary, the run stops and may leave an exact
+provisional tag, or a private exact draft after a later interruption. Stale-`E`
+publication remains blocked. Release Please also remains parked because it
+requires a published release. A tag alone does not satisfy that check. Do not
+restore an old main tip or delete/recreate evidence.
+
+GitHub offers no branch compare-and-publish transaction for the final
+draft-to-public request. The publisher detects movement after exact release
+readback and withholds a green receipt, but the exact release is already public.
+This limitation requires the single-writer hold even though the publisher
+revalidates every API state.
+
+Resolving a provisional tag, draft, or unreceipted public release is a separate
+destructive recovery action that needs exact-state cross-validation. A
+conflicting tag, release, or asset always fails closed.
+
+## Offline verification
+
+After downloading all release assets, verify the distribution checksum and
+both frozen bundles without relying on GitHub's release page:
+
+```sh
+sha256sum --check --strict typikon-v0.6.0.tar.gz.sha256
+R=$(python3 -c 'import json; print(json.load(open("candidate.json"))["release"]["candidate_commit"])')
+gh attestation verify typikon-v0.6.0.tar.gz \
+  --bundle typikon-v0.6.0.tar.gz.provenance.intoto.jsonl \
+  --repo forkwright/typikon \
+  --signer-workflow forkwright/typikon/.github/workflows/release-candidate.yml \
+  --source-digest "$R" \
+  --predicate-type https://slsa.dev/provenance/v1
+gh attestation verify typikon-v0.6.0.tar.gz \
+  --bundle typikon-v0.6.0.tar.gz.sbom.intoto.jsonl \
+  --repo forkwright/typikon \
+  --signer-workflow forkwright/typikon/.github/workflows/release-candidate.yml \
+  --source-digest "$R" \
+  --predicate-type https://cyclonedx.org/bom
+```
+
+Require the compatibility lock to name the same `R` before running either
+command.
+
+This is the first typed two-consumer promotion and rollback increment for
+forkwright/typikon#70. It does not claim the issue's later generalized release
+bundle, provider adapter, or automatic Kanon merge refusal work is complete.

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -92,6 +92,10 @@ Top-level pages and section children that aren't journal entries or products. Bu
 
 **Optional `[extra]`:** `seo_title`, `body_class`, `og_image`, `og_type`, `greek` (qualified alternate-language text carried by the owned H1), `audience`, `price`, `price_source`, `stripe_url`, paired `availability`/`availability_source`, and paired `shipping_note`/`shipping_source`.
 
+`body_class` is the semantic hook for page-wide presentation. A branded
+not-found page uses `body_class = "error-page"`. Its Markdown body does not
+wrap or replace the H1 because `page.html` owns that heading.
+
 **Constraints:**
 - title: ≤80 chars
 - description: ≤200 chars

--- a/llms.txt
+++ b/llms.txt
@@ -16,6 +16,10 @@ Product pages fail closed: a recorded price remains catalog data until sourced p
 
 `bin/typikon-check` - run the local web-property gate.
 
+`ci/verify-release-lock.py` - replay the exact candidate, consumer PR/run/artifact, promotion, and rollback subjects before publication.
+
+`ci/publish-locked-release.py` - reconcile or publish only the exact annotated tag, draft, and nine locked release assets while the verified evidence commit is current.
+
 ## Architecture
 
 Structured LLM corpus:
@@ -33,3 +37,5 @@ Structured LLM corpus:
 - Default page and section templates carry qualified `extra.greek` metadata on the single Typikon-owned H1.
 - [scaffolds/](scaffolds/): reserved, currently empty — typikon-init scaffolds content inline
 - [bin/](bin/): typikon-init, typikon-validate, typikon-check, typikon-refresh, typikon-migrate-template
+- [docs/RELEASING.md](docs/RELEASING.md): two-phase candidate, compatibility-lock, credential, rollback, and publication contract
+- [release/compatibility-lock.schema.json](release/compatibility-lock.schema.json): closed v0.6 two-consumer evidence shape

--- a/release/compatibility-lock.schema.json
+++ b/release/compatibility-lock.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/forkwright/typikon/release/compatibility-lock.schema.json",
+  "title": "Typikon release cohort compatibility lock",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "release", "candidate_artifact", "consumers"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "tag", "release_pr", "candidate_commit", "candidate_tree"],
+      "properties": {
+        "version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+        "tag": { "type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$" },
+        "release_pr": { "type": "integer", "minimum": 1 },
+        "candidate_commit": { "$ref": "#/$defs/sha" },
+        "candidate_tree": { "$ref": "#/$defs/sha" }
+      }
+    },
+    "candidate_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workflow_run_id", "run_attempt", "artifact_id", "artifact_name", "artifact_digest", "archive_name", "archive_sha256", "archive_size", "checksum_name", "checksum_sha256", "checksum_size", "sbom_name", "sbom_sha256", "sbom_size", "provenance_bundle_name", "provenance_bundle_sha256", "provenance_bundle_size", "sbom_bundle_name", "sbom_bundle_sha256", "sbom_bundle_size"],
+      "properties": {
+        "workflow_run_id": { "type": "integer", "minimum": 1 },
+        "run_attempt": { "type": "integer", "minimum": 1 },
+        "artifact_id": { "type": "integer", "minimum": 1 },
+        "artifact_name": { "type": "string", "pattern": "^typikon-v[0-9]+\\.[0-9]+\\.[0-9]+-candidate$" },
+        "artifact_digest": { "$ref": "#/$defs/digest" },
+        "archive_name": { "type": "string", "pattern": "^typikon-v[0-9]+\\.[0-9]+\\.[0-9]+\\.tar\\.gz$" },
+        "archive_sha256": { "$ref": "#/$defs/hex_digest" },
+        "archive_size": { "type": "integer", "minimum": 1 },
+        "checksum_name": { "type": "string", "pattern": "^typikon-v[0-9]+\\.[0-9]+\\.[0-9]+\\.tar\\.gz\\.sha256$" },
+        "checksum_sha256": { "$ref": "#/$defs/hex_digest" },
+        "checksum_size": { "type": "integer", "minimum": 1 },
+        "sbom_name": { "type": "string", "pattern": "^typikon-v[0-9]+\\.[0-9]+\\.[0-9]+\\.tar\\.gz\\.cdx\\.json$" },
+        "sbom_sha256": { "$ref": "#/$defs/hex_digest" },
+        "sbom_size": { "type": "integer", "minimum": 1 },
+        "provenance_bundle_name": { "type": "string", "pattern": "^typikon-v[0-9]+\\.[0-9]+\\.[0-9]+\\.tar\\.gz\\.provenance\\.intoto\\.jsonl$" },
+        "provenance_bundle_sha256": { "$ref": "#/$defs/hex_digest" },
+        "provenance_bundle_size": { "type": "integer", "minimum": 1 },
+        "sbom_bundle_name": { "type": "string", "pattern": "^typikon-v[0-9]+\\.[0-9]+\\.[0-9]+\\.tar\\.gz\\.sbom\\.intoto\\.jsonl$" },
+        "sbom_bundle_sha256": { "$ref": "#/$defs/hex_digest" },
+        "sbom_bundle_size": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "consumers": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "prefixItems": [
+        { "$ref": "#/$defs/tools_consumer" },
+        { "$ref": "#/$defs/leather_consumer" }
+      ],
+      "items": false
+    }
+  },
+  "$defs": {
+    "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "hex_digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "tools_consumer": {
+      "allOf": [
+        { "$ref": "#/$defs/consumer" },
+        {
+          "properties": {
+            "id": { "const": "tools" },
+            "repository": { "const": "ardent-tools/ardent-tools-site" },
+            "receipt_path": { "const": "release/compatibility/receipts/tools.json" }
+          }
+        }
+      ]
+    },
+    "leather_consumer": {
+      "allOf": [
+        { "$ref": "#/$defs/consumer" },
+        {
+          "properties": {
+            "id": { "const": "leather" },
+            "repository": { "const": "forkwright/ardent-site" },
+            "receipt_path": { "const": "release/compatibility/receipts/leather.json" }
+          }
+        }
+      ]
+    },
+    "consumer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "repository", "pull_request", "base_commit", "head_commit", "head_tree", "merge_commit", "merge_tree", "gitlink_path", "previous_gitlink_commit", "previous_gitlink_tree", "gitlink_commit", "gitlink_tree", "workflow_path", "workflow_commit", "workflow_blob", "workflow_run_id", "run_attempt", "required_job", "receipt_path", "receipt_sha256", "artifact_id", "artifact_name", "artifact_digest"],
+      "properties": {
+        "id": { "enum": ["tools", "leather"] },
+        "repository": { "enum": ["ardent-tools/ardent-tools-site", "forkwright/ardent-site"] },
+        "pull_request": { "type": "integer", "minimum": 1 },
+        "base_commit": { "$ref": "#/$defs/sha" },
+        "head_commit": { "$ref": "#/$defs/sha" },
+        "head_tree": { "$ref": "#/$defs/sha" },
+        "merge_commit": { "$ref": "#/$defs/sha" },
+        "merge_tree": { "$ref": "#/$defs/sha" },
+        "gitlink_path": { "const": "themes/typikon" },
+        "previous_gitlink_commit": { "$ref": "#/$defs/sha" },
+        "previous_gitlink_tree": { "$ref": "#/$defs/sha" },
+        "gitlink_commit": { "$ref": "#/$defs/sha" },
+        "gitlink_tree": { "$ref": "#/$defs/sha" },
+        "workflow_path": { "type": "string", "pattern": "^\\.github/workflows/[A-Za-z0-9._/-]+\\.ya?ml$" },
+        "workflow_commit": { "$ref": "#/$defs/sha" },
+        "workflow_blob": { "$ref": "#/$defs/sha" },
+        "workflow_run_id": { "type": "integer", "minimum": 1 },
+        "run_attempt": { "type": "integer", "minimum": 1 },
+        "required_job": { "const": "gate-and-deploy" },
+        "receipt_path": { "type": "string", "pattern": "^release/compatibility/receipts/(tools|leather)\\.json$" },
+        "receipt_sha256": { "$ref": "#/$defs/hex_digest" },
+        "artifact_id": { "type": "integer", "minimum": 1 },
+        "artifact_name": { "type": "string", "pattern": "^typikon-consumer-receipt-[0-9]+-[0-9]+$" },
+        "artifact_digest": { "$ref": "#/$defs/digest" }
+      }
+    }
+  }
+}

--- a/release/components.json
+++ b/release/components.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": 1,
+  "components": [
+    {
+      "name": "Zola",
+      "version": "0.23.3",
+      "purl": "pkg:github/getzola/zola@0.23.3?arch=x86_64&os=linux",
+      "scope": "required",
+      "license": "MIT",
+      "hash": {
+        "kind": "external-distribution",
+        "url": "https://github.com/getzola/zola/releases/download/v0.23.3/zola-v0.23.3-x86_64-unknown-linux-gnu.tar.gz",
+        "sha256": "f07c92607e5745268b576bd325ceef3a582aada253bb64db8d92a8a85303d958"
+      }
+    },
+    {
+      "name": "EB Garamond variable italic WOFF2",
+      "version": "1.003",
+      "purl": "pkg:generic/eb-garamond@1.003?file_name=eb-garamond-variable-italic.woff2",
+      "scope": "required",
+      "license": "OFL-1.1",
+      "hash": {
+        "kind": "repository-file",
+        "path": "static/fonts/eb-garamond-variable-italic.woff2"
+      }
+    },
+    {
+      "name": "EB Garamond variable WOFF2",
+      "version": "1.003",
+      "purl": "pkg:generic/eb-garamond@1.003?file_name=eb-garamond-variable.woff2",
+      "scope": "required",
+      "license": "OFL-1.1",
+      "hash": {
+        "kind": "repository-file",
+        "path": "static/fonts/eb-garamond-variable.woff2"
+      }
+    },
+    {
+      "name": "IBM Plex Mono 400 WOFF2",
+      "version": "2.004",
+      "purl": "pkg:generic/ibm-plex-mono@2.004?file_name=ibm-plex-mono-400.woff2",
+      "scope": "required",
+      "license": "OFL-1.1",
+      "hash": {
+        "kind": "repository-file",
+        "path": "static/fonts/ibm-plex-mono-400.woff2"
+      }
+    },
+    {
+      "name": "IBM Plex Mono 500 WOFF2",
+      "version": "2.004",
+      "purl": "pkg:generic/ibm-plex-mono@2.004?file_name=ibm-plex-mono-500.woff2",
+      "scope": "required",
+      "license": "OFL-1.1",
+      "hash": {
+        "kind": "repository-file",
+        "path": "static/fonts/ibm-plex-mono-500.woff2"
+      }
+    },
+    {
+      "name": "Spectral 400 italic WOFF2",
+      "version": "2.005",
+      "purl": "pkg:generic/spectral@2.005?file_name=spectral-400-italic.woff2",
+      "scope": "required",
+      "license": "OFL-1.1",
+      "hash": {
+        "kind": "repository-file",
+        "path": "static/fonts/spectral-400-italic.woff2"
+      }
+    },
+    {
+      "name": "Spectral 400 WOFF2",
+      "version": "2.005",
+      "purl": "pkg:generic/spectral@2.005?file_name=spectral-400.woff2",
+      "scope": "required",
+      "license": "OFL-1.1",
+      "hash": {
+        "kind": "repository-file",
+        "path": "static/fonts/spectral-400.woff2"
+      }
+    },
+    {
+      "name": "Spectral 500 italic WOFF2",
+      "version": "2.005",
+      "purl": "pkg:generic/spectral@2.005?file_name=spectral-500-italic.woff2",
+      "scope": "required",
+      "license": "OFL-1.1",
+      "hash": {
+        "kind": "repository-file",
+        "path": "static/fonts/spectral-500-italic.woff2"
+      }
+    },
+    {
+      "name": "Spectral 500 WOFF2",
+      "version": "2.005",
+      "purl": "pkg:generic/spectral@2.005?file_name=spectral-500.woff2",
+      "scope": "required",
+      "license": "OFL-1.1",
+      "hash": {
+        "kind": "repository-file",
+        "path": "static/fonts/spectral-500.woff2"
+      }
+    }
+  ]
+}

--- a/schemas/page.core.schema.json
+++ b/schemas/page.core.schema.json
@@ -61,7 +61,7 @@
         "body_class": {
           "type": "string",
           "pattern": "^[a-z][a-z0-9 -]*$",
-          "description": "CSS class on <body>. Used by the home page to hide nav/footer (body_class = 'home-page')."
+          "description": "CSS class on <body>. Used by the home page to hide nav/footer and by the branded error page to style its template-owned heading."
         },
         "og_image": {
           "type": "string",

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -765,18 +765,20 @@ footer p {
   opacity: 0;
 }
 
-/* === 404 PAGE === */
-.error-page {
+/* === 404 PAGE ===
+   The default page template owns the H1, so the semantic hook belongs on
+   body rather than on a Markdown wrapper below that heading (#187). */
+body.error-page main {
   text-align: center;
   padding: var(--space-xl) 0;
 }
 
-.error-page h1 {
+body.error-page main > h1 {
   font-size: var(--step-3);
   margin-bottom: var(--space-l);
 }
 
-.error-page p {
+body.error-page main p {
   color: var(--text-mid);
   margin-bottom: var(--space-s);
 }


### PR DESCRIPTION
## Purpose

Separate release preparation, immutable candidate evidence, consumer compatibility,
and publication so Typikon cannot tag v0.6 before both owned consumers have tested
the exact final release commit.

This change establishes four distinct subjects:

1. Release Please prepares a release PR but cannot create a tag.
2. The release PR squash becomes one untagged candidate commit `R`.
3. Ardent Tools and Ardent Leatherworks gate the exact `R` gitlink and retain
   machine-readable receipts.
4. A later evidence-only commit `E` carries one closed compatibility lock and
   those two byte-identical receipts. Manual publication replays that evidence,
   then creates an annotated SemVer tag at `R`.

The lock records distinct promotion and rollback commit/tree pairs for each
consumer. It binds candidate archive, checksum, SBOM, and offline attestation
bytes; consumer PR merge trees and workflow blobs; hosted runs and required jobs;
and raw artifact ZIP digests. Publication accepts only the exact tag, release body,
and nine locked assets.

This is the first typed two-consumer increment for #70. It does not complete the
broader generalized bundle, provider-adapter, or automatic merge-refusal program.

## Adjacent substrate fixes

- Refs #186: start Python directly with `--directory`, retain `$!` as
  the actual server process, and exercise launch/teardown topology in both
  source and rendered workflows.
- Refs #187: scope `error-page` presentation to the Typikon-owned main/H1
  content instead of leaking the class across the body shell, with an isolated
  heading/presentation fixture.

## Security and authority

- Candidate freezing has `contents: read` plus narrowly scoped attestation and
  OIDC authority. It has no contents, ref, PR, or release write and receives no
  repository secrets. It writes only the frozen run artifact and GitHub
  attestations for that exact candidate.
- Manual publication is bound to the current default `main` head and requires a
  reviewed single-writer hold through terminal readback. GitHub cannot atomically
  compare `main` with its separate tag/ref and draft-to-public writes.
- The two external consumer credentials appear only in the read-only verifier
  job. The write-authorized publisher is stdlib-only and receives neither token.
- Candidate bytes and both offline bundles are frozen once at `R`. A second live
  replay rebuilds the nine-file publication set, byte-compares it, then seals a
  raw-digest-bound same-run handoff for the publisher.
- Exact tag, draft, partial-asset, and published states are replayable only while
  `E` remains current. Main movement can leave an exact provisional tag, private
  draft, or unreceipted public release; those states fail closed and require a
  separately reviewed recovery action.
- The compatibility lock and both receipts are public release assets. The manual
  dispatch defaults to refusing publication until the operator explicitly
  acknowledges disclosure of the private Leather repository's operational
  metadata.

No repository secret is created or changed by this PR. Creating the two narrowly
scoped read tokens, accepting the private-metadata disclosure, enforcing a main
writer hold, and dispatching a release remain separate operator-owned actions.

## Deliberate publication blocks

- Reopened #58 owns the unmet lock-derived direct/transitive runtime, build, and
  development dependency graph. The all-tree source distribution ships `bin/`
  and `ci/`, so the current Zola-and-font inventory is incomplete. The candidate
  builder refuses to freeze any release until that original acceptance condition
  is genuinely met.
- #188 owns the inert `agent_corpus_exposure = "repository"` declaration. It must
  become a typed, pre-receipt rendered-artifact boundary before v0.6 freezes or
  Leather lands.
- The parked Release Please PR exists as #182. Its final squash `R`, both
  consumer migration receipts, and evidence lock `E` do not exist yet. The two
  receipt-token repository secrets are not installed, and no final dispatch has
  been authorized.

Merging this control change may refresh the parked release PR, but it cannot
itself tag, publish, deploy, or mutate a consumer. It does not authorize
bypassing either outstanding block; #58 is mechanically enforced here, while
#188 remains a required policy and follow-up substrate gate.

## Candidate

- base: `a6600b3e2121e6828528dbfd97799411a5922ce3`
- source commit: `600daa08118c2f24a15032c42ae6f1bdff519f3b`
- source tree: `423c5b50216b5f6462149024fa4147c346d95d7e`

## Static verification

- Kanon MCP lint: 0 violations, 8 documented suppressions, untruncated
- `check-static-server-template.py`
- `check-release-candidate.py`
- `check-consumer-receipt.py`
- `check-release-lock.py`
- `check-release-publication.py`
- `check-release-handoff.py`
- `check-release-workflows.py`
- `check-published-release.py`
- `check-tera2-contract.py`
- release-script AST, workflow YAML, and release JSON parsing
- `git diff --check`

No local Zola, browser, or full-site build ran. GitHub's pull-request workflow on
the synthetic merge tree is the first renderer authority. Keep this PR draft until
that exact candidate tree is green and independently reviewed.

Refs #58
Refs #70
Refs #188
