### PR TITLE
fix(ci): name the sha's real version on every action pin

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -90,7 +90,7 @@ jobs:
           test "$PRIVACY_ACKNOWLEDGED" = true
           echo "Operator acknowledged publication of private-consumer receipt metadata." >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -210,7 +210,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## Finding

Pinned actions in this repo carry version comments that name the wrong major. A pin's comment is
the only human-readable part of it, and one naming the wrong major answers the audit question
**confidently and wrongly** — worse than carrying no comment at all.

## Evidence

Every version below was resolved from the upstream tag list with `git ls-remote --tags`, not
inferred:

| pin | comment said | sha actually is |
|---|---|---|
| `actions/checkout@3d3c42e5aac5` | `v6` | **v7.0.1** |
| `actions/stale@4391f3da665f` | `v10` | **v11.0.0** |
| `actions/upload-artifact@043fb46d1a93` | `v4` | **v7.0.1** |
| `googleapis/release-please-action@45996ed1f6d0` | `v4` | **v5.0.0** |

(Only the pins present in this repo are changed here.)

## Why this matters

This is dependabot's documented blind spot rather than a typo. It rewrites a version comment only
when it can parse a **precise** version out of the existing one — so a pin bumped across a major
boundary keeps its stale comment while the SHA moves underneath, silently.

The same mechanism means an imprecise `# v7` is a comment dependabot *cannot* maintain. Naming
`# v7.0.1` is what lets it stay correct on the next bump.

## Desired correction

Name the SHA's real version. `utilities/check-action-pin-comments.py` reports **0 wrong-major
comments across the whole fleet** after this change, down from 22 across 8 repos.

**Done when:** the checker exits clean for this repo.

## Verification note

This class needs no CI to verify — correctness is settled by the upstream tag list and confirmed by
the checker. Comment-only changes have no behavioural effect. Relevant because GitHub Actions is
recovering from a major outage (incident 2026-08-26T15:11:58Z) and private repos additionally have
no Actions minutes; I will not merge on an empty rollup either way.
