### PR TITLE
fix(ci): scope the release-PR healer to typikon's real required contexts

### DIFF
--- a/.github/workflows/release-pr-checks.yml
+++ b/.github/workflows/release-pr-checks.yml
@@ -45,3 +45,18 @@ permissions:
 jobs:
   heal:
     uses: forkwright/.github/.github/workflows/release-pr-checks.yml@main
+    with:
+      # WHY one name, not the reusable's two-name default: the default
+      # "gate-attestation.yml,security.yml" names the fleet's common shape, but
+      # typikon has no security.yml -- it is a Zola theme with no Cargo.toml,
+      # and the security reusable (cargo-deny + cargo-audit + osv-scanner
+      # against Cargo.lock) has nothing to scan here and no input that skips
+      # itself; the ci-substrate SPEC excludes typikon from that substrate for
+      # exactly this reason. Branch protection on main requires only
+      # "gate / gate", which gate-attestation.yml produces. Naming a workflow
+      # this repo does not have makes the healer's has_run_at probe 404 and the
+      # run exit 1 -- measured on every hourly tick since 2026-09-01 (e.g. run
+      # 33741149318). This scopes the fallback dispatch path only; the approval
+      # path is workflow-agnostic and correct either way. hamma's caller is the
+      # precedent for the override.
+      required_context_workflows: "gate-attestation.yml"


### PR DESCRIPTION
## Problem

The `Release PR checks` healer has failed on every hourly tick since 09-01 (e.g. run 33741149318). The reusable's `required_context_workflows` default is `gate-attestation.yml,security.yml`, but typikon has no `security.yml`, so the healer's `has_run_at` probe against `/actions/workflows/security.yml/runs` returns 404 and the run exits 1 before approving anything:

```
release-pr-checks: gh api repos/forkwright/typikon/actions/workflows/security.yml/runs?head_sha=... failed: gh: Not Found (HTTP 404)
```

## Why not add security.yml instead

Typikon is a Zola theme with no `Cargo.toml`. The fleet security reusable (cargo-deny + cargo-audit + osv-scanner against `Cargo.lock`) has nothing to scan here and exposes no input that skips the cargo jobs, so a caller would install a permanently red workflow; the ci-substrate SPEC excludes typikon from the security substrate for exactly this reason (`typikon = HTML; excluded`). Branch protection on main requires only `gate / gate`, which `gate-attestation.yml` produces.

## Fix

Pass `required_context_workflows: "gate-attestation.yml"` — the input the reusable exposes for exactly this per-repo difference (hamma's caller is the precedent). This scopes the fallback dispatch path only; the approval path is workflow-agnostic and was never the broken part.

## Verification

- YAML parses; `uses:` line and triggers unchanged.
- After merge: the next healer tick (or a manual `workflow_dispatch`) should go green instead of 404ing.
