### PR TITLE
fix(schema): refuse an og:image format no link-preview consumer renders

### DIFF
--- a/ci/check-og-image-format.py
+++ b/ci/check-og-image-format.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""check-og-image-format — regression test for the og:image format constraint.
+
+WHY: `og_image` is the one field whose value is consumed entirely by software
+this repository never runs — Facebook's, LinkedIn's, Slack's, X's link
+scrapers. Those do not render an SVG og:image, so a consumer that configures
+one ships a link card with **no image at all**, and every gate here stays green
+because the file exists, the path resolves, and the pattern admitted it.
+
+That is the failure shape this substrate keeps producing and then fixing: a
+contract permitting a construct that cannot do the job, so the consumer
+inherits a silent failure from the thing meant to prevent it. The same week,
+`_redirects.tmpl` recommended a host-source rule Cloudflare accepts and ignores
+(forkwright/typikon#191).
+
+The check runs over EVERY schema declaring og_image rather than one, because
+the pattern was copy-pasted into five files. A sixth schema written by copying
+a fifth is exactly how this comes back, and a single-file assertion would not
+see it.
+
+NOTE: runs standalone (no consumer site needed) as part of ci/run-fixtures.sh.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+THEME_ROOT = Path(__file__).resolve().parent.parent
+SCHEMAS = THEME_ROOT / "schemas"
+
+# (value, must_validate)
+CASES: list[tuple[str, bool]] = [
+    ("img/og-cover.png", True),
+    ("img/og-card.jpg", True),
+    ("img/og-card.jpeg", True),
+    ("img/social/og.webp", True),
+    # The defect: accepted before, renders nowhere.
+    ("img/og-cover.svg", False),
+    ("img/og.SVG", False),
+    # Adjacent shapes that must stay refused.
+    ("https://example.test/og.png", False),
+    ("img/og-cover", False),
+    ("img/og cover.png", False),
+]
+
+
+def og_image_patterns() -> dict[str, str]:
+    """Every og_image pattern in the registry, keyed by the file declaring it."""
+    found: dict[str, str] = {}
+    for path in sorted(SCHEMAS.glob("*.json")):
+        try:
+            document = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"{path.name} is not parseable JSON: {exc}") from exc
+
+        def walk(node: object) -> None:
+            if isinstance(node, dict):
+                for key, value in node.items():
+                    if key == "og_image" and isinstance(value, dict) and "pattern" in value:
+                        found[path.name] = value["pattern"]
+                    walk(value)
+            elif isinstance(node, list):
+                for item in node:
+                    walk(item)
+
+        walk(document)
+    return found
+
+
+def main() -> int:
+    patterns = og_image_patterns()
+    if not patterns:
+        print("check-og-image-format: no og_image pattern found in schemas/", file=sys.stderr)
+        return 1
+
+    failures: list[str] = []
+    for name, pattern in sorted(patterns.items()):
+        compiled = re.compile(pattern)
+        for value, must_validate in CASES:
+            # JSON Schema `pattern` is an unanchored search, and both shipped
+            # patterns anchor themselves with ^...$; re.search honours that
+            # rather than assuming fullmatch semantics the schema does not have.
+            accepted = compiled.search(value) is not None
+            if accepted != must_validate:
+                want = "accept" if must_validate else "refuse"
+                failures.append(f"{name}: expected to {want} {value!r}, it did not")
+
+    # One definition would be better than five identical ones; until then, prove
+    # they have not diverged. A schema tightened in one file and not the others
+    # is a constraint a consumer can route around by picking a different template.
+    distinct = set(patterns.values())
+    if len(distinct) > 1:
+        detail = ", ".join(f"{name}={pattern!r}" for name, pattern in sorted(patterns.items()))
+        failures.append(f"og_image patterns have diverged across schemas: {detail}")
+
+    if failures:
+        print("check-og-image-format: FAIL", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print(
+        f"check-og-image-format: ok ({len(patterns)} schema(s) agree, "
+        f"{len(CASES)} cases each, SVG refused)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -101,7 +101,7 @@ wrap or replace the H1 because `page.html` owns that heading.
 - description: ≤200 chars
 - path: matches `^/[a-z0-9/_-]*/?$`
 - template: matches `^[a-z0-9_-]+\.html$`
-- og_image: ends in `.svg|.png|.jpg|.webp`
+- og_image: ends in `.png|.jpg|.jpeg|.webp` — SVG is refused; the major link-preview consumers do not render it, so an SVG card shows no image while the gate stays green
 
 Setting any commercial fact triggers the product-shaped contract in `page.html`,
 which requires `audience`, `price`, and `price_source`. Those three fields
@@ -172,7 +172,7 @@ Pages under `content/journal/` (excluding `_index.md`), OR any page whose effect
 - extra.components: 5–120 chars (the conceptual-tags line)
 - extra.words: matches `^~?\d+( words)?$`. **Optional override** — `journal-entry.html`/`journal-section.html` render Zola's own `page.word_count`/`entry.word_count` by default (the rendered body's word count, excluding fenced code blocks — see `templates/journal-entry.html`), so the figure cannot drift from the body it describes. Set this only to force a custom string
 - extra.words_source: 3–200 chars. **Required alongside `extra.words`, forbidden without it** (`dependentRequired`, both directions — same pattern as `product.schema.json`'s `availability`/`availability_source`). Not needed for the default derived count, which carries no separate provenance claim
-- extra.og_image: ends in `.svg|.png|.jpg|.webp`
+- extra.og_image: ends in `.png|.jpg|.jpeg|.webp` — SVG is refused; see the page section above
 - extra.figure: ends in `.svg|.png|.jpg|.webp`. Not consumed by typikon's own stock `journal-entry.html` — a consumer shadow template renders it as furniture above the entry body (forkwright/typikon#163)
 - extra.figure_alt: 5–500 chars. **Required whenever `extra.figure` is set** (enforced via `dependentRequired`, not just documented)
 - extra.tier: one of `notes | research`. Not consumed by typikon's own stock `journal-section.html` — a consumer shadow template that groups its listing by tier reads it (forkwright/typikon#163)

--- a/schemas/faq.schema.json
+++ b/schemas/faq.schema.json
@@ -58,7 +58,7 @@
         },
         "seo_title": { "type": "string", "maxLength": 80 },
         "body_class": { "type": "string", "pattern": "^[a-z][a-z0-9 -]*$" },
-        "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|jpeg|webp)$" },
+        "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(png|jpg|jpeg|webp)$", "description": "Path under static/ (e.g. 'img/og-cover.png'). get_url() resolves to absolute. SVG is deliberately not accepted: the major link-preview consumers do not render an SVG og:image, so a card configured that way produces no image at all while every gate stays green. Ship a raster." },
         "skip_sitemap": { "type": "boolean" },
         "author": { "type": "string" }
       }

--- a/schemas/journal-entry.schema.json
+++ b/schemas/journal-entry.schema.json
@@ -50,7 +50,7 @@
         },
         "seo_title": { "type": "string", "maxLength": 80 },
         "body_class": { "type": "string", "pattern": "^[a-z][a-z0-9 -]*$" },
-        "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|jpeg|webp)$" },
+        "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(png|jpg|jpeg|webp)$", "description": "Path under static/ (e.g. 'img/og-cover.png'). get_url() resolves to absolute. SVG is deliberately not accepted: the major link-preview consumers do not render an SVG og:image, so a card configured that way produces no image at all while every gate stays green. Ship a raster." },
         "og_type": { "type": "string", "enum": ["website", "article", "profile"] },
         "author": { "type": "string", "description": "Per-entry author override; falls back to config.extra.author.name." },
         "skip_sitemap": { "type": "boolean", "description": "Exclude this entry from sitemap.xml." },

--- a/schemas/page.core.schema.json
+++ b/schemas/page.core.schema.json
@@ -65,8 +65,8 @@
         },
         "og_image": {
           "type": "string",
-          "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|jpeg|webp)$",
-          "description": "Path under static/ (e.g. 'img/og-cover.png'). get_url() resolves to absolute."
+          "pattern": "^[a-z0-9/_-]+\\.(png|jpg|jpeg|webp)$",
+          "description": "Path under static/ (e.g. 'img/og-cover.png'). get_url() resolves to absolute. SVG is deliberately not accepted: the major link-preview consumers do not render an SVG og:image, so a card configured that way produces no image at all while every gate stays green. Ship a raster."
         },
         "og_type": {
           "type": "string",

--- a/schemas/product.schema.json
+++ b/schemas/product.schema.json
@@ -67,7 +67,7 @@
         },
         "seo_title": { "type": "string", "maxLength": 80 },
         "body_class": { "type": "string", "pattern": "^[a-z][a-z0-9 -]*$" },
-        "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|jpeg|webp)$" },
+        "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(png|jpg|jpeg|webp)$", "description": "Path under static/ (e.g. 'img/og-cover.png'). get_url() resolves to absolute. SVG is deliberately not accepted: the major link-preview consumers do not render an SVG og:image, so a card configured that way produces no image at all while every gate stays green. Ship a raster." },
         "og_type": { "type": "string", "enum": ["website", "article", "profile"] },
         "skip_sitemap": { "type": "boolean", "description": "Exclude from sitemap.xml." },
         "author": { "type": "string", "description": "Per-product author override." },

--- a/schemas/sizing-guide.schema.json
+++ b/schemas/sizing-guide.schema.json
@@ -96,7 +96,7 @@
         },
         "seo_title": { "type": "string", "maxLength": 80 },
         "body_class": { "type": "string", "pattern": "^[a-z][a-z0-9 -]*$" },
-        "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|jpeg|webp)$" },
+        "og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(png|jpg|jpeg|webp)$", "description": "Path under static/ (e.g. 'img/og-cover.png'). get_url() resolves to absolute. SVG is deliberately not accepted: the major link-preview consumers do not render an SVG og:image, so a card configured that way produces no image at all while every gate stays green. Ship a raster." },
         "skip_sitemap": { "type": "boolean" },
         "author": { "type": "string" }
       },


### PR DESCRIPTION
## Finding

`og_image` accepted `.svg` in all five schemas that declare it:

```
"og_image": { "type": "string", "pattern": "^[a-z0-9/_-]+\\.(svg|png|jpg|jpeg|webp)$" }
```

`og:image` is the one field whose value is consumed entirely by software this repository never runs.
The major link scrapers — Facebook, LinkedIn, Slack, X, iMessage — do not render an SVG `og:image`.
A consumer that configures one ships a link card with **no image at all**, and every gate here stays
green: the file exists, the path resolves, and the pattern admitted it.

**Found from the consumer end.** `forkwright/ardent-site` has `og_image = "img/og-cover.svg"` at
`config.toml:21` and has since it was scaffolded. Its social card is the thing this permitted.

## Why it is the substrate's problem

This is the second instance of one shape in a few hours. `_redirects.tmpl` recommended a host-source
rule Cloudflare accepts and silently ignores (#191). Both are a contract admitting a construct that
cannot do the job, so the consumer inherits a silent failure from the thing meant to prevent it —
and in both cases the consumer wrote what the substrate offered.

The sibling consumer already uses `og-card.png`, so the field was never load-bearing in the SVG form;
it was simply admitted.

## Scope, and why nothing breaks now

Consumers adopt a schema change when they bump their gitlink, so this cannot break a site that has
not chosen to move. `ardent-tools-site` is already on `og-card.png`. `ardent-site`'s migration is
`forkwright/ardent-site#12`, which now carries the finding and the reason a raster is the fix rather
than embedding fonts into the SVG — with raster, the text is already pixels and the font question
disappears.

Typikon's own examples set no `og_image`, and `ci/check-asset-path-existence.py`'s fixtures use
`og.png`.

## Evidence

`ci/check-og-image-format.py` runs nine cases against **every** schema declaring the field, not one:

```
check-og-image-format: ok (5 schema(s) agree, 9 cases each, SVG refused)
```

Accepts `.png`, `.jpg`, `.jpeg`, `.webp`, including a nested path. Refuses `.svg`, `.SVG`, an
absolute URL, an extensionless path, and a path with a space.

Two mutations, both caught:

| Mutation | Result |
|---|---|
| Reintroduce `svg` in **one** schema | `faq.schema.json: expected to refuse 'img/og-cover.svg', it did not` |
| — same mutation, second assertion | `og_image patterns have diverged across schemas: …` |

That second row is why the check reads all five. The pattern is copy-pasted five times; a sixth
schema written by copying a fifth is how this returns, and a constraint tightened in one file is one
a consumer routes around by choosing a different template. One definition would be better than five
identical ones — until that exists, this proves they have not drifted.

Green locally: `check-og-image-format`, `check-triad-schema`, `check-consumer-schema-registry`,
`check-asset-path-existence`, `check-tera2-contract`, `check-tool-lock`, `check-artifact-boundary`.

Refs forkwright/ardent-site#12.
