### PR TITLE
fix(ci): give the consumer receipt the history it reads

### DIFF
--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -51,6 +51,12 @@ jobs:
         with:
           submodules: recursive  # Pulls typikon as themes/typikon/
           persist-credentials: false
+          # WHY full history: ci/write-consumer-receipt.py proves the checkout
+          # IS the pull request's synthetic merge by reading its parents. A
+          # shallow clone grafts those away, so `rev-list --parents` returns
+          # none and the receipt cannot be written. A step whose job is to
+          # prove provenance cannot run on a checkout with the provenance cut.
+          fetch-depth: 0
 
       # ── Tooling install ────────────────────────────────────────
       - name: Install Zola


### PR DESCRIPTION
## Finding

`ci/github-workflow.yml.tmpl` generates a consumer workflow that runs
`ci/write-consumer-receipt.py` (line 322) on a checkout it configures **shallow** (lines 50-53, no
`fetch-depth`). The receipt script's first assertion reads the checkout's parents:

```python
# ci/write-consumer-receipt.py:64-70
parents = git(root, "rev-list", "--parents", "-n", "1", "HEAD").split()[1:]
expected_parents = [pr["base"]["sha"], pr["head"]["sha"]]
if parents != expected_parents:
    raise ReceiptError(
        "checkout is not the pull request synthetic merge: "
        f"parents={parents}, expected={expected_parents}"
    )
```

A depth-1 checkout grafts the parents away, so `parents` is always `[]` and the comparison can never
succeed. **The consumer receipt has never been able to pass on a pull request in a
template-generated workflow.**

## Evidence

Reproduced on `forkwright/ardent-site` PR #37, run 32443077734:

```
write-consumer-receipt: checkout is not the pull request synthetic merge:
  parents=[], expected=['ccf76532b50fa10fe4310bafb0d1ad4b00a34d13',
                        'dc51ccd08f20724648c25ea68d327ee397bef0d0']
##[error]Process completed with exit code 1
```

`parents=[]` is the tell: not a wrong parent, no parents at all.

The other consumer, `ardent-tools/ardent-tools-site`, does not hit this — and the reason is worth
stating, because it is why the defect stayed hidden. Its workflow sets `fetch-depth: 0` for an
unrelated reason ("Retention history is proved against the event's trusted base SHA") **and** does not
run the receipt step. So the one repository with the right checkout does not exercise the step, and
the one that exercises the step has the wrong checkout. Neither was in a position to report it.

## Why this matters

The receipt is the evidence half of the two-phase release control landed in #189, and #70 ("verify
the complete consumer cohort before Typikon publication") is meant to rest on consumers producing
these receipts against one identical candidate. A receipt step that cannot pass makes that
verification unobtainable — the cohort gate would be waiting on an artifact no consumer can emit.

The shape is also worth naming, because it is the third instance found in this repository's
neighbourhood today: a control that appears present and does nothing. Here it at least fails loudly
once reached, which is why it was findable at all — but it was only reached after two earlier stages
in the same consumer's gate were fixed, so it had been sitting behind them.

## Desired correction

Give the step the history it reads. `fetch-depth: 0` rather than a two-commit minimum, because a step
whose entire purpose is proving which commit this is should not run on a checkout with its
provenance truncated — and because it makes both consumers' checkouts consistent.

Done when:
- The generated workflow's checkout carries `fetch-depth: 0` with the reason stated at the call site.
- A consumer pull request reaches `write-consumer-receipt.py` and the step passes.

Verified by `forkwright/ardent-site` PR #37 once it consumes a Typikon carrying this.
