### PR TITLE
fix(template): stop recommending an apex redirect Cloudflare ignores

### DIFF
--- a/_redirects.tmpl
+++ b/_redirects.tmpl
@@ -9,9 +9,21 @@
 # Common cases the template ships disabled by default. Uncomment and edit
 # to match the consumer's domain, then commit.
 
-# Apex enforcement — point the wildcard at the canonical apex host.
-# Replace example.com with the consumer's apex.
-# https://www.example.com/* https://example.com/:splat 301
+# Apex enforcement is NOT expressible here. A source field naming a host
+# — `https://www.example.com/* https://example.com/:splat 301` — is
+# accepted by Cloudflare without error and then ignored: the file keeps
+# working for every path rule in it while that one line does nothing.
+# Measured on a live deployment carrying exactly that rule, where
+# `www.<apex>/` returned 200 alongside the apex and `www.<apex>/shop/`
+# redirected to `www.<apex>/products/` rather than leaving the www host,
+# while a sibling path rule in the same file redirected correctly.
+#
+# The silence is the danger: a rule that errored would be fixed, and one
+# that is ignored reads as protection nobody re-checks. ci/validate-deploy-bundle.py
+# therefore rejects a non-'/' source, so this cannot ship undetected.
+#
+# Enforce the apex where the hostname is actually in scope — a zone-level
+# Redirect Rule, or by not attaching the www CNAME to the Pages project.
 
 # Trailing-slash normalization — Cloudflare Pages handles this on its
 # own when files end in /index.html, but explicit rules can be added


### PR DESCRIPTION
## Finding

`_redirects.tmpl` ships this as the apex-enforcement recipe, commented out for consumers to enable:

```
# https://www.example.com/* https://example.com/:splat 301
```

Cloudflare Pages accepts a `_redirects` file containing that line and **ignores the line**. It does
not error, does not warn, and does not stop honouring the rest of the file. A consumer that enables
it gets a www/apex split it believes is closed.

## Evidence

Measured against a live consumer deployment carrying exactly that rule at its deployed `main`:

```
$ curl -sI https://www.ardentleatherworks.com/          -> HTTP/2 200        (no redirect)
$ curl -s -o /dev/null -w '%{http_code} %{redirect_url}' https://www.ardentleatherworks.com/shop/
                                                        -> 301 https://www.ardentleatherworks.com/products/
$ curl -s -o /dev/null -w '%{http_code} %{redirect_url}' https://ardentleatherworks.com/shop/
                                                        -> 301 https://ardentleatherworks.com/products/
```

The third line is the control: the sibling **path** rule `/shop/* /products/ 301` in the same file
works, on both hosts. So the file is read and honoured. The second line is the finding: on the www
host the path rule fires and the result **stays on www** — the host-source rule that was supposed to
move it to the apex never applies.

Both hosts therefore serve the site independently, which is precisely the condition the template's own
comment claimed the rule prevented.

## Why this matters

A rule that fails loudly gets fixed. This one succeeds at nothing and reports nothing, so it reads as
protection that nobody re-checks — the site's links, caches, analytics and cookie scope split across
two live host identities while the repository contains a line asserting they do not.

The template is the right place to fix it rather than each consumer, because the template is where
the belief came from: every site scaffolded by `typikon-init` inherits this file, and the one
consumer that enabled the rule did so *because the substrate recommended it*.

There is also an internal contradiction worth closing. `ci/validate-deploy-bundle.py:132` already
rejects a source that does not start with `/` — correctly. So the template was instructing consumers
to write exactly what this repository's own validator refuses. The two now agree, and the validator
is the reason this cannot ship again undetected.

## Desired correction

Replace the recipe with a statement of why it cannot work here and where apex enforcement actually
belongs — a zone-level Redirect Rule, or not attaching the www CNAME to the Pages project. Keep the
example string visible in the comment so a reader searching for it finds the explanation rather than
re-deriving it.

Done when:
- `_redirects.tmpl` no longer offers a host-source rule as a working option.
- It names why, with the measurement, and points at where the enforcement belongs.
- The template and `ci/validate-deploy-bundle.py` agree about what a valid source is.
