### PR TITLE
ci: float the fleet gate on main so it stops freezing

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -78,12 +78,20 @@ permissions:
 
 jobs:
   gate:
-    # WHY pinned to a commit SHA, not @main: a mutable branch ref lets the
-    # remote workflow's behavior change under an already-merged typikon
-    # commit. Refresh via:
-    #   gh api repos/forkwright/.github/commits/main --jq '.sha'
-    # and review the diff at forkwright/.github before bumping.
-    uses: forkwright/.github/.github/workflows/hybrid-gate.yml@84a39d3344660e4010c32755b33a6a88912ad929 # main
+    # WHY @main and not a commit SHA, reversing the earlier position here: the
+    # concern that a mutable ref can change behaviour under an already-merged
+    # commit is real, but the mitigation it proposed was a manual refresh that
+    # nobody ran. forkwright/.github publishes no tags, so dependabot has no
+    # version to compare a SHA against and never touches this line -- it simply
+    # freezes. This pin sat far enough behind that the gate failed on a defect
+    # already fixed upstream, and the failure looked like this repo's problem.
+    #
+    # A first-party reusable holding none of our secrets is not the supply-chain
+    # case a SHA pin exists for, and the ci-substrate SPEC settles it: triggers,
+    # permissions and inputs live in the caller, logic is delegated, pin @main.
+    # A floating first-party ref cannot go stale, which is stronger than any
+    # process for keeping it fresh.
+    uses: forkwright/.github/.github/workflows/hybrid-gate.yml@main
     with:
       # WHY empty, not a literal channel: rust-toolchain.toml at the repo
       # root (forkwright/kanon#3489) carries the pin even though this repo


### PR DESCRIPTION
## Finding

This repo's gate has been failing on a defect **already fixed upstream**, and the failure looked like typikon's problem rather than a stale pin.

The mechanism: `hybrid-gate.yml` ran `Swatinem/rust-cache` unconditionally, which shells out to `cargo metadata` and fails outright here —

```
error: could not find `Cargo.toml`
```

— because typikon has **no `Cargo.toml` anywhere**. That is deliberate: this repo passes `fmt_cmd: "true"`, `clippy_cmd: "true"`, `nextest_cmd: "true"` and uses `check_cmd` for its own non-Rust checks, and the caller says so in a comment.

Fixed in `forkwright/.github#55`, which guards that step on a manifest existing.

## Why the fix could not reach here

This repo pins the reusable **by SHA**, and `forkwright/.github` publishes **no tags** — so dependabot has no version to compare a SHA against and never touches the line. The pin does not get bumped; it freezes.

## The previous comment's concern, answered rather than deleted

It said: a mutable branch ref lets the remote workflow's behaviour change under an already-merged commit. That is true, and it is the real tradeoff.

But the mitigation it proposed was a **manual** refresh — `gh api repos/forkwright/.github/commits/main --jq '.sha'`, review the diff, bump. Nobody ran it. So the pin did not stay reviewed; it just went stale, far enough that the gate started failing on something fixed upstream.

A first-party reusable that holds none of our secrets is not the supply-chain case a SHA pin exists for. The ci-substrate SPEC settles the convention — *"Triggers + permissions + inputs live in the caller; logic is delegated. Pin `@main`."* A floating first-party ref **cannot** go stale, which is a stronger property than any process for keeping it fresh.

`akroasis` froze in exactly this way, on a revision predating a fix, while its own comment asserted dependabot was maintaining the pin.

## Note

This PR runs its own gate against the **floated** ref, since `pull_request` workflows execute the workflow file from the head branch — so a green check here is evidence the fix works, not just that the syntax parses.
