### PR TITLE
feat(ci): enforce the repository-only agent corpus at the rendered boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ All decisions are in [CLAUDE.md](CLAUDE.md) under "Locked decisions". Key ones:
 - **Strict CSP**: no `unsafe-inline` anywhere. CSP-enforce CI gate fails the build on inline script/style/handler.
 - **Self-hosted fonts**: WOFF2 under `static/fonts/`. Zero external CDN at visitor runtime.
 - **Root Atom ownership**: a consumer may set `extra.feed_source_section` to one canonical `_index.md` path. That owner and every translation use `sort_by = "date"`; missing, empty, or wrongly sorted sources fail while native section/taxonomy feeds remain Zola-owned.
+- **Repository-only agent corpus**: a consumer may set `extra.agent_corpus_exposure = "repository"`, the only accepted value. It is enforced, not advisory: `ci/validate-artifact-boundary.py` fails the local gate and both generated pipelines — before the consumer receipt and before deploy — if the rendered `public/` or `public-local/` tree carries an `llms.txt` basename or an `_llm` path component, under any casing or behind a renamed symlink. Omit the field to make no claim.
 - **Fail-closed checkout**: a catalog price does not imply readiness. Checkout and Offer URLs require sourced purchasable availability; shipping copy requires paired provenance.
 - **Push authority**: `origin` is GitHub; no forge remote is configured. forkwright/kanon#3045 owns the typed authority split.
 - **License**: PolyForm Noncommercial 1.0.0 (`LicenseRef-PolyForm-Noncommercial-1.0.0`). `LICENSE` is authoritative.

--- a/bin/typikon-check
+++ b/bin/typikon-check
@@ -464,6 +464,17 @@ else
     require_or_skip "playwright-smoke" "npx not on PATH"
 fi
 
+# Stage 11 — agent-corpus boundary (forkwright/typikon#188). LAST by design:
+# every earlier stage can still write into public/ or public-local/, so this is
+# the only point where the trees asserted are the trees that would ship.
+# WHY not require_or_skip: skipping would report the boundary held on output
+# that was never produced. The checker makes the distinction itself — a
+# consumer declaring nothing passes, an absent tree is an error.
+run_stage "agent-corpus-boundary" \
+    python3 "$TYPIKON_ROOT/ci/validate-artifact-boundary.py" \
+        --root "$ROOT" public public-local \
+    || FAIL=1
+
 if [[ "$FAIL" -eq 1 ]]; then
     exit 1
 elif [[ "$INCOMPLETE" -eq 1 ]]; then

--- a/bin/typikon-validate
+++ b/bin/typikon-validate
@@ -459,6 +459,44 @@ def validate_file(
     return failures
 
 
+def validate_agent_corpus_exposure_contract(root: Path) -> list[dict]:
+    """Type the repository-only agent-corpus declaration (forkwright/typikon#188).
+
+    The field is optional: a consumer that does not set it makes no claim, and
+    that is a legitimate posture rather than an omission. What it may not be is
+    *almost* set. `repository` is the only value the substrate can prove, so any
+    other value — a typo, a plausible-looking `private`, a bool — is rejected
+    here rather than passing config validation and then being silently ignored
+    by ci/validate-artifact-boundary.py at the rendered boundary.
+
+    INVARIANT: whatever this admits, the boundary checker enforces. Both read
+    the same field for the same reason, so the set that validates and the set
+    that is enforced are the same set.
+    """
+    config_path = root / "config.toml"
+    if not config_path.is_file():
+        return []
+    try:
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return [{"file": "config.toml", "pointer": "", "error": f"malformed config.toml: {exc}"}]
+    extra = config.get("extra")
+    declared = extra.get("agent_corpus_exposure") if isinstance(extra, dict) else None
+    if declared is None:
+        return []
+    if declared != "repository":
+        return [{
+            "file": "config.toml",
+            "pointer": "/extra/agent_corpus_exposure",
+            "error": (
+                'agent_corpus_exposure accepts only "repository"; it declares that the '
+                "agent corpus stays in the repository and is enforced against the rendered "
+                "output by ci/validate-artifact-boundary.py. Omit the field to make no claim."
+            ),
+        }]
+    return []
+
+
 def validate_feed_source_contract(root: Path, content_root: Path) -> list[dict]:
     """Require a scoped root-feed owner to expose Zola's native date order.
 
@@ -741,6 +779,7 @@ def main(argv: list[str]) -> int:
 
     files = sorted(content_root.rglob("*.md"))
     contract_failures = validate_feed_source_contract(root, content_root)
+    contract_failures.extend(validate_agent_corpus_exposure_contract(root))
     failures: list[dict] = list(contract_failures)
     for f in files:
         failures.extend(validate_file(

--- a/ci/check-artifact-boundary.py
+++ b/ci/check-artifact-boundary.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""check-artifact-boundary — regression test for the agent-corpus boundary
+(forkwright/typikon#188).
+
+WHY: `extra.agent_corpus_exposure = "repository"` is a promise about bytes that
+reach the public web. Before this, the field was inert — typed nowhere, checked
+nowhere — so validation output overstated what the substrate guaranteed. This
+proves two separate things, because either alone would be a false comfort:
+
+1. The shipped ci/validate-artifact-boundary.py refuses every shape of the leak,
+   driven as the real subprocess the pipelines run, not a reimplementation.
+2. The stage is actually WIRED, in a position where it can still block. A
+   checker nothing calls is worth exactly nothing, and #48's own re-derivation
+   found "the assertion is present and nothing would catch its removal" to be
+   the more durable defect. So removal or reordering fails here.
+
+NOTE: runs standalone (no consumer site needed) as part of ci/run-fixtures.sh.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+THEME_ROOT = Path(__file__).resolve().parent.parent
+VALIDATE = THEME_ROOT / "ci" / "validate-artifact-boundary.py"
+WORKFLOW_TMPL = THEME_ROOT / "ci" / "github-workflow.yml.tmpl"
+KANON_TMPL = THEME_ROOT / "ci" / "kanon-ci.toml.tmpl"
+LOCAL_GATE = THEME_ROOT / "bin" / "typikon-check"
+
+DECLARED = 'base_url = "https://example.test"\n[extra]\nagent_corpus_exposure = "repository"\n'
+UNDECLARED = 'base_url = "https://example.test"\n'
+
+# (label, config.toml body, {relative path: kind}, expect_pass)
+# kind: "file" writes an empty file; "dir" makes a directory;
+#       "link:<target>" makes a symlink with that literal target.
+CASES: list[tuple[str, str, dict[str, str], bool]] = [
+    ("clean tree, boundary declared", DECLARED, {"public/index.html": "file"}, True),
+    ("llms.txt at the tree root", DECLARED, {"public/llms.txt": "file"}, False),
+    ("llms.txt nested deep", DECLARED, {"public/a/b/c/llms.txt": "file"}, False),
+    # A case-preserving filesystem holds this happily and a case-insensitive
+    # host serves it as llms.txt, so matching one spelling would admit the leak.
+    ("LLMS.TXT differing only in case", DECLARED, {"public/LLMS.TXT": "file"}, False),
+    ("_llm directory at the root", DECLARED, {"public/_llm": "dir"}, False),
+    ("_llm directory nested", DECLARED, {"public/a/_llm": "dir"}, False),
+    ("_LLM directory differing only in case", DECLARED, {"public/_LLM": "dir"}, False),
+    ("file inside a nested _llm component", DECLARED, {"public/a/_llm/facts.toml": "file"}, False),
+    # Renaming is the cheap way around a name check: the served path says
+    # "docs" while every byte behind it is the corpus.
+    ("directory symlink renaming _llm", DECLARED, {"public/docs": "link:../_llm"}, False),
+    ("file symlink named llms.txt", DECLARED, {"public/llms.txt": "link:../_llm/facts.toml"}, False),
+    # public-local/ ships nothing itself, but it is what pa11y and playwright
+    # serve, so a leak there is a leak to every browser assertion downstream.
+    ("leak only in public-local", DECLARED, {"public/index.html": "file", "public-local/llms.txt": "file"}, False),
+    # The field is optional. A consumer that never claimed the boundary is not
+    # violating it, and failing here would punish a legitimate posture.
+    ("no declaration, corpus present", UNDECLARED, {"public/llms.txt": "file"}, True),
+]
+
+
+def build(tmp: Path, config_body: str, entries: dict[str, str]) -> Path:
+    root = tmp / "site"
+    (root / "public").mkdir(parents=True, exist_ok=True)
+    (root / "public-local").mkdir(parents=True, exist_ok=True)
+    (root / "config.toml").write_text(config_body, encoding="utf-8")
+    for rel, kind in entries.items():
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if kind == "dir":
+            target.mkdir(exist_ok=True)
+        elif kind.startswith("link:"):
+            os.symlink(kind[len("link:"):], target)
+        else:
+            target.write_text("", encoding="utf-8")
+    return root
+
+
+def run_cases() -> list[str]:
+    failures: list[str] = []
+    for label, config_body, entries, expect_pass in CASES:
+        with tempfile.TemporaryDirectory() as td:
+            root = build(Path(td), config_body, entries)
+            proc = subprocess.run(
+                [sys.executable, str(VALIDATE), "--root", str(root), "public", "public-local"],
+                cwd=root, capture_output=True, text=True,
+            )
+        passed = proc.returncode == 0
+        if passed != expect_pass:
+            want = "pass" if expect_pass else "fail"
+            failures.append(
+                f"{label}: expected {want}, got exit {proc.returncode}"
+                f" (stdout={proc.stdout.strip()!r} stderr={proc.stderr.strip()!r})"
+            )
+    return failures
+
+
+def check_missing_tree() -> list[str]:
+    """An absent rendered tree must be an error, never a silent pass.
+
+    WHY its own case: this is the difference between "the boundary held" and
+    "there was nothing to check", and collapsing the two is precisely how an
+    inert guard reports success forever.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "site"
+        root.mkdir(parents=True)
+        (root / "config.toml").write_text(DECLARED, encoding="utf-8")
+        proc = subprocess.run(
+            [sys.executable, str(VALIDATE), "--root", str(root), "public", "public-local"],
+            cwd=root, capture_output=True, text=True,
+        )
+    if proc.returncode == 0:
+        return ["absent rendered trees: expected fail, got exit 0"]
+    return []
+
+
+def check_malformed_declaration() -> list[str]:
+    """A value the config contract rejects must not be silently enforced as absent."""
+    with tempfile.TemporaryDirectory() as td:
+        root = build(Path(td), 'base_url = "https://x.test"\n[extra]\nagent_corpus_exposure = "private"\n',
+                     {"public/index.html": "file"})
+        proc = subprocess.run(
+            [sys.executable, str(VALIDATE), "--root", str(root), "public", "public-local"],
+            cwd=root, capture_output=True, text=True,
+        )
+    if proc.returncode == 0:
+        return ['agent_corpus_exposure = "private": expected fail, got exit 0']
+    return []
+
+
+def check_hosted_wiring() -> list[str]:
+    """The generated GitHub pipeline must call the checker, in a blocking position."""
+    failures: list[str] = []
+    text = WORKFLOW_TMPL.read_text(encoding="utf-8")
+    if "validate-artifact-boundary.py" not in text:
+        return [f"{WORKFLOW_TMPL.name}: does not invoke validate-artifact-boundary.py at all"]
+    steps = [(i, line) for i, line in enumerate(text.splitlines()) if line.lstrip().startswith("- name:")]
+
+    def index_of(fragment: str) -> int | None:
+        for i, line in steps:
+            if fragment in line:
+                return i
+        return None
+
+    boundary = index_of("agent corpus stayed out")
+    consumer = index_of("Consumer checks")
+    receipt = index_of("Record Typikon consumer receipt")
+    deploy = index_of("Deploy to Cloudflare Pages")
+    if boundary is None:
+        failures.append(f"{WORKFLOW_TMPL.name}: no step asserting the agent-corpus boundary")
+        return failures
+    for label, other in (("Consumer checks", consumer),):
+        if other is not None and boundary < other:
+            failures.append(
+                f"{WORKFLOW_TMPL.name}: boundary step runs BEFORE '{label}', so it would "
+                "assert a tree that stage can still write to"
+            )
+    for label, other in (("Record Typikon consumer receipt", receipt), ("Deploy to Cloudflare Pages", deploy)):
+        if other is not None and boundary > other:
+            failures.append(
+                f"{WORKFLOW_TMPL.name}: boundary step runs AFTER '{label}', so the corpus "
+                "would already be recorded or published before it is checked"
+            )
+    return failures
+
+
+def check_kanon_wiring() -> list[str]:
+    """The generated Kanon pipeline must define the stage AND schedule it.
+
+    WHY both: `[pipeline] stages` is execution order in this file. A stage
+    defined but left out of that list is inert, and reads as present.
+    """
+    failures: list[str] = []
+    raw = KANON_TMPL.read_text(encoding="utf-8")
+    if "validate-artifact-boundary.py" not in raw:
+        failures.append(f"{KANON_TMPL.name}: does not invoke validate-artifact-boundary.py at all")
+    try:
+        parsed = tomllib.loads(raw)
+    except tomllib.TOMLDecodeError as exc:
+        return failures + [f"{KANON_TMPL.name}: is not parseable TOML: {exc}"]
+    order = parsed.get("pipeline", {}).get("stages", [])
+    stage = "assert-agent-corpus-boundary"
+    if stage not in parsed.get("stages", {}):
+        failures.append(f"{KANON_TMPL.name}: [stages.{stage}] is not defined")
+    if stage not in order:
+        failures.append(
+            f"{KANON_TMPL.name}: '{stage}' is absent from [pipeline] stages, so it never runs"
+        )
+        return failures
+    at = order.index(stage)
+    if "consumer-checks" in order and at < order.index("consumer-checks"):
+        failures.append(f"{KANON_TMPL.name}: '{stage}' is scheduled before consumer-checks")
+    if "deploy-cloudflare-pages" in order and at > order.index("deploy-cloudflare-pages"):
+        failures.append(f"{KANON_TMPL.name}: '{stage}' is scheduled after deploy-cloudflare-pages")
+    return failures
+
+
+def check_local_wiring() -> list[str]:
+    """The local gate must run the checker, and must not treat it as skippable."""
+    failures: list[str] = []
+    text = LOCAL_GATE.read_text(encoding="utf-8")
+    if "validate-artifact-boundary.py" not in text:
+        return [f"{LOCAL_GATE.name}: does not invoke validate-artifact-boundary.py at all"]
+    if "require_or_skip \"agent-corpus-boundary\"" in text or "require_or_skip 'agent-corpus-boundary'" in text:
+        failures.append(
+            f"{LOCAL_GATE.name}: the boundary stage is skippable; a skipped boundary "
+            "reports a guarantee nothing checked"
+        )
+    call = text.index("validate-artifact-boundary.py")
+    playwright = text.rfind("playwright-smoke")
+    if playwright != -1 and call < playwright:
+        failures.append(
+            f"{LOCAL_GATE.name}: the boundary stage runs before the last stage that "
+            "writes public-local/, so it would assert a non-final tree"
+        )
+    return failures
+
+
+def main() -> int:
+    if not VALIDATE.is_file():
+        print(f"check-artifact-boundary: missing {VALIDATE}", file=sys.stderr)
+        return 1
+    failures: list[str] = []
+    failures += run_cases()
+    failures += check_missing_tree()
+    failures += check_malformed_declaration()
+    failures += check_hosted_wiring()
+    failures += check_kanon_wiring()
+    failures += check_local_wiring()
+
+    if failures:
+        print("check-artifact-boundary: FAIL", file=sys.stderr)
+        for f in failures:
+            print(f"  {f}", file=sys.stderr)
+        return 1
+    print(
+        f"check-artifact-boundary: ok ({len(CASES)} corpus cases, absent-tree and "
+        "malformed-declaration cases, and the stage's wiring in all three pipelines)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/github-workflow.yml.tmpl
+++ b/ci/github-workflow.yml.tmpl
@@ -318,6 +318,20 @@ jobs:
         timeout-minutes: 2
         run: bash ci/consumer-check.sh
 
+      # ── Agent-corpus boundary (forkwright/typikon#188) ─────────
+      # POSITION IS LOAD-BEARING: after every stage that can still write into a
+      # rendered tree, and before the receipt records what was evaluated and
+      # before Wrangler publishes it. Moved earlier it would assert a tree that
+      # is not yet final; moved later it would assert one that is already
+      # public. ci/check-artifact-boundary.py fails if this step is removed or
+      # reordered relative to those two neighbours.
+      - name: Assert the agent corpus stayed out of the rendered output
+        timeout-minutes: 1
+        run: |
+          python3 themes/typikon/ci/validate-artifact-boundary.py \
+            --root "$GITHUB_WORKSPACE" \
+            public public-local
+
       # A successful PR run is later eligible for a release-cohort lock only
       # when its exact checkout, workflow, and Typikon gitlink are retained as
       # machine-readable evidence. The job conclusion remains GitHub-owned and

--- a/ci/kanon-ci.toml.tmpl
+++ b/ci/kanon-ci.toml.tmpl
@@ -31,6 +31,7 @@ stages = [
   "playwright",
   "teardown-static-server",
   "consumer-checks",
+  "assert-agent-corpus-boundary",
   "deploy-cloudflare-pages",
 ]
 
@@ -231,6 +232,20 @@ if [ -f ci/consumer-check.sh ]; then
 fi
 """
 timeout_secs = 120
+
+# Agent-corpus boundary (forkwright/typikon#188). Mirrors the hosted pipeline's
+# step, in the same position and for the same reason: the last writer to a
+# rendered tree is upstream of here, and publication is downstream.
+# WARNING: execution order is the `[pipeline] stages` list above, NOT this
+# file's layout — a stage defined here but absent from that list never runs at
+# all. ci/check-artifact-boundary.py asserts both the definition and its
+# position in that list.
+[stages.assert-agent-corpus-boundary]
+cmd = """
+set -euo pipefail
+python3 themes/typikon/ci/validate-artifact-boundary.py --root . public public-local
+"""
+timeout_secs = 60
 
 [stages.deploy-cloudflare-pages]
 cmd = """

--- a/ci/validate-artifact-boundary.py
+++ b/ci/validate-artifact-boundary.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""validate-artifact-boundary — prove a repository-only agent corpus stayed out of
+the rendered site (forkwright/typikon#188).
+
+WHY this exists rather than a consumer-side browser assertion: a consumer can
+declare `extra.agent_corpus_exposure = "repository"` and mean it, while the
+rendered tree ships the corpus anyway. A browser test reaches one route on one
+consumer, after the build, and a generated pipeline can regress before it gets
+there. The declaration is only a contract if something proves the artifact
+honours it, on every consumer, at the boundary where the bytes become public.
+
+WHY case-insensitive matching: the check is fail-closed about what a host might
+serve. Cloudflare Pages resolves some paths case-insensitively and a
+case-preserving filesystem will happily hold `LLMS.txt`, so matching only the
+exact lowercase spelling would let the same corpus through under a different
+capitalisation. A guard keyed to one spelling is a guard on a spelling.
+
+WHY symlinks are judged by name and never followed: a symlink named `llms.txt`
+serves the corpus exactly as a regular file does, and following one could walk
+outside the tree entirely. The name is the disclosure, so the name is what is
+checked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+FORBIDDEN_BASENAME = "llms.txt"
+FORBIDDEN_COMPONENT = "_llm"
+DECLARED_REPOSITORY_ONLY = "repository"
+FIELD = "agent_corpus_exposure"
+
+
+class BoundaryError(Exception):
+    """The declaration could not be read, so the boundary cannot be asserted."""
+
+
+def read_declaration(root: Path) -> str | None:
+    """Return the consumer's declared exposure, or None when it declares none.
+
+    INVARIANT: an absent config or an absent field means the consumer never
+    claimed the boundary, which is not a failure. A config that exists and
+    cannot be parsed is a failure, because then the claim is unknowable and
+    silently skipping would report a guarantee this never checked.
+    """
+    config_path = root / "config.toml"
+    if not config_path.is_file():
+        return None
+    try:
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise BoundaryError(f"config.toml exists but could not be read: {exc}") from exc
+    extra = config.get("extra")
+    if not isinstance(extra, dict):
+        return None
+    declared = extra.get(FIELD)
+    if declared is None:
+        return None
+    if declared != DECLARED_REPOSITORY_ONLY:
+        raise BoundaryError(
+            f"extra.{FIELD} must be {DECLARED_REPOSITORY_ONLY!r} when present, "
+            f"got {declared!r}"
+        )
+    return declared
+
+
+def _forbidden_target(entry: Path) -> bool:
+    """True when `entry` is a symlink whose target path names the corpus.
+
+    WHY: renaming is the cheap way around a name check. `public/docs -> ../_llm`
+    publishes every byte of the corpus under a basename this would otherwise
+    admit, and os.walk never descends it because links are not followed. Reading
+    the link's own target costs one syscall and closes that.
+
+    NOTE: this reads the recorded target, not a resolved one. A chain of links
+    through a directory this walk never visits is outside what a name-based
+    check can see, and is stated as a limit rather than implied to be covered.
+    """
+    if not entry.is_symlink():
+        return False
+    target = os.readlink(entry)
+    return any(part.lower() == FORBIDDEN_COMPONENT for part in Path(target).parts)
+
+
+def violations(tree: Path) -> list[str]:
+    """Every path under `tree` that would publish the repository-only corpus."""
+    found: set[str] = set()
+    for dirpath, dirnames, filenames in os.walk(tree, followlinks=False):
+        here = Path(dirpath)
+        rel_dir = here.relative_to(tree)
+        for name in dirnames:
+            if name.lower() == FORBIDDEN_COMPONENT:
+                found.add(f"{rel_dir / name}/")
+            elif _forbidden_target(here / name):
+                found.add(f"{rel_dir / name} -> {os.readlink(here / name)}")
+        for name in filenames:
+            if name.lower() == FORBIDDEN_BASENAME:
+                found.add(str(rel_dir / name))
+            elif _forbidden_target(here / name):
+                found.add(f"{rel_dir / name} -> {os.readlink(here / name)}")
+    return sorted(found)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--root", type=Path, default=Path("."),
+                        help="consumer root holding config.toml (default: cwd)")
+    parser.add_argument("trees", type=Path, nargs="+",
+                        help="rendered output trees to scan, e.g. public public-local")
+    args = parser.parse_args(argv)
+
+    try:
+        declared = read_declaration(args.root)
+    except BoundaryError as exc:
+        print(f"validate-artifact-boundary: {exc}", file=sys.stderr)
+        return 1
+
+    if declared is None:
+        print(
+            f"validate-artifact-boundary: skipped — no extra.{FIELD} declared, "
+            "so no repository-only boundary is claimed"
+        )
+        return 0
+
+    scanned: list[str] = []
+    failures: list[str] = []
+    for tree in args.trees:
+        if not tree.is_dir():
+            # A tree the local gate did not build is not a violation; the hosted
+            # pipeline passes only trees it produced.
+            continue
+        scanned.append(str(tree))
+        for hit in violations(tree):
+            failures.append(f"{tree}/{hit}")
+
+    if not scanned:
+        print(
+            "validate-artifact-boundary: no rendered tree found among "
+            f"{', '.join(str(t) for t in args.trees)} — nothing to assert",
+            file=sys.stderr,
+        )
+        return 1
+
+    if failures:
+        print(
+            f"validate-artifact-boundary: extra.{FIELD} = {declared!r} promises the "
+            "agent corpus stays in the repository, but the rendered output would "
+            "publish it:",
+            file=sys.stderr,
+        )
+        for hit in failures:
+            print(f"  {hit}", file=sys.stderr)
+        return 1
+
+    print(
+        f"validate-artifact-boundary: ok ({', '.join(scanned)} carry no "
+        f"{FORBIDDEN_BASENAME} and no {FORBIDDEN_COMPONENT} path component)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -235,6 +235,7 @@ The substrate is design-family neutral. Brand-specific values go in `config.toml
 | `nav_items`, `footer_links` | navigation structure                        |
 | `[extra.author]`            | atom feed `<author>` + JSON-LD Article author |
 | `feed_source_section`       | optional root Atom owner, e.g. `journal/_index.md` |
+| `agent_corpus_exposure`     | optional; only `"repository"`. Declares — and makes Typikon enforce — that the agent corpus never reaches the rendered site |
 | `consumer_css`              | list of stylesheet paths, each `<link>`ed after core's own `style.css`, in order (`templates/base.html`'s Consumer stylesheet hook) |
 
 If a brand needs a *visual* override beyond the table above (different scale ratio, different color palette, different type pairing), declare it via `consumer_css` and redeclare the relevant `:root` custom properties in that file. Core's own interactive-state CSS never hard-codes a hue. Nav hover, buttons, the home triad mark, FAQ anchors, and similar surfaces resolve through four semantic tokens: `--accent-1` through `--accent-4`. Those tokens default to a neutral `--text-mid` and exist solely for a skin to redeclare. `static/css/skins/leather.css` is the first-party example: it maps those four tokens to Ardent Leatherworks' dye palette and carries that brand's own content-authoring classes (`.dye-entry-*`, `.swatch-*`, `.dye-marks`) — copy its shape, not its colors, for a new skin. **Do not edit typikon's `static/css/style.css`** for one-off site needs — that's a fork by mutation.
@@ -248,6 +249,29 @@ parsed-datetime ordering and prevents its section serializer from omitting
 pages under an incompatible sort key. `include_in_feeds = false` pages and pages bubbled from transparent
 subsections stay out. Native section and taxonomy feeds keep Zola's supplied
 membership.
+
+`agent_corpus_exposure` is the one `extra` field whose value is a promise about
+the *output* rather than the build. Setting it to `"repository"` declares that
+your agent corpus — `llms.txt`, anything under `_llm/` — stays in Git and never
+becomes a public route. Typikon holds you to it: `ci/validate-artifact-boundary.py`
+scans the final `public/` and `public-local/` trees and fails if either would
+publish that corpus. It runs last in `bin/typikon-check`, and in both generated
+pipelines it runs after every stage that can still write to a rendered tree and
+before the consumer receipt and the deploy — so a violation blocks publication
+rather than being discovered on the live site.
+
+Three things it deliberately catches beyond the obvious spelling, because a
+guard keyed to one spelling is a guard on a spelling: any casing (`LLMS.TXT`),
+any depth (`a/b/_llm/facts.toml`), and a symlink that renames the corpus to
+something innocuous (`public/docs -> ../_llm`). What it does not follow is a
+chain of links through a directory outside the scanned trees; that limit is
+stated in the script rather than implied away.
+
+The field is optional and its absence is a legitimate posture, not an omission
+— a site that intends to publish `llms.txt` simply does not set it. What is
+rejected is a value that is *almost* right: `bin/typikon-validate` fails config
+validation on anything other than `"repository"`, so a plausible-looking
+`"private"` cannot pass validation and then be silently ignored at the boundary.
 
 A missing source or one with no eligible direct pages fails the
 build and names the configured path instead of silently reverting to a


### PR DESCRIPTION
## Finding

`extra.agent_corpus_exposure = "repository"` was inert. `bin/typikon-validate` had no branch for it,
no stage scanned either rendered tree for the corpus, and nothing connected the declaration to the
bytes it was about. A consumer could set it, pass every gate, and publish `llms.txt` anyway — and
validation output would report a guarantee the substrate did not provide.

Ardent Leatherworks declares it (`config.toml:25`) and its agent contract says neither `/llms.txt`
nor `/_llm/` may be served. That was resting on a site-local substitute rather than on the substrate.

## What this does

**Types the declaration.** `validate_agent_corpus_exposure_contract` accepts the field as optional —
a consumer that makes no claim is not in violation — and rejects any value other than `"repository"`.
The point of rejecting rather than ignoring: a plausible-looking `"private"` would otherwise pass
config validation and then be silently treated as *absent* by the boundary check, which is the worst
of both readings. Whatever validation admits, the boundary enforces; the two read the same field.

**Adds the boundary checker.** `ci/validate-artifact-boundary.py`, stdlib only, walks the final
`public/` and `public-local/` trees and fails on an `llms.txt` basename or an `_llm` path component.
Three deliberate hardenings, each because a name check keyed to one spelling is a guard on a
spelling rather than on the fact:

- **Case-insensitive.** `LLMS.TXT` sits happily on a case-preserving filesystem and is served by a
  case-insensitive host as the same route.
- **Symlink targets are read.** `public/docs -> ../_llm` publishes every byte of the corpus under a
  basename the check would otherwise admit, and `os.walk` never descends it. One `readlink` closes
  that. The limit — a chain of links through a directory outside the scanned trees — is stated in
  the script rather than implied away.
- **An absent tree is an error, not a pass.** "The boundary held" and "there was nothing to check"
  are different results, and collapsing them is how an inert guard reports success forever.

**Wires it where it can still block.** Last stage in `bin/typikon-check`; in both generated
pipelines, after every stage that can still write a rendered tree and before the consumer receipt
and before Wrangler. Earlier it would assert a non-final tree; later it would assert one already
published.

## Evidence

`ci/check-artifact-boundary.py` drives the shipped checker as the real subprocess over twelve corpus
cases — root, nested, case-differing, `_llm` directory at two depths, a file inside a nested `_llm`,
a renamed directory symlink, a symlinked `llms.txt`, a leak only in `public-local/`, and the
no-declaration posture that must pass — plus the absent-tree and malformed-declaration cases.

It then asserts the wiring itself, which is the half that rots silently. #48's own re-derivation
found "the assertion is present and nothing would catch its removal" to be the more durable defect,
so this proves the equivalent claim does **not** hold here. Every mutation below was run against the
shipped files and each was caught:

| Mutation | Result |
|---|---|
| Delete the step from `github-workflow.yml.tmpl` | `does not invoke validate-artifact-boundary.py at all` |
| Move the Kanon stage after `deploy-cloudflare-pages` | `scheduled after deploy-cloudflare-pages` |
| Define the Kanon stage but drop it from `[pipeline] stages` | `absent from [pipeline] stages, so it never runs` |
| Remove the stage from `bin/typikon-check` | `does not invoke validate-artifact-boundary.py at all` |
| Neuter the checker so it always exits 0 | 10 corpus cases report `expected fail, got exit 0` |

That third row is the one worth naming: in `kanon-ci.toml.tmpl` the `[pipeline] stages` list is
execution order, so a stage can be fully defined, read as present, and never run. Checking the
definition alone would have missed it.

## Why this matters

Repository-facing facts can carry private operational context that belongs in Git and not on a
public website. A consumer-specific browser assertion is both too late and too narrow — it reaches
one route on one consumer after the build, and the next consumer to adopt the field inherits none of
it. Putting the guarantee in the substrate is what makes the declaration mean something on every
consumer, and lets Leather drop its site-local substitute without weakening anything.

Done when, from the issue, and where each is met:
- declaration typed — `bin/typikon-validate`
- malformed values fail config validation — `"private"` case in the fixture
- a clean consumer passes — first fixture case
- either tree failing locally and in both hosted contracts before receipt/deploy — the wiring
  assertions above
- removal or reordering fails a causal fixture — the mutation table above
- Leather can remove its site-local substitute — the guarantee is now substrate-side

Closes #188.
