### PR TITLE
docs: correct the stale #58 publication-block paragraph in RELEASING.md

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -3,10 +3,13 @@
 Typikon separates release preparation, candidate freezing, consumer evidence,
 and publication. A green theme gate does not by itself authorize a tag.
 
-Publication remains deliberately blocked by forkwright/typikon#58. The current
-component inventory covers the renderer and embedded fonts but not every
-transitive dependency of the shipped `bin/` and `ci/` surfaces. The candidate
-builder refuses to freeze a release until that lock-derived graph is complete.
+Publication was previously blocked by forkwright/typikon#58, which has landed:
+`release/components.json` now covers every tool declared in
+`ci/tool-lock.toml`, including the transitive dependencies of the shipped
+`bin/` and `ci/` surfaces. The candidate builder enforces that completeness —
+`ci/build-release-candidate.py` refuses to freeze a release whose inventory
+omits a locked tool, and `ci/check-release-candidate.py` is the fixture that
+locks the refusal in.
 
 ## Subjects
 


### PR DESCRIPTION
## Finding

`docs/RELEASING.md` still said "Publication remains deliberately blocked by forkwright/typikon#58" and described the component inventory as covering only the renderer and embedded fonts. #58 closed on 2026-08-21 when #189 landed the lock-derived inventory.

## Change

Rewrite the paragraph to record that #58 landed and that the completeness check is enforced: `ci/build-release-candidate.py` refuses to freeze a release whose `release/components.json` omits a tool declared in `ci/tool-lock.toml`; `ci/check-release-candidate.py` is the fixture that locks the refusal in.

Docs-only; no behavioural change. Unblocks the 0.6.0 release lane's step 0.
