### PR TITLE
ci(security): add CodeQL static analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 14 * * 3" # Wednesday 08:00 CST
+
+# PROJECT: explicit top-level default deny; job-level permissions grant only what's needed
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze-actions:
+    name: Analyze (actions)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false # PROJECT: security hardening — never expose token to steps
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd677812177e0c29f9c970a6c58d8607ae1bfefd # v4
+        with:
+          languages: actions
+          queries: +security-extended
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@dd677812177e0c29f9c970a6c58d8607ae1bfefd # v4
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@dd677812177e0c29f9c970a6c58d8607ae1bfefd # v4
+        with:
+          category: /language:actions


### PR DESCRIPTION
CodeQL ran in **three of twelve** fleet repos. This one was not among them, so nothing read its source for injection paths, unsafe patterns, or over-broad workflow permissions — `cargo audit`, `cargo deny` and OSV all read the *dependency list*, not the code.

## What this adds

| job | scans | timeout |
|---|---|---|
| `analyze-actions` | the workflow definitions themselves — untrusted input reaching a `run` block, permissions wider than needed, unpinned references | 30m |
| `analyze-rust` | the crate source | 90m |

Scheduled weekly plus on push to `main`, so it adds no latency to the merge path. Free on a public repository.

## Sourced from aletheia, not from the template

`workflow/templates/ci/codeql.yml` is the **stalest copy of this file in the fleet** (kanon#3644). It differs from aletheia's live version in three ways, all regressions:

- **No `timeout-minutes` on either job.** A hung CodeQL run reaches GitHub's six-hour default.
- **An older `actions/checkout` pin** — v6 where aletheia is on v7.0.1.
- **`permissions: {}`** where aletheia states an explicit `contents: read` default-deny with the reasoning attached.

Copying the template into eight repos would have planted those three regressions everywhere at once. The rollout script asserts every job carries a `timeout-minutes` before writing — that being the specific thing the template lacks, and the specific thing nobody notices until a job has been running six hours.

## Part of a fleet-wide pass

Eight public repos are getting this. `typikon` and `dioptron` take `analyze-actions` alone — they carry no Cargo manifest, so a Rust scan would analyse nothing and fail looking for a build. `gnomon` is skipped: it is private and its Actions minutes are exhausted (kanon#3638), so it would gain nothing today.
